### PR TITLE
A conversation happens where its project is

### DIFF
--- a/crates/neosh-agent/src/agent.rs
+++ b/crates/neosh-agent/src/agent.rs
@@ -234,6 +234,7 @@ impl Agent {
 
         let request = TurnRequest {
             selection,
+            cwd: self.session().cwd.clone(),
             system,
             messages: vec![Message {
                 role: Role::User,
@@ -408,12 +409,13 @@ impl Agent {
 
             // One guard, not two: temporaries in a struct literal live to the end of the
             // statement, so taking the session lock twice here would deadlock against itself.
-            let (system, messages) = {
+            let (cwd, system, messages) = {
                 let sess = self.session();
-                (sess.system.clone(), sess.messages.clone())
+                (sess.cwd.clone(), sess.system.clone(), sess.messages.clone())
             };
             let request = TurnRequest {
                 selection: selection.clone(),
+                cwd,
                 system,
                 messages,
                 // An agent driver brings its own tools; advertising ours would list tools it

--- a/crates/neosh-agent/src/permission.rs
+++ b/crates/neosh-agent/src/permission.rs
@@ -68,6 +68,19 @@ impl PermissionLayer {
         &self.workspace
     }
 
+    /// Move the root every relative path is resolved against.
+    ///
+    /// Which follows the *conversation*, not the process. A conversation belongs to a project, and
+    /// a layer pinned to wherever neosh was launched refuses `src/main.rs` in every project but
+    /// one — with "outside the workspace", which is true and useless.
+    ///
+    /// The allow-lists are deliberately kept: they are about *what kind of thing* the agent may do,
+    /// not about which tree it does it in, and dropping them on every switch would silently
+    /// re-prompt for things the user has already permitted.
+    pub fn set_workspace(&mut self, workspace: impl Into<PathBuf>) {
+        self.workspace = workspace.into();
+    }
+
     /// Resolve a possibly-relative path and confirm it stays inside an allowed root.
     ///
     /// Returns the resolved path on success. `None` means the path escapes every root, by any

--- a/crates/neosh-proto/src/provider.rs
+++ b/crates/neosh-proto/src/provider.rs
@@ -569,6 +569,19 @@ fn auth_none() -> AuthRef {
 #[ts(export)]
 pub struct TurnRequest {
     pub selection: ModelSelection,
+    /// The directory this turn happens in.
+    ///
+    /// The conversation's, not the process's. A vendor CLI is an agent that reads files, runs
+    /// commands and looks at git — all of it relative to where it was started — so a driver that
+    /// spawns it in whatever directory neosh happened to be launched from is asking about the
+    /// wrong repository. Every conversation carries a project; this is how a driver finds out
+    /// which one.
+    ///
+    /// Empty means "wherever the host process is", which is what a driver with no opinion did
+    /// before this field existed.
+    #[serde(default)]
+    #[ts(type = "string")]
+    pub cwd: std::path::PathBuf,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub system: Option<String>,
     pub messages: Vec<Message>,

--- a/crates/neosh-provider/src/drivers/acp.rs
+++ b/crates/neosh-provider/src/drivers/acp.rs
@@ -420,6 +420,15 @@ impl Provider for AcpProvider {
         let session_slot = self.session.clone();
         let mode = *self.mode.lock().expect("mode lock poisoned");
         let model = request.selection.model.as_ref().to_string();
+        // The conversation's directory. ACP makes this explicit — `cwd` is a parameter of
+        // `session/new` — so unlike the other two drivers this one was always going to send
+        // *something*; it just used to send whatever directory neosh was launched from.
+        let workdir = if request.cwd.as_os_str().is_empty() {
+            std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
+        } else {
+            request.cwd.clone()
+        };
+        let cwd = workdir.display().to_string();
 
         tokio::spawn(async move {
             let fail = |tx: mpsc::Sender<ProviderEvent>, message: String| async move {
@@ -427,7 +436,10 @@ impl Provider for AcpProvider {
             };
 
             let mut cmd = Command::new(&program);
-            cmd.args(&args)
+            // Spawned there as well as told about it: an agent reads its own configuration
+            // relative to where it starts, and `session/new` is too late for that.
+            cmd.current_dir(&workdir)
+                .args(&args)
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());
@@ -505,9 +517,6 @@ impl Provider for AcpProvider {
             // 2. a session: continue the old one if the agent can, else start a fresh one and send
             //    the whole conversation.
             let previous = session_slot.lock().expect("session lock poisoned").clone();
-            let cwd = std::env::current_dir()
-                .map(|p| p.display().to_string())
-                .unwrap_or_else(|_| ".".into());
             let mut resumed = false;
             let mut session_id = None;
             if let Some(id) = previous {
@@ -790,6 +799,7 @@ mod tests {
             extra_headers: vec![],
         };
         let req = TurnRequest {
+            cwd: std::path::PathBuf::new(),
             selection: ModelSelection {
                 instance: InstanceId::from("ghost"),
                 model: "m".into(),

--- a/crates/neosh-provider/src/drivers/anthropic.rs
+++ b/crates/neosh-provider/src/drivers/anthropic.rs
@@ -289,6 +289,7 @@ mod tests {
 
     fn request(options: Vec<OptionSelection>) -> TurnRequest {
         TurnRequest {
+            cwd: std::path::PathBuf::new(),
             selection: ModelSelection {
                 instance: InstanceId::from("anthropic"),
                 model: ModelId::from("claude-opus-5"),

--- a/crates/neosh-provider/src/drivers/claude_cli.rs
+++ b/crates/neosh-provider/src/drivers/claude_cli.rs
@@ -222,6 +222,11 @@ impl Provider for ClaudeCliProvider {
 
         tokio::spawn(async move {
             let mut cmd = Command::new(&program);
+            // Where the conversation is, not where neosh was launched. The CLI is an agent: it
+            // reads files, runs commands and looks at git, all of it relative to here.
+            if !request.cwd.as_os_str().is_empty() {
+                cmd.current_dir(&request.cwd);
+            }
             cmd.arg("-p")
                 .arg(Self::prompt_from(&request.messages))
                 .args(["--output-format", "stream-json"])
@@ -360,6 +365,7 @@ mod tests {
 
     fn req(model: &str) -> TurnRequest {
         TurnRequest {
+            cwd: std::path::PathBuf::new(),
             selection: ModelSelection {
                 instance: InstanceId::from("claude-cli"),
                 model: model.into(),
@@ -457,6 +463,49 @@ mod tests {
             Some(r#"{"alwaysThinkingEnabled":false}"#),
             "thinking off is a real instruction — the CLI's own default is not necessarily off"
         );
+    }
+
+    /// The child is spawned in the conversation's directory.
+    ///
+    /// Worth a real process rather than a mock: the whole failure this fixes was a `Command` that
+    /// looked complete and inherited a directory nobody had chosen, and nothing short of asking a
+    /// child where it woke up would have caught it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn the_child_is_started_in_the_conversations_directory() {
+        use futures::StreamExt;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join(format!("neosh-cwd-{}", std::process::id()));
+        let work = dir.join("work");
+        std::fs::create_dir_all(&work).expect("dirs");
+        let script = dir.join("fake-claude");
+        std::fs::write(&script, "#!/bin/sh\npwd > \"$(dirname \"$0\")/where\"\n").expect("script");
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+        let p = ClaudeCliProvider::new(script.display().to_string());
+        let mut req = req("claude-opus-5");
+        req.cwd = work.clone();
+        let _: Vec<_> = p.stream(&inst(), req, CancellationToken::new()).collect().await;
+
+        let saw = std::fs::read_to_string(dir.join("where")).expect("the child ran");
+        // Compared canonically: the temp directory is a symlink on some systems, and `pwd` in a
+        // shell reports the logical path.
+        assert_eq!(
+            std::fs::canonicalize(saw.trim()).ok(),
+            std::fs::canonicalize(&work).ok(),
+            "spawned in {saw:?}, wanted {}",
+            work.display()
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An empty directory means "wherever the host is", which is what a driver with no opinion did
+    /// before the field existed — so a provider plugin written against the old shape still works.
+    #[test]
+    fn an_empty_directory_is_left_to_the_process() {
+        let r = req("claude-opus-5");
+        assert!(r.cwd.as_os_str().is_empty());
     }
 
     /// A missing binary must surface as a provider error on the stream, not a panic or a hang.

--- a/crates/neosh-provider/src/drivers/codex_cli.rs
+++ b/crates/neosh-provider/src/drivers/codex_cli.rs
@@ -454,6 +454,9 @@ impl Provider for CodexCliProvider {
             let previous = thread.lock().expect("thread lock poisoned").clone();
 
             let mut cmd = Command::new(&program);
+            if !request.cwd.as_os_str().is_empty() {
+                cmd.current_dir(&request.cwd);
+            }
             cmd.arg("exec");
             if let Some(id) = &previous {
                 cmd.arg("resume").arg(id);
@@ -721,6 +724,7 @@ mod tests {
             extra_headers: vec![],
         };
         let req = TurnRequest {
+            cwd: std::path::PathBuf::new(),
             selection: ModelSelection {
                 instance: InstanceId::from("codex-cli"),
                 model: "gpt-5.6-terra".into(),

--- a/crates/neosh-provider/src/drivers/google.rs
+++ b/crates/neosh-provider/src/drivers/google.rs
@@ -256,6 +256,7 @@ mod tests {
 
     fn req(msgs: Vec<Message>) -> TurnRequest {
         TurnRequest {
+            cwd: std::path::PathBuf::new(),
             selection: ModelSelection {
                 instance: InstanceId::from("google"),
                 model: neosh_proto::ModelId::from("gemini-3-pro"),

--- a/crates/neosh-provider/src/drivers/mock.rs
+++ b/crates/neosh-provider/src/drivers/mock.rs
@@ -128,6 +128,7 @@ mod tests {
 
     fn req() -> TurnRequest {
         TurnRequest {
+            cwd: std::path::PathBuf::new(),
             selection: ModelSelection {
                 instance: InstanceId::from("mock"),
                 model: "mock".into(),

--- a/crates/neosh-provider/src/drivers/openai.rs
+++ b/crates/neosh-provider/src/drivers/openai.rs
@@ -360,6 +360,7 @@ mod tests {
     #[test]
     fn usage_reporting_is_requested_explicitly() {
         let r = TurnRequest {
+            cwd: std::path::PathBuf::new(),
             selection: ModelSelection {
                 instance: InstanceId::from("openai"),
                 model: neosh_proto::ModelId::from("some-model"),

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -685,6 +685,10 @@ impl Host {
                     i
                 };
                 if activate {
+                    // Before the redraw: the banner names the directory, and the file tools have
+                    // to be pointed at it before the first turn rather than after it.
+                    let here = { self.agent.sessions().active().cwd.clone() };
+                    self.work_in(here).await;
                     self.enter_session();
                 }
                 self.persist_sessions();
@@ -703,7 +707,7 @@ impl Host {
                     .switch(&session)
                     .map_err(|e| ApiError::NotFound { what: e.to_string() })?;
                 let cwd = { self.agent.sessions().active().cwd.clone() };
-                self.remember_repo(cwd).await;
+                self.work_in(cwd).await;
                 self.enter_session();
                 Ok(ApiOk::Unit)
             }
@@ -1021,6 +1025,19 @@ impl Host {
                 };
                 if self.editor.set_theme(variant) {
                     self.refresh_status();
+                }
+            }
+            "worktree.root" => {
+                // Expanded here, once, so nothing downstream has to know what `~` means. A path
+                // half the readers expand is a path that works until the day it does not.
+                let raw = value.as_str().unwrap_or_default();
+                if let Some(full) = expand_tilde(raw)
+                    && full != raw
+                {
+                    self.set_option_or_defer(
+                        "worktree.root".into(),
+                        OptionValue::Str(full),
+                    );
                 }
             }
             "ui.hints" => self.refresh_composer(),
@@ -3356,6 +3373,13 @@ impl Host {
         for dir in dirs {
             self.remember_repo(dir).await;
         }
+        // And the one that is active decides where "here" is, which is not necessarily where neosh
+        // was started: reopening the last conversation you were in should put you back in *its*
+        // project, not in whichever directory the shell happened to be sitting in.
+        let here = { self.agent.sessions().active().cwd.clone() };
+        if here.is_dir() {
+            self.work_in(here).await;
+        }
         self.enter_session();
         tracing::info!("restored {restored} conversation(s)");
     }
@@ -3371,14 +3395,30 @@ impl Host {
     }
 
     pub async fn discover_repo(&mut self, cwd: &std::path::Path) {
-        self.cwd = cwd.to_path_buf();
-        self.remember_repo(cwd.to_path_buf()).await;
+        self.work_in(cwd.to_path_buf()).await;
     }
 
     /// Look a directory up once and remember the answer, including "not a repository".
     ///
     /// The negative is cached too: a plain directory would otherwise cost a `git rev-parse` on
     /// every status refresh forever.
+    /// Point everything that means "here" at a directory.
+    ///
+    /// Called on every switch and on every new conversation, because *here* is a property of the
+    /// conversation. Three things follow it and each was pinned to the launch directory before:
+    /// the git repository plugins ask about, the root the agent's file tools resolve against, and
+    /// the directory the welcome banner names.
+    ///
+    /// The vendor CLI drivers are the fourth, and they are told per turn rather than held here —
+    /// see [`neosh_proto::TurnRequest::cwd`].
+    async fn work_in(&mut self, dir: std::path::PathBuf) {
+        self.cwd = dir.clone();
+        let mut layer = (*self.agent.permissions()).clone();
+        layer.set_workspace(dir.clone());
+        self.agent.set_permissions(layer);
+        self.remember_repo(dir).await;
+    }
+
     async fn remember_repo(&mut self, dir: std::path::PathBuf) {
         if self.repos.contains_key(&dir) {
             return;
@@ -3916,6 +3956,21 @@ impl Host {
                 ty: OptionType::Str,
                 default: OptionValue::Str("<S-Tab> <Left>".into()),
                 description: Some("Move back a pane in a two-pane widget.".into()),
+            },
+            // Where worktrees go. Host-owned rather than the git plugin's, for two reasons: it is
+            // a place neosh writes on your disk, which is the host's business to answer for, and
+            // the default has to be an absolute path — a plugin has no way to find your home
+            // directory, and a `~` that only some readers expand is worse than no `~` at all.
+            OptionSpec {
+                name: "worktree.root".into(),
+                ty: OptionType::Str,
+                default: OptionValue::Str(default_worktree_root()),
+                description: Some(
+                    "Where `git.worktree.new` puts a new worktree, as `<root>/<repo>/<branch>`. \
+                     A leading `~` is expanded. Empty means beside the repository instead, in \
+                     `<repo>-worktrees/`."
+                        .into(),
+                ),
             },
             // Display settings every widget reads. Declared here rather than by whichever plugin
             // happens to load first: two plugins declaring one name is an error, and a plugin that
@@ -4473,6 +4528,30 @@ fn chunk(text: impl Into<String>, hl: &str) -> neosh_proto::VirtChunk {
 fn display_width(s: &str) -> usize {
     use unicode_width::UnicodeWidthStr;
     s.width()
+}
+
+/// The other direction: `~/x` back into an absolute path.
+///
+/// Returns nothing when there is no home directory to substitute, which leaves the path exactly as
+/// written — a literal directory called `~` is a strange thing to have, but inventing a path is
+/// worse than honouring one.
+fn expand_tilde(raw: &str) -> Option<String> {
+    let rest = raw.strip_prefix('~')?;
+    if !(rest.is_empty() || rest.starts_with('/')) {
+        // `~other/x` is another user's home, which is not ours to resolve.
+        return None;
+    }
+    let home = std::env::var_os("HOME").filter(|h| !h.is_empty())?;
+    Some(format!("{}{rest}", home.to_string_lossy()))
+}
+
+/// Where worktrees go unless told otherwise.
+///
+/// `~/.nsh`, expanded at declare time so the default is already absolute — an option whose default
+/// value is a string only some readers understand is a trap for the first plugin that reads it
+/// without thinking.
+fn default_worktree_root() -> String {
+    expand_tilde("~/.nsh").unwrap_or_else(|| ".nsh".to_string())
 }
 
 /// A path with the home directory written the way people say it.

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -133,6 +133,26 @@ impl Session {
         ));
     }
 
+    /// `^N`, and wait until the conversation it starts is actually in the list.
+    ///
+    /// Worth a helper: starting one is now several round trips — it asks git whether there are
+    /// worktrees to offer before deciding whether to ask you anything — so a test that pressed the
+    /// key and immediately moved the cursor was moving it over a list about to gain a row.
+    fn new_conversation(&mut self) {
+        let before = self.sidebar_rows();
+        self.ctrl("n");
+        assert!(
+            self.pump(|s| s.sidebar_rows() > before),
+            "a conversation was started\n{:?}",
+            self.sidebar_now()
+        );
+    }
+
+    /// How many conversation rows the panel is showing, however they are named.
+    fn sidebar_rows(&self) -> usize {
+        self.sidebar_now().iter().filter(|l| l.starts_with("     ") || l.starts_with("       ")).count()
+    }
+
     fn ctrl(&mut self, c: &str) {
         self.send(&format!(
             r#"{{"type":"key","key":{{"code":{{"kind":"char","c":"{c}"}},"mods":{{"ctrl":true}}}}}}"#
@@ -1440,7 +1460,7 @@ fn moving_and_selecting_in_the_thread_list_switches_conversation() {
     s.enter();
     s.wait_for("first");
 
-    s.ctrl("n"); // a second conversation, now active
+    s.new_conversation(); // a second conversation, now active
     assert!(s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("New conversation"))));
 
     // Into the list, down to the other row, select it.
@@ -1633,6 +1653,119 @@ fn adding_a_project_is_a_row_you_can_see_rather_than_a_key_you_have_to_know() {
     s.wait_for("Add project");
 }
 
+// ---------------------------------------------------------------------------
+// Worktrees
+// ---------------------------------------------------------------------------
+
+/// `^N` in a repository asks where the conversation goes, because there is a real answer that is
+/// not always "here".
+///
+/// Outside a repository it does not ask — the question would have one answer — so this also pins
+/// down that `session.new` stays a single key everywhere the choice would be theatre.
+#[test]
+fn a_new_conversation_in_a_repository_offers_a_worktree() {
+    let sb = Sandbox::new("newwhere");
+    sb.git_init();
+    let mut s = sb.start();
+    s.wait_for("PROJECTS");
+    s.ctrl("n");
+    // Waiting on the picker's own buffer, not on the words in it: "New conversation" is also what
+    // an unnamed conversation is called in the panel, so a text match passes before it opens.
+    assert!(
+        s.pump(|s| !s.picker_named("[New conversation]").is_empty()),
+        "the picker opened\n{:?}",
+        s.sidebar_now()
+    );
+    let rows = s.picker_named("[New conversation]");
+    assert!(rows.iter().any(|l| l.contains("Here")), "the default\n{rows:?}");
+    assert!(rows.iter().any(|l| l.contains("new worktree")), "and the other one\n{rows:?}");
+}
+
+#[test]
+fn a_new_conversation_outside_a_repository_does_not_ask() {
+    let sb = Sandbox::new("newnoask");
+    let mut s = sb.start();
+    s.wait_for("PROJECTS");
+    let before = s.sidebar_now().iter().filter(|l| l.contains("New conversation")).count();
+    s.ctrl("n");
+    assert!(
+        s.pump(|s| {
+            s.sidebar_now().iter().filter(|l| l.contains("New conversation")).count() > before
+        }),
+        "it just started one\n{:?}",
+        s.sidebar_now()
+    );
+    assert!(
+        s.picker_named("[New conversation]").is_empty(),
+        "without asking a question with one answer"
+    );
+}
+
+/// A worktree goes under `worktree.root`, as `<root>/<repo>/<branch>`, and you land in it.
+///
+/// The landing is the point. Creating a directory you then have to go and find is not a feature,
+/// it is a chore with extra steps — and `^N` offering it only makes sense if choosing it puts you
+/// where you asked to be.
+#[test]
+fn a_worktree_is_created_under_the_configured_root_and_you_land_in_it() {
+    let sb = Sandbox::new("wtnew");
+    sb.git_init();
+    let root = sb.root.join("trees");
+    sb.write_config(&format!(
+        "[options]\n\"worktree.root\" = \"{}\"\n",
+        root.display()
+    ));
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("PROJECTS");
+
+    s.send(&command("git.worktree.new"));
+    s.wait_for("Branch for the new worktree");
+    s.type_text("feat/thing");
+    s.enter();
+
+    // The path it proposes says both halves of the layout: the repository, then the branch with
+    // its slash flattened, because a directory is a name and not a path.
+    let want = format!("{}/work/feat-thing", root.display());
+    assert!(
+        s.pump(|s| s.prompt_now().iter().any(|l| l.contains(&want))),
+        "proposed {want}\n{:?}",
+        s.prompt_now()
+    );
+    s.enter();
+
+    assert!(
+        s.pump(|_| std::path::Path::new(&want).is_dir()),
+        "the worktree is on disk at {want}"
+    );
+    assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("feat-thing"))),
+        "and the conversation is in it\n{:?}",
+        s.chat_now()
+    );
+}
+
+/// An empty root restores the old sibling layout, for anyone who wants their trees beside the
+/// thing they are trees of.
+#[test]
+fn an_empty_worktree_root_puts_them_beside_the_repository() {
+    let sb = Sandbox::new("wtsibling");
+    sb.git_init();
+    sb.write_config("[options]\n\"worktree.root\" = \"\"\n");
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("PROJECTS");
+
+    s.send(&command("git.worktree.new"));
+    s.wait_for("Branch for the new worktree");
+    s.type_text("side");
+    s.enter();
+    let want = format!("{}/work-worktrees/side", sb.root.display());
+    assert!(
+        s.pump(|s| s.prompt_now().iter().any(|l| l.contains(&want))),
+        "proposed {want}\n{:?}",
+        s.prompt_now()
+    );
+}
+
 #[test]
 fn folding_a_project_hides_its_conversations_and_keeps_the_count() {
     let sb = Sandbox::new("fold");
@@ -1816,7 +1949,7 @@ fn archiving_takes_a_conversation_out_of_the_list_and_u_brings_it_back() {
     }
     s.enter();
     s.wait_for("keep");
-    s.ctrl("n"); // a second conversation, so the first is not the only one left
+    s.new_conversation(); // a second conversation, so the first is not the only one left
 
     s.enter_panel();
     assert!(s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("keep"))));
@@ -1888,7 +2021,7 @@ fn deleting_a_conversation_with_something_in_it_asks_first() {
     }
     s.enter();
     s.wait_for("keep");
-    s.ctrl("n"); // a second conversation, so deleting the first is even allowed
+    s.new_conversation(); // a second conversation, so deleting the first is even allowed
 
     s.enter_panel();
     assert!(s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("keep"))));
@@ -1959,7 +2092,7 @@ fn confirmation_can_be_switched_off() {
     }
     s.enter();
     s.wait_for("gone");
-    s.ctrl("n");
+    s.new_conversation();
 
     s.enter_panel();
     assert!(s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("gone"))));
@@ -3205,6 +3338,122 @@ fn the_working_line_says_how_much_is_waiting() {
 ///
 /// The case this exists for is a tool card, which has no trailing blank of its own: the previous
 /// turn ends with `└ 3 files`, and the next thing you said starts on the very next row.
+// ---------------------------------------------------------------------------
+// A conversation happens where its project is
+// ---------------------------------------------------------------------------
+
+/// A provider that answers with the directory it was told the turn happens in.
+///
+/// Which is the only way to check this from outside: the thing that was wrong was what a *driver*
+/// received, and a driver is the far side of the provider boundary.
+const WHERE: &str = r#"
+import type { PluginContext } from "@neosh/api";
+
+export async function activate({ neosh }: PluginContext) {
+  await neosh.provider.register("where", [{
+    id: "where", driver: "where", display_name: "Where",
+    models: [{ id: "where-1", display_name: "Where One" }],
+  }], async (req, emit) => {
+    emit({ type: "text_delta", index: 0, text: `cwd=${req.cwd}` });
+    emit({ type: "message_stop" });
+  });
+  // Driven through the same calls a real plugin uses, so the test exercises the public path
+  // rather than a back door the product does not have.
+  await neosh.cmd.register("where.at", async (args) => {
+    await neosh.session.create({ cwd: args[0], activate: true });
+  }, { desc: "open a conversation in a directory" });
+  await neosh.cmd.register("where.goto", async (args) => {
+    const all = await neosh.session.list();
+    const found = all.find((s) => s.cwd === args[0]);
+    if (found) await neosh.session.switch(found.id);
+    else neosh.notify(`no conversation in ${args[0]}`, "warn");
+  }, { desc: "switch to the conversation in a directory" });
+  neosh.notify("where ready");
+}
+"#;
+
+fn install_where(sb: &Sandbox) {
+    let dir = sb.root.join("config/plugins/where");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    std::fs::write(
+        dir.join("plugin.toml"),
+        "name = \"where\"\nversion = \"0.1.0\"\nentry = \"main.ts\"\npermissions = [\"providers\"]\n",
+    )
+    .expect("manifest");
+    std::fs::write(dir.join("main.ts"), WHERE).expect("plugin");
+}
+
+/// A turn happens in the conversation's project, not in whatever directory neosh was started from.
+///
+/// This was the whole bug. A conversation carried a `cwd` and the sidebar grouped by it, but the
+/// thing that actually does the work — a vendor CLI, which reads files and runs commands relative
+/// to where it was spawned — was never told. So every project's conversations ran in the same
+/// directory, and the grouping was decoration.
+#[test]
+fn a_turn_runs_in_the_project_the_conversation_belongs_to() {
+    let sb = Sandbox::new("turncwd");
+    install_where(&sb);
+    let elsewhere = sb.root.join("elsewhere");
+    std::fs::create_dir_all(&elsewhere).expect("mkdir");
+    sb.write_config("[options]\n\"agent.model\" = \"where/where-1\"\n");
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("where ready");
+    s.wait_for("PROJECTS");
+
+    // A conversation in a second directory, which is what adding a project amounts to.
+    s.send(&command_with("where.at", &elsewhere.display().to_string()));
+    assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("elsewhere"))),
+        "the banner names the project this conversation is in\n{:?}",
+        s.chat_now()
+    );
+
+    s.type_text("go");
+    s.enter();
+    let want = format!("cwd={}", elsewhere.display());
+    assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains(&want))),
+        "and the driver was told to work there\n{:?}",
+        s.chat_now()
+    );
+}
+
+/// Switching back moves everything back with it.
+#[test]
+fn switching_conversations_moves_the_working_directory_too() {
+    let sb = Sandbox::new("switchcwd");
+    install_where(&sb);
+    let elsewhere = sb.root.join("elsewhere");
+    std::fs::create_dir_all(&elsewhere).expect("mkdir");
+    sb.write_config("[options]\n\"agent.model\" = \"where/where-1\"\n");
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("where ready");
+    s.wait_for("PROJECTS");
+    s.send(&command_with("where.at", &elsewhere.display().to_string()));
+    assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("elsewhere"))),
+        "in the second project\n{:?}",
+        s.chat_now()
+    );
+
+    // Back to the first, and a turn there must run in the original workspace again.
+    let home = format!("directory  {}", sb.work().display());
+    s.send(&command_with("where.goto", &sb.work().display().to_string()));
+    assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains(&home))),
+        "back in the first\n{:?}",
+        s.chat_now()
+    );
+    s.type_text("go");
+    s.enter();
+    let want = format!("cwd={}", sb.work().display());
+    assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains(&want))),
+        "back in the first project\n{:?}",
+        s.chat_now()
+    );
+}
+
 #[test]
 fn a_question_gets_a_gap_above_it_and_keeps_its_bar() {
     let sb = Sandbox::new("questiongap");

--- a/docs/adr/0000-index.md
+++ b/docs/adr/0000-index.md
@@ -34,3 +34,4 @@ implementation — and in two cases (0005, 0008) it did not, which is itself rec
 | [0026](0026-a-block-is-settled-once-it-cannot-change.md) | A markdown block is settled once it cannot change | Accepted |
 | [0027](0027-one-driver-for-every-agent-that-speaks-acp.md) | One driver for every agent that speaks ACP | Accepted |
 | [0028](0028-the-transcript-is-a-place-you-go.md) | The transcript is a place you go, not a pane you focus | Accepted |
+| [0029](0029-a-conversation-carries-its-directory.md) | A conversation carries its directory, and everything follows it | Accepted |

--- a/docs/adr/0029-a-conversation-carries-its-directory.md
+++ b/docs/adr/0029-a-conversation-carries-its-directory.md
@@ -1,0 +1,67 @@
+# 0029 — A conversation carries its directory, and everything follows it
+
+**Status:** accepted
+
+## Context
+
+A conversation has had a `cwd` since the session store existed. The sidebar grouped by it, so the
+panel showed projects rather than a flat list of threads, and `neosh.git` resolved against it, so
+the footer showed the right branch.
+
+None of that reached the agent. The permission layer's workspace root was fixed at launch from the
+process's own directory, so `read_file("src/main.rs")` in any project but the one neosh was started
+in came back "outside the workspace" — true, and useless. And `TurnRequest` had no directory at all,
+so the vendor CLI drivers spawned their child in whatever directory the shell happened to be in.
+
+That last one is the whole problem. `claude -p` and `codex exec` are *agents*: they read files, run
+commands, and look at git, all of it relative to where they were started. A driver that ignores the
+conversation's project is not slightly wrong about a path — it is answering questions about a
+different repository, confidently, while the sidebar says otherwise. The grouping was decoration.
+
+## Decision
+
+**The conversation is the unit of "where", and every consumer follows it.**
+
+Four things move when the active conversation changes, and they move through one function so it
+cannot be three out of four again:
+
+- the git repository `neosh.git` answers about,
+- the root [`PermissionLayer`] resolves relative paths against,
+- the directory the welcome block names,
+- and `self.cwd`, which is what a new conversation inherits.
+
+The fifth is the drivers, and they are told *per turn* rather than held anywhere:
+`TurnRequest.cwd`. A driver is a value shared across conversations — one `ClaudeCliProvider` serves
+every session — so a field on the provider would be a mutable "current directory" with exactly the
+races that implies. A turn already carries its model, its messages and its tools; where it happens
+is the same kind of fact.
+
+Empty means "wherever the host process is", which is what a driver with no opinion did before the
+field existed. That keeps every third-party provider plugin working unchanged.
+
+**A worktree is a project.** Not a mode, not a setting on a conversation — a directory with
+conversations in it, which the sidebar already knows how to show. Everything a worktree needs was
+therefore already built; what was missing was a way to make one without leaving what you were
+doing, which is one row in the picker `^N` now opens.
+
+Worktrees go under `worktree.root`, defaulting to `~/.nsh`, laid out `<root>/<repo>/<branch>`.
+A directory of neosh's own rather than a sibling of the repository: a worktree is not part of the
+project you are working on, and littering its parent is how people end up with checkouts they
+cannot account for. The option is declared by the **host**, not by the git plugin that reads it,
+for two reasons — it is a place neosh writes on your disk, which is the host's business to answer
+for, and its default has to be absolute. A plugin has no way to find your home directory, and a
+`~` that only some readers expand is worse than no `~` at all.
+
+## Consequences
+
+`^N` asks a question it did not used to ask, and only where the question has more than one answer:
+in a git repository, with the git plugin loaded. `Here` is selected, so the old behaviour is
+`^N ⏎`, and `session.new.here` skips the question for anyone who wants their key back.
+
+Restoring conversations at startup now puts you in the active one's project rather than in whatever
+directory the shell was sitting in. That is a behaviour change and the right one: reopening the
+conversation you were last in should put you back where it was.
+
+The permission layer's allow-lists survive a move. They are about *what kind of thing* the agent may
+do, not about which tree it does it in, and clearing them on every switch would silently re-prompt
+for things already permitted.

--- a/docs/config.md
+++ b/docs/config.md
@@ -132,8 +132,53 @@ it my setup".
 
 The sidebar groups conversations by the directory they were opened in. There is no project registry
 to maintain: opening a conversation somewhere else *is* how a second project appears, and
-`git.worktree.list` opens one in another worktree. `neosh.git` answers about whichever conversation
-is active, so switching conversation switches which tree you are looking at.
+`git.worktree.list` opens one in another worktree.
+
+**A conversation's directory is where its work happens**, not just where it is filed. Switching
+conversation moves four things with it: the repository `neosh.git` answers about, the root the
+agent's file tools resolve paths against, the directory the welcome block names, and — the one that
+matters most — the directory the model's own agent is started in. A vendor CLI reads files, runs
+commands and looks at git relative to where it was spawned, so a driver launched in whatever
+directory neosh happened to be started from is answering about the wrong repository. Drivers are
+told per turn, through `TurnRequest.cwd`.
+
+### Worktrees
+
+A worktree is a second checkout of the same repository on a different branch, and it is the answer
+to "I want to try something without disturbing what is checked out". neosh treats one as a
+*project*: it gets its own group in the sidebar, its own conversations, and its own branch in the
+footer.
+
+`^N` asks where a new conversation goes when there is something to ask:
+
+```
+New conversation
+>
+❯ Here                  /home/you/work/project
+  In a new worktree…    a branch of its own, checked out somewhere else
+  fix/thing             worktree  ·  ~/.nsh/project/fix-thing
+  Another directory…    somewhere else entirely
+```
+
+`Here` is selected, so `^N ⏎` is what `^N` always did. Outside a git repository the question has
+one answer and is not asked at all — `^N` stays a single key everywhere the choice would be
+theatre. `session.new.here` skips it unconditionally, for a key of your own.
+
+New worktrees go under `worktree.root`, laid out as `<root>/<repo>/<branch>`:
+
+```toml
+[options]
+"worktree.root" = "~/.nsh"   # the default. `~` expands.
+```
+
+A directory of neosh's own rather than a sibling of the repository, because a worktree is not part
+of the project you are working on and littering its parent with `project-worktrees/` is how people
+end up with checkouts they cannot account for. The repository name is a level of its own so two
+projects with a `main` branch do not collide, and a slash in a branch becomes a dash — `feat/thing`
+is one directory, not two, because the directory is a name and not a path.
+
+Setting it to `""` restores the sibling layout, for anyone who wants their trees next to the thing
+they are trees of.
 
 Conversations are saved as you go — one file each under `~/.local/state/neosh/sessions/` — and
 restored at startup, in the one you were last in. `--clean` neither reads nor writes them.

--- a/plugins/api/src/generated/TurnRequest.ts
+++ b/plugins/api/src/generated/TurnRequest.ts
@@ -5,6 +5,19 @@ import type { ToolDef } from "./ToolDef";
 
 export type TurnRequest = {
   selection: ModelSelection;
+  /**
+   * The directory this turn happens in.
+   *
+   * The conversation's, not the process's. A vendor CLI is an agent that reads files, runs
+   * commands and looks at git — all of it relative to where it was started — so a driver that
+   * spawns it in whatever directory neosh happened to be launched from is asking about the
+   * wrong repository. Every conversation carries a project; this is how a driver finds out
+   * which one.
+   *
+   * Empty means "wherever the host process is", which is what a driver with no opinion did
+   * before this field existed.
+   */
+  cwd: string;
   system?: string | null;
   messages: Array<Message>;
   tools?: Array<ToolDef>;

--- a/plugins/builtin/git/main.ts
+++ b/plugins/builtin/git/main.ts
@@ -87,13 +87,6 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
   }
 
   await neosh.opt.declare({
-    name: "git.worktree.root",
-    type: { type: "str" },
-    default: "",
-    description:
-      'Where new worktrees are created. Empty means a sibling of the repository, named "<repo>-<branch>". A relative path is resolved against the repository root.',
-  });
-  await neosh.opt.declare({
     name: "git.commit.confirm",
     type: { type: "bool" },
     default: true,
@@ -570,15 +563,7 @@ async function newWorktree(neosh: Neosh): Promise<void> {
   if (!branch || !branch.trim()) return;
   const name = slug(branch);
 
-  const configured = ((await neosh.opt.get<string>("git.worktree.root")) ?? "").trim();
-  const root = status.repo.root;
-  const repoName = root.split("/").filter(Boolean).pop() ?? "repo";
-  const base = configured
-    ? configured.startsWith("/")
-      ? configured
-      : `${root}/${configured}`
-    : `${parentOf(root)}/${repoName}-worktrees`;
-  const path = `${base}/${name.replace(/\//g, "-")}`;
+  const path = await worktreePath(neosh, status.repo.root, name);
 
   const taken = new Set((await neosh.git.branches({ includeRemote: true })).map((b) => b.name));
   const create = !taken.has(name);
@@ -596,6 +581,30 @@ async function newWorktree(neosh: Neosh): Promise<void> {
   // feature, it is a chore with extra steps.
   await neosh.session.create({ cwd: where.trim() });
   neosh.notify(`working in ${name}`);
+}
+
+/**
+ * Where a worktree for `branch` goes.
+ *
+ * `<root>/<repo>/<branch>` under `worktree.root`, which is `~/.nsh` unless configured — a
+ * directory of neosh's own rather than a sibling of the repository, because a worktree is not part
+ * of the project you are working on and littering its parent with `foo-worktrees/` is how people
+ * end up with checkouts they cannot account for. The repository name is a level of its own so two
+ * projects with a `main` branch do not collide.
+ *
+ * An empty `worktree.root` restores the sibling layout, for anyone who wants their trees next to
+ * the thing they are trees of.
+ *
+ * Slashes in a branch become dashes: `feat/thing` is one directory, not two, because the directory
+ * is a name and not a path.
+ */
+async function worktreePath(neosh: Neosh, repoRoot: string, branch: string): Promise<string> {
+  const leaf = branch.replace(/\//g, "-");
+  const repoName = repoRoot.split("/").filter(Boolean).pop() ?? "repo";
+  const configured = ((await neosh.opt.get<string>("worktree.root")) ?? "").trim();
+  if (configured === "") return `${parentOf(repoRoot)}/${repoName}-worktrees/${leaf}`;
+  const base = configured.startsWith("/") ? configured : `${repoRoot}/${configured}`;
+  return `${base}/${repoName}/${leaf}`;
 }
 
 async function removeWorktree(neosh: Neosh): Promise<void> {

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -20,7 +20,7 @@
  * off, and a sidebar of your own loads after this one and wins.
  */
 
-import type { Disposable, Neosh, PluginContext, SessionInfo, WindowId } from "@neosh/api";
+import type { Disposable, Neosh, PluginContext, SessionInfo, WindowId, WorktreeInfo } from "@neosh/api";
 import {
   confirmDestructive,
   configureMotion,
@@ -518,9 +518,14 @@ async function registerCommands(w: Wiring): Promise<void> {
     await neosh.cmd.register("sidebar.refresh", w.draw, { desc: "Redraw the sidebar now" }),
   );
   w.subscriptions.push(
-    await neosh.cmd.register("session.new", async () => {
+    await neosh.cmd.register("session.new", () => newConversation(neosh), {
+      desc: "Start a new conversation — here, or in a worktree of its own",
+    }),
+  );
+  w.subscriptions.push(
+    await neosh.cmd.register("session.new.here", async () => {
       await neosh.session.create();
-    }, { desc: "Start a new conversation" }),
+    }, { desc: "Start a new conversation in this project, without asking where" }),
   );
   w.subscriptions.push(
     await neosh.cmd.register("session.close", async (args) => {
@@ -569,6 +574,87 @@ async function registerCommands(w: Wiring): Promise<void> {
 
   await neosh.hint.set("sessions", { keys: "^T", label: "conversations", priority: 20 });
   await neosh.hint.set("new", { keys: "^N", label: "new", priority: 21 });
+}
+
+/**
+ * Start a conversation, asking where when there is something to ask.
+ *
+ * A conversation belongs to a directory — that is what makes the sidebar a list of projects rather
+ * than a list of threads — and in a git repository "where" has a real answer that is not always
+ * "here". A branch you want to work on without disturbing what is checked out is a *worktree*, and
+ * having to create one, find it, and then open a conversation in it is three steps for one
+ * intention.
+ *
+ * Outside a repository the question has one answer, so it is not asked: `^N` stays a single key
+ * everywhere the choice would be theatre. Inside one, `Here` is selected, so `^N ⏎` is what `^N`
+ * always did.
+ */
+async function newConversation(neosh: Neosh): Promise<void> {
+  const current = await neosh.session.current().catch(() => null);
+  const here = current?.cwd;
+  // Empty outside a repository, which is also how this knows there is nothing to ask about: a
+  // worktree is a git idea, and a directory that is not a checkout has exactly one answer to
+  // "where does this conversation go".
+  const trees = await neosh.git.worktrees().catch(() => [] as WorktreeInfo[]);
+  // The git plugin may also be switched off, in which case the rows that lead into it would lead
+  // nowhere. Offering an action that cannot happen is worse than not offering it.
+  const commands = new Set((await neosh.cmd.list().catch(() => [])).map((c) => c.name));
+  const canBranch = trees.length > 0 && commands.has("git.worktree.new");
+  const others = trees.filter((t) => t.path !== here);
+
+  if (!canBranch && others.length === 0) {
+    await neosh.session.create();
+    return;
+  }
+
+  type Where =
+    | { kind: "here" }
+    | { kind: "new" }
+    | { kind: "elsewhere" }
+    | { kind: "tree"; path: string; label: string };
+  const rows: Array<{ label: string; detail?: string; keywords?: string; value: Where }> = [
+    { label: "Here", detail: here ?? "this project", value: { kind: "here" } },
+  ];
+  if (canBranch) {
+    rows.push({
+      label: "In a new worktree…",
+      detail: "a branch of its own, checked out somewhere else",
+      keywords: "branch worktree",
+      value: { kind: "new" },
+    });
+  }
+  for (const t of others) {
+    const label = t.branch ?? t.head ?? t.path;
+    rows.push({
+      label,
+      detail: `worktree  ·  ${t.path}`,
+      keywords: `${t.path} worktree`,
+      value: { kind: "tree", path: t.path, label },
+    });
+  }
+  rows.push({
+    label: "Another directory…",
+    detail: "somewhere else entirely",
+    keywords: "project folder",
+    value: { kind: "elsewhere" },
+  });
+
+  const chosen = await picker(neosh, rows, { title: "New conversation", width: 76 });
+  if (chosen === null) return;
+  switch (chosen.kind) {
+    case "here":
+      await neosh.session.create();
+      return;
+    case "new":
+      await neosh.cmd.exec("git.worktree.new").catch((e: unknown) => neosh.notify(String(e), "warn"));
+      return;
+    case "tree":
+      await neosh.session.create({ cwd: chosen.path });
+      neosh.notify(`new conversation in ${chosen.label}`);
+      return;
+    case "elsewhere":
+      await neosh.cmd.exec("project.open").catch(() => {});
+  }
 }
 
 async function activateTarget(


### PR DESCRIPTION
The sidebar grouped conversations by directory and `neosh.git` answered about it, so the panel looked like a list of projects. It was decoration — nothing that does the work was ever told which one.

`TurnRequest` had no directory at all. A vendor CLI is an agent: it reads files, runs commands and looks at git, all of it relative to where it was spawned. Every conversation's turn started in whatever directory neosh was launched from, so it was not slightly wrong about a path — it was answering questions about a different repository, confidently, while the sidebar said otherwise. The permission layer's workspace root was pinned at launch too, so `read_file("src/main.rs")` in any project but one came back "outside the workspace".

Four things now follow the active conversation, through one function so it cannot be three out of four again: the repository plugins ask about, the root the agent's file tools resolve against, the directory the welcome block names, and what a new conversation inherits. Drivers are told per turn rather than held anywhere — one `ClaudeCliProvider` serves every session, so a field on the provider would be a mutable "current directory" with the races that implies. Empty means "wherever the host is", which is what a driver with no opinion did before the field existed, so third-party provider plugins are unaffected.

Restoring at startup now puts you in the active conversation's project rather than wherever the shell was sitting.

## Worktrees

A worktree is a *project* — not a mode, not a flag on a conversation, a directory with conversations in it, which the sidebar already knew how to show. What was missing was a way to make one without leaving what you were doing.

`^N` asks where a conversation goes when there is something to ask: here, in a new worktree, in one that already exists, or somewhere else. `Here` is selected, so `^N ⏎` is what `^N` always did, and outside a git repository it does not ask at all. `session.new.here` skips it outright.

New worktrees go under `worktree.root` — `~/.nsh` by default — laid out `<root>/<repo>/<branch>`. A directory of neosh's own rather than a sibling of the repository: littering a project's parent with `project-worktrees/` is how people end up with checkouts they cannot account for. The option is the host's rather than the git plugin's, because a plugin has no way to find your home directory and a `~` only some readers expand is worse than no `~` at all. Setting it to `""` restores the sibling layout.

## Verification

The driver test spawns a real child and asks it where it woke up — nothing short of that would have caught this, because the `Command` looked complete the whole time. End-to-end tests drive a provider plugin that answers with the `cwd` it was handed, so the assertion is on what a *driver* receives rather than on internal state.

Also here: `PluginEvent::SelectionChanged`, because the model was changing silently on four of the five paths that change it; one context meter instead of two, drawn from the start; `^D` to remove a model you added; and the model picker's actions moved off bare letters, which had made it impossible to type "sonnet" into the filter.

ADRs 0028 and 0029 record the two decisions worth arguing about.