### PR TITLE
A checkout named after what it is, and pickers that say what they answer to

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,168 @@
+# Working on neosh
+
+A terminal-first agent workspace: Rust core, TypeScript plugins, "the extensibility model of Neovim
+and the feature set of Cursor".
+
+The thesis is that **extensibility is the product**. Every capability ships on the same public API a
+third-party plugin author would use. If a feature needs a private escape hatch, the API is wrong and
+the API is what to fix.
+
+## Layout
+
+| Crate | Owns |
+|---|---|
+| `neosh-proto` | Every wire type. `#[derive(TS)]` on all of them; generated `.ts` is committed. |
+| `neosh-core` | Buffers, windows, floats, extmarks, highlights, focus, keymaps, the single-writer `Editor`. No I/O. |
+| `neosh-script` | The `deno_core` host and the op surface. The only crate that knows deno exists. |
+| `neosh-provider` | `trait Provider`, the shared SSE parser, and one driver per transport. |
+| `neosh-agent` | `Session`, `Turn`, the tool registry, the permission layer, the agent loop. |
+| `neosh-tui` | Terminal frontend. Owns **all** display-width maths. |
+| `neosh` | The binary. Wires the tasks, owns config, hosts the chat. |
+
+`plugins/api/` is `@neosh/api` — generated protocol types plus a hand-written ergonomic layer.
+`plugins/builtin/` are ordinary plugins that happen to ship in the binary. `docs/adr/` is one file
+per decision, and records the *reasoning*, not the choice.
+
+## Rules that are not negotiable
+
+- **Unicode width is not optional.** `unicode-width` + `unicode-segmentation`. Column maths on
+  `char` counts corrupts layout on day one. Columns on the wire are UTF-8 byte offsets; motion steps
+  by grapheme cluster; every display-width question is answered in `neosh-tui`.
+- **No `unwrap()` on anything touching plugin input or a network response.**
+- **Secrets never touch disk in plaintext and never appear in logs or event payloads.** They are
+  `secrecy::SecretString`, read at request time, and structurally absent from `UiEvent`.
+- **Every public API has a TS type generated from or checked against the Rust side.** Drift fails
+  the build.
+- **Streaming markdown caches to the last *complete* block boundary** and re-parses only the
+  trailing partial block. See ADR 0026.
+- `Editor::handles` is a **deny-list**. A new API call that is not added to it silently routes to
+  the core.
+
+## Verification
+
+Per crate, not workspace-wide — the full run is heavy and `neosh`'s integration tests take about a
+minute on their own:
+
+```sh
+cargo test -p neosh-core -- --test-threads 2
+cargo test -p neosh --test builtin_plugins -- --test-threads 2
+cargo test -p neosh-proto export_bindings && git diff --exit-code plugins/api/src/generated
+cd plugins/api && npx tsc --noEmit
+```
+
+**Terminal behaviour is checked by driving the real binary**, not by reading the code. `scripts/shot.py`
+runs neosh under a pty and prints what the screen actually looks like:
+
+```sh
+/tmp/ptyenv/bin/python scripts/shot.py --cols 110 --rows 34 '<c-p>' '<wait:2000>'
+```
+
+Keys are literal text or `<c-p>` / `<cr>` / `<esc>` / `<s-tab>` / `<wait:400>`; `--arg=` passes
+through to the binary. Several real bugs — a float silently losing two rows of content, a binding
+that had never once fired — were invisible to the test suite and obvious on screen.
+
+After editing anything under `plugins/`, `touch crates/neosh-script/src/loader.rs` before building:
+the plugin tree is embedded with `include_dir!` and cargo will not notice otherwise.
+
+---
+
+# Keys
+
+Everything here is an ordinary binding in the same table your `init.ts` writes to, bound to a
+*command name* rather than a callback. Setting the same key replaces it. `F1` lists the live
+registry — this table is what ships.
+
+## Chat
+
+| Key | Does |
+|---|---|
+| `⏎` | Send. While a turn is running, **steer** it: the message is held and taken in at the next gap. |
+| `⇧⏎` | Newline, so a pasted snippet stays one message |
+| `^P` | Pick a model |
+| `^E` | Reasoning effort and the other per-model options |
+| `⌥↑` `⌥↓` | One rung up or down the capability ladder, same provider |
+| `⇧⇥` | Permission mode — ask, allow-listed, full access, deny |
+| `^T` | Projects and conversations |
+| `^N` | New conversation. In a repository it asks where: here, a new worktree, an existing one, elsewhere |
+| `^O` | Add a project |
+| `^B` | Toggle the sidebar |
+| `^K` | Command palette |
+| `^G` | Git status |
+| `^D` | Show what changed |
+| `^S` | Read the transcript — see below |
+| `^A` `^X` | Select everything, cut the selection |
+| `^C` | Copy the selection, or clear the draft, or (twice) quit |
+| `PgUp` `PgDn` `^End` | Scroll, and back to the newest message |
+| `^R` | Reload configuration |
+| `^Q` | Quit |
+| `F1` | Every binding, live |
+| `Esc` | Interrupt what is running |
+
+Composer editing is a text field: `←`/`→` by character and `^←`/`^→` by word, `Home`/`End` and
+`^Home`/`^End` for the ends, shift with any of them to select, `^W` and `^U` to delete a word or
+back to the start of the line.
+
+## Reading the transcript — `^S`
+
+The answer is the artefact; this is how you get a piece of it out. See ADR 0028.
+
+| Key | Does |
+|---|---|
+| `hjkl`, arrows | Move |
+| `w` `b` | By word |
+| `0` `$` | Ends of the line |
+| `gg` `G` | Ends of the transcript |
+| `^D` `^U` | Half a screen |
+| `^F` `^B`, `PgUp`/`PgDn` | A screen |
+| `zz` `zt` `zb` | Put the cursor's line in the middle, at the top, at the bottom |
+| `[` `]` | Previous / next **turn** |
+| `{` `}` | Previous / next **block** |
+| `/` `?` then `n` `N` | Search, and step through the matches |
+| `v` | Start a selection that motions extend |
+| `V` | Select this whole line |
+| `y` | Copy the selection, and leave |
+| `yy` `Y` | Copy the line |
+| `yc` | Copy the **code block** the cursor is in, without its indent or language line |
+| `ym` | Copy the whole **turn** — the question and everything it produced |
+| `ya` | Copy the entire transcript |
+| `i` `a` `o` `⏎` | Back to the composer |
+| `Esc` | Drop the search highlight, then leave |
+
+## The project panel — `^T`
+
+| Key | Does |
+|---|---|
+| `↵` | Open a conversation, fold a project, or add one from the `+` row |
+| `j` `k` | Move |
+| `n` | New conversation here |
+| `o` | Add a project |
+| `f` | Pin a project to the top |
+| `J` `K` | Reorder within a group |
+| `r` | Rename a conversation |
+| `x` `X` | Archive, delete |
+| `u` | Bring an archived one back |
+| `?` | The keys for whatever row you are on |
+| `Esc` | Back to the composer |
+
+## Pickers
+
+| Key | Does |
+|---|---|
+| `↵` | Choose |
+| `↑`/`↓`, `^N`/`^P`, `^J`/`^K` | Move |
+| type | Filter |
+| `⇥` `⇧⇥`, `→` `←` | Between the two panes of the model picker |
+| `Esc`, `^C` | Close |
+
+In the model picker specifically — chords, because every bare letter a picker takes is a letter its
+filter can never contain:
+
+| Key | Does |
+|---|---|
+| `^S` | Sign in to the provider the rail is on |
+| `^R` | Ask that endpoint what it serves again |
+| `^A` | Add a model by id, for something the catalogue has never heard of |
+| `^D` | Remove one you added |
+
+All of these are settings — `ui.keys.next`, `ui.keys.accept`, and so on — so rebinding them changes
+what the pickers say they do.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/neosh-agent/src/session.rs
+++ b/crates/neosh-agent/src/session.rs
@@ -133,6 +133,13 @@ impl Session {
         SessionInfo {
             id: self.id.clone(),
             cwd: self.cwd.display().to_string(),
+            // Filled in by the host, which is the only thing that has looked at the repository.
+            // The leaf directory is the honest fallback, and what every caller used before.
+            project: self
+                .cwd
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| self.cwd.display().to_string()),
             message_count: self.messages.len() as u32,
             active_turn: self.active_turn.clone(),
             turn_started_at: self.turn_started_at,

--- a/crates/neosh-proto/src/agent.rs
+++ b/crates/neosh-proto/src/agent.rs
@@ -118,6 +118,17 @@ impl Usage {
 pub struct SessionInfo {
     pub id: SessionId,
     pub cwd: String,
+    /// What to call the directory this conversation is in.
+    ///
+    /// The last segment of the path is the obvious answer and is wrong for the case that matters:
+    /// a worktree is named by whoever created it, and a list of projects reading `wt-fe3c0d93`
+    /// tells you nothing about which repository or branch that is. A checkout is named by the
+    /// repository it belongs to, and a linked worktree adds the branch — `neosh · fix/thing` —
+    /// because that is what a person means when they say which one they are in.
+    ///
+    /// Computed by the host so every frontend and plugin agrees, the same as `label`.
+    #[serde(default)]
+    pub project: String,
     pub message_count: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_turn: Option<TurnId>,

--- a/crates/neosh-vcs/src/lib.rs
+++ b/crates/neosh-vcs/src/lib.rs
@@ -70,6 +70,35 @@ impl Git {
         &self.cwd
     }
 
+    /// What to call this checkout, and what it is a checkout *of*.
+    ///
+    /// Returns `(branch, main worktree)`. Both are needed to name a directory usefully, and
+    /// neither is [`Self::root`]: in a linked worktree `--show-toplevel` is the worktree itself,
+    /// so the repository's own name has to come from `--git-common-dir`, whose parent is the
+    /// original checkout.
+    ///
+    /// One `rev-parse` for both, and deliberately not [`Self::info`] — that runs a full
+    /// `git status`, which is the wrong price to pay for a label in a list.
+    pub async fn identity(&self) -> (Option<String>, Option<PathBuf>) {
+        let Ok(out) = self
+            .git(["rev-parse", "--path-format=absolute", "--git-common-dir", "--abbrev-ref", "HEAD"])
+            .await
+        else {
+            return (None, None);
+        };
+        let mut lines = out.stdout.lines().map(str::trim).filter(|l| !l.is_empty());
+        // `--git-common-dir` is the `.git` of the original checkout; its parent is that checkout.
+        // A bare repository has no parent worth naming, which `None` says.
+        let main = lines
+            .next()
+            .map(PathBuf::from)
+            .and_then(|g| g.parent().map(Path::to_path_buf))
+            .filter(|p| p.is_dir());
+        // `HEAD` on a detached head, which is not a branch name and should not be shown as one.
+        let branch = lines.next().filter(|b| *b != "HEAD").map(str::to_string);
+        (branch, main)
+    }
+
     async fn git<I, S>(&self, args: I) -> Result<Output, VcsError>
     where
         I: IntoIterator<Item = S>,

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -250,6 +250,8 @@ pub struct Host {
     repos: std::collections::HashMap<std::path::PathBuf, Option<neosh_vcs::Git>>,
     /// Where neosh was started, and the fallback for a session that names nowhere.
     cwd: std::path::PathBuf,
+    /// What to call each directory a conversation lives in, worked out once when it is first seen.
+    projects: std::collections::HashMap<std::path::PathBuf, String>,
     /// A key being typed in, if one is.
     ///
     /// The host collects this itself rather than lending a plugin a text field, because a plugin
@@ -463,6 +465,7 @@ impl Host {
             pstate: crate::pstate::PluginState::new(None),
             repos: Default::default(),
             cwd: std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+            projects: Default::default(),
             secret: None,
         }
     }
@@ -639,9 +642,12 @@ impl Host {
                 Ok(ApiOk::Unit)
             }
             // ---- sessions ----------------------------------------------
-            ApiCall::SessionList { include_archived } => Ok(ApiOk::Sessions {
-                sessions: self.agent.sessions().list_with(include_archived),
-            }),
+            ApiCall::SessionList { include_archived } => {
+                let list = self.agent.sessions().list_with(include_archived);
+                Ok(ApiOk::Sessions {
+                    sessions: list.into_iter().map(|s| self.named(s)).collect(),
+                })
+            }
             ApiCall::SessionCurrent => {
                 let info = {
                     let store = self.agent.sessions();
@@ -649,7 +655,7 @@ impl Host {
                     i.is_active = true;
                     i
                 };
-                Ok(ApiOk::Session { session: info })
+                Ok(ApiOk::Session { session: self.named(info) })
             }
             ApiCall::SessionNew { cwd, title, activate } => {
                 let cwd = cwd.map(std::path::PathBuf::from).unwrap_or_else(|| self.cwd.clone());
@@ -684,6 +690,7 @@ impl Host {
                     i.is_active = store.active_id() == &id;
                     i
                 };
+                let info = self.named(info);
                 if activate {
                     // Before the redraw: the banner names the directory, and the file tools have
                     // to be pointed at it before the first turn rather than after it.
@@ -3426,8 +3433,24 @@ impl Host {
         let found = neosh_vcs::Git::discover(&dir).await;
         if let Some(g) = &found {
             tracing::info!(dir = %dir.display(), root = %g.root().display(), "git repository");
+            // Asked once, when the directory is first seen, and remembered. A label is read on
+            // every redraw of the panel and is not worth a `rev-parse` each time.
+            let (branch, main) = g.identity().await;
+            self.projects.insert(dir.clone(), project_name(&dir, branch, main));
         }
         self.repos.insert(dir, found);
+    }
+
+    /// Stamp the display name onto a conversation's info.
+    ///
+    /// Done here rather than in the session store because naming a checkout means having looked at
+    /// the repository, which is the host's job — the store holds conversations and knows nothing
+    /// about git.
+    fn named(&self, mut info: neosh_proto::SessionInfo) -> neosh_proto::SessionInfo {
+        if let Some(name) = self.projects.get(std::path::Path::new(&info.cwd)) {
+            info.project = name.clone();
+        }
+        info
     }
 
     pub fn begin_startup(&mut self, boot: Bootstrap) {
@@ -4528,6 +4551,51 @@ fn chunk(text: impl Into<String>, hl: &str) -> neosh_proto::VirtChunk {
 fn display_width(s: &str) -> usize {
     use unicode_width::UnicodeWidthStr;
     s.width()
+}
+
+/// What to call a checkout.
+///
+/// The last segment of the path is what everything used to use, and it is wrong for exactly the
+/// case a project list exists to make sense of: a worktree is named by whoever created it, so a
+/// panel reading `wt-fe3c0d93` says nothing about which repository or branch that is — and
+/// somebody looking at it reasonably wonders what an unrelated tool's directory is doing in their
+/// workspace.
+///
+/// So: a checkout is named after the repository it belongs to, and a *linked* worktree adds its
+/// branch. `neosh` for the original, `neosh · fix/thing` for a worktree of it. Anything that is not
+/// a repository keeps its directory name, which is all there is to go on.
+fn project_name(
+    dir: &std::path::Path,
+    branch: Option<String>,
+    main: Option<std::path::PathBuf>,
+) -> String {
+    let leaf = |p: &std::path::Path| {
+        p.file_name().map(|n| n.to_string_lossy().into_owned()).unwrap_or_else(|| p.display().to_string())
+    };
+    let Some(main) = main else { return leaf(dir) };
+    let repo = leaf(&main);
+    // The original checkout is just the repository. Adding its branch would put a word that
+    // changes on every `git switch` next to a name that never does.
+    if same_dir(dir, &main) {
+        return repo;
+    }
+    match branch {
+        Some(b) => format!("{repo} \u{b7} {b}"),
+        // A detached head has no name of its own; the directory somebody chose is the next best
+        // thing, and better than showing a bare hash.
+        None => format!("{repo} \u{b7} {}", leaf(dir)),
+    }
+}
+
+/// Whether two paths are the same directory, following symlinks where they resolve.
+fn same_dir(a: &std::path::Path, b: &std::path::Path) -> bool {
+    if a == b {
+        return true;
+    }
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    }
 }
 
 /// The other direction: `~/x` back into an absolute path.

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -573,6 +573,41 @@ fn d_on_a_model_the_provider_serves_explains_rather_than_deleting() {
     assert_eq!(s.picker_now(), before, "and nothing moved");
 }
 
+/// A picker says which keys it answers to.
+///
+/// Every one of them is a list you arrived at by pressing something, and none of them used to say
+/// what to press next — which makes a modal you have to guess your way out of.
+#[test]
+fn a_picker_says_how_to_use_it() {
+    let sb = Sandbox::new("pickerhints");
+    let mut s = sb.start();
+    s.wait_for("PROJECTS");
+    s.ctrl("k");
+    assert!(
+        s.pump(|s| s.picker_named("[Go to]").iter().any(|l| l.contains("choose"))),
+        "the key strip is there\n{:?}",
+        s.picker_named("[Go to]")
+    );
+    let rows = s.picker_named("[Go to]");
+    let strip = rows.iter().find(|l| l.contains("choose")).expect("found above");
+    assert!(strip.contains("close"), "and how to get out again: {strip:?}");
+}
+
+/// Written from the bindings, not from a string, so rebinding one does not make the strip a lie.
+#[test]
+fn the_key_strip_says_the_keys_that_are_actually_bound() {
+    let sb = Sandbox::new("pickerhintsbound");
+    sb.write_config("[options]\n\"ui.keys.accept\" = \"<C-y>\"\n");
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("PROJECTS");
+    s.ctrl("k");
+    assert!(
+        s.pump(|s| s.picker_named("[Go to]").iter().any(|l| l.contains("^y choose"))),
+        "the strip follows the setting\n{:?}",
+        s.picker_named("[Go to]")
+    );
+}
+
 #[test]
 fn a_picker_owns_its_navigation_keys_while_it_is_open() {
     // `<C-n>` is bound globally to "new conversation". A raw capture only receives keys that no
@@ -1723,16 +1758,9 @@ fn a_worktree_is_created_under_the_configured_root_and_you_land_in_it() {
     s.type_text("feat/thing");
     s.enter();
 
-    // The path it proposes says both halves of the layout: the repository, then the branch with
-    // its slash flattened, because a directory is a name and not a path.
+    // The layout says both halves: the repository, then the branch with its slash flattened,
+    // because a directory is a name and not a path.
     let want = format!("{}/work/feat-thing", root.display());
-    assert!(
-        s.pump(|s| s.prompt_now().iter().any(|l| l.contains(&want))),
-        "proposed {want}\n{:?}",
-        s.prompt_now()
-    );
-    s.enter();
-
     assert!(
         s.pump(|_| std::path::Path::new(&want).is_dir()),
         "the worktree is on disk at {want}"
@@ -1741,6 +1769,63 @@ fn a_worktree_is_created_under_the_configured_root_and_you_land_in_it() {
         s.pump(|s| s.chat_now().iter().any(|l| l.contains("feat-thing"))),
         "and the conversation is in it\n{:?}",
         s.chat_now()
+    );
+}
+
+/// A worktree is named by the repository it belongs to and the branch it is on, not by whatever
+/// the directory happens to be called.
+///
+/// The directory is named by whoever created it, which for a worktree made by another tool is a
+/// string like `wt-fe3c0d93`. A panel of those says nothing about which checkout is which, and
+/// reads as somebody else's directory having wandered into your workspace.
+#[test]
+fn a_worktree_is_listed_by_its_repository_and_branch() {
+    let sb = Sandbox::new("wtname");
+    sb.git_init();
+    let root = sb.root.join("trees");
+    sb.write_config(&format!("[options]\n\"worktree.root\" = \"{}\"\n", root.display()));
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("PROJECTS");
+    // The original checkout is just the repository — adding its branch would put a word that
+    // changes on every `git switch` beside a name that never does.
+    assert!(
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("work") && !l.contains('\u{b7}'))),
+        "the main checkout is named plainly\n{:?}",
+        s.sidebar_now()
+    );
+
+    s.send(&command_with("git.worktree.new", "sideline"));
+    assert!(
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("work \u{b7} sideline"))),
+        "and the worktree says which repository and which branch\n{:?}",
+        s.sidebar_now()
+    );
+}
+
+/// One question. The location is a setting; asking again is asking somebody to repeat themselves.
+#[test]
+fn making_a_worktree_asks_only_for_the_branch() {
+    let sb = Sandbox::new("wtoneq");
+    sb.git_init();
+    let root = sb.root.join("trees");
+    sb.write_config(&format!("[options]\n\"worktree.root\" = \"{}\"\n", root.display()));
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("PROJECTS");
+
+    s.send(&command("git.worktree.new"));
+    s.wait_for("Branch for the new worktree");
+    s.type_text("quick");
+    s.enter();
+
+    let want = format!("{}/work/quick", root.display());
+    assert!(
+        s.pump(|_| std::path::Path::new(&want).is_dir()),
+        "it went straight to {want} without a second prompt"
+    );
+    assert!(
+        s.prompt_now().is_empty() || !s.prompt_now().iter().any(|l| l.contains("Create worktree at")),
+        "nothing asked where\n{:?}",
+        s.prompt_now()
     );
 }
 
@@ -1760,9 +1845,8 @@ fn an_empty_worktree_root_puts_them_beside_the_repository() {
     s.enter();
     let want = format!("{}/work-worktrees/side", sb.root.display());
     assert!(
-        s.pump(|s| s.prompt_now().iter().any(|l| l.contains(&want))),
-        "proposed {want}\n{:?}",
-        s.prompt_now()
+        s.pump(|_| std::path::Path::new(&want).is_dir()),
+        "the worktree went beside the repository, at {want}"
     );
 }
 

--- a/docs/adr/0010-mcp-and-acp.md
+++ b/docs/adr/0010-mcp-and-acp.md
@@ -5,9 +5,10 @@
 ## Context
 
 The brief: treat MCP as "a well-known case of the JSON-RPC door, do not invent a competing tool
-protocol". While surveying prior art we found `packages/effect-acp` in t3code — Zed's **Agent Client
-Protocol**, a JSON-RPC-over-stdio standard for the editor↔agent boundary — alongside a Codex
-app-server integration. The same "don't invent a competitor" logic plausibly extends to it.
+protocol". Surveying prior art turned up a second standard already occupying the neighbouring
+boundary — Zed's **Agent Client Protocol**, JSON-RPC over stdio for the editor↔agent seam — and,
+separately, Codex's app-server speaking its own JSON-RPC on the same seam. The "don't invent a
+competitor" logic plausibly extends to both.
 
 ## Decision
 

--- a/docs/adr/0011-open-provider-drivers.md
+++ b/docs/adr/0011-open-provider-drivers.md
@@ -4,9 +4,9 @@
 
 ## Context
 
-The requirement was "support every model", explicitly modelled on t3code. Reading t3code's contracts
-showed the load-bearing idea: `ProviderDriverKind` is an **open branded slug**, not a closed enum,
-and drivers advertise per-model option descriptors that the UI renders generically.
+The requirement was "support every model". Surveying how existing multi-provider clients manage it
+turned up one load-bearing idea worth copying: the driver kind is an **open branded slug**, not a
+closed enum, and drivers advertise per-model option descriptors that the UI renders generically.
 
 ## Decision
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -164,6 +164,14 @@ New conversation
 one answer and is not asked at all — `^N` stays a single key everywhere the choice would be
 theatre. `session.new.here` skips it unconditionally, for a key of your own.
 
+Choosing it asks one question — the branch. The location is a setting, and asking again would be
+asking somebody to repeat themselves; the message says where it landed. `git.worktree.new <branch>
+<path>` takes an explicit path for the times you want one.
+
+A worktree is listed by the repository it belongs to and the branch it is on — `neosh · fix/thing`
+— rather than by its directory name. The directory is named by whoever created it, and a panel of
+those says nothing about which checkout is which.
+
 New worktrees go under `worktree.root`, laid out as `<root>/<repo>/<branch>`:
 
 ```toml
@@ -252,7 +260,11 @@ timeoutlen = 500   # how long to wait for the rest of a sequence
 ```
 
 `^K` searches every command by name, and `F1` lists every binding — both read the live registry, so
-a plugin loaded five minutes ago is in them without anything having been written down.
+a plugin loaded five minutes ago is in them without anything having been written down. Every picker
+carries a strip along its foot saying what it answers to, written from the bindings rather than from
+a string, so rebinding `ui.keys.*` changes what the strip says rather than making it a lie.
+
+`AGENTS.md` at the root of the repository has the whole key table in one place.
 
 ### Adding a project
 

--- a/plugins/api/src/generated/SessionInfo.ts
+++ b/plugins/api/src/generated/SessionInfo.ts
@@ -6,6 +6,18 @@ import type { Usage } from "./Usage";
 export type SessionInfo = {
   id: SessionId;
   cwd: string;
+  /**
+   * What to call the directory this conversation is in.
+   *
+   * The last segment of the path is the obvious answer and is wrong for the case that matters:
+   * a worktree is named by whoever created it, and a list of projects reading `wt-fe3c0d93`
+   * tells you nothing about which repository or branch that is. A checkout is named by the
+   * repository it belongs to, and a linked worktree adds the branch — `neosh · fix/thing` —
+   * because that is what a person means when they say which one they are in.
+   *
+   * Computed by the host so every frontend and plugin agrees, the same as `label`.
+   */
+  project: string;
   message_count: number;
   active_turn?: TurnId | null;
   /**

--- a/plugins/api/src/ui.ts
+++ b/plugins/api/src/ui.ts
@@ -238,6 +238,8 @@ function keyLabel(keys: Map<WidgetAction, KeySpec[]>, action: WidgetAction): str
     "<S-Tab>": "⇧⇥",
     "<Left>": "←",
     "<Right>": "→",
+    "<Up>": "↑",
+    "<Down>": "↓",
     "<CR>": "↵",
     "<Esc>": "esc",
   };
@@ -265,6 +267,23 @@ function actionFor(
     }
   }
   return null;
+}
+
+/**
+ * The key strip a single-pane picker gets unless the caller writes its own.
+ *
+ * Built from the bindings rather than written out, because the point of putting a key on screen is
+ * that it is the key that works — a legend that goes stale the moment somebody rebinds `ui.keys.*`
+ * is worse than no legend, since it is believed.
+ */
+function defaultHints(keys: Map<WidgetAction, KeySpec[]>, filtering: boolean): string {
+  const parts = [
+    `${keyLabel(keys, "accept")} choose`,
+    `${keyLabel(keys, "prev")}/${keyLabel(keys, "next")} move`,
+  ];
+  if (filtering) parts.push("type to filter");
+  parts.push(`${keyLabel(keys, "dismiss")} close`);
+  return parts.join("   ");
 }
 
 /** What a two-pane widget answers to. Notably not `complete`, whose key it shares. */
@@ -324,6 +343,14 @@ export interface PickerOptions<T> {
    * you typed in full, which is not one of them.
    */
   freeform?(query: string): T | null;
+  /**
+   * The key strip at the foot. One line.
+   *
+   * Written out by default, from the keys actually bound, so a rebinding shows up here rather than
+   * making the row a lie. Pass `""` for a picker with nothing worth saying — a two-row yes/no
+   * question is not helped by being told that `↵` chooses.
+   */
+  hints?: string;
 }
 
 const NS = "neosh.ui.picker";
@@ -360,20 +387,27 @@ export async function picker<T>(
 
   const buf = await neosh.buf.create({ name: `[${opts.title ?? "picker"}]`, scratch: true });
   const ns = await neosh.ns.create(NS);
+
+  watchKeys(neosh);
+  const keys = await widgetKeys(neosh);
+  // A picker with no keys on it is a modal you have to guess your way out of. Every one of these
+  // is a list you arrived at by pressing something, and none of them said what to press next.
+  const hints = opts.hints ?? defaultHints(keys, filtering);
+
   const win = await neosh.float.open(buf, {
     anchor: { kind: "screen" },
     width: { kind: "fixed", n: width },
-    // +1 for the separator, +1 more for the filter line when there is one; the title, when
-    // present, adds another.
-    height: { kind: "fixed", n: height + 1 + (filtering ? 1 : 0) + (opts.title ? 1 : 0) },
+    // Exactly the rows that get drawn: the list, plus a filter line when there is one, a title
+    // when there is one, and the key strip unless it was waived.
+    height: {
+      kind: "fixed",
+      n: height + (filtering ? 1 : 0) + (opts.title ? 1 : 0) + (hints === "" ? 0 : 1),
+    },
     border: "rounded",
     focusable: true,
     closeOnBlur: true,
     z: 200,
   });
-
-  watchKeys(neosh);
-  const keys = await widgetKeys(neosh);
 
   let query = opts.query ?? "";
   let cursor = Math.min(Math.max(0, opts.selected ?? 0), Math.max(0, items.length - 1));
@@ -442,11 +476,24 @@ export async function picker<T>(
       const detail = row.item.detail ? `  ${row.item.detail}` : "";
       lines.push(`${mark}${row.item.label}${detail}`);
     }
+    // Pushed onto the last row rather than floated: the float is sized for it, and a strip that
+    // moved up as the list shortened would be a strip you have to look for.
+    const hintLine = hints === "" ? -1 : lines.length + Math.max(0, height - window.length);
+    if (hintLine >= 0) {
+      while (lines.length < hintLine) lines.push("");
+      lines.push(` ${hints}`);
+    }
     await neosh.buf.setLines(buf, 0, -1, lines);
 
     // Marks are reapplied rather than moved: the buffer was just replaced, so there is nothing to
     // move, and clearing first keeps a stale highlight from surviving a filter that shortened it.
     await neosh.ns.clear(ns, buf);
+    if (hintLine >= 0) {
+      await neosh.ns.mark(ns, buf, hintLine, 0, {
+        hlGroup: "Sidebar.Dim",
+        endCol: byteLength(lines[hintLine] ?? ""),
+      });
+    }
     const listTop = (opts.title ? 1 : 0) + (filtering ? 1 : 0);
     for (let i = 0; i < window.length; i++) {
       const row = window[i]!;

--- a/plugins/builtin/git/main.ts
+++ b/plugins/builtin/git/main.ts
@@ -100,14 +100,18 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
       "Largest patch sent to the model when writing a commit message. A large refactor is truncated rather than rejected.",
   });
 
-  const cmds: Array<[string, () => Promise<void>, string]> = [
+  const cmds: Array<[string, (args: string[]) => Promise<void>, string]> = [
     ["git.status", () => showStatus(neosh), "Show working tree status"],
     ["git.branch.switch", () => switchBranch(neosh), "Switch to another branch"],
     ["git.branch.new", () => newBranch(neosh), "Start a branch named after what you describe"],
     ["git.commit", () => commit(neosh), "Stage everything and commit with a written message"],
     ["git.diff", () => showDiff(neosh), "Show what changed"],
     ["git.worktree.list", () => pickWorktree(neosh), "Open a conversation in another worktree"],
-    ["git.worktree.new", () => newWorktree(neosh), "Create a worktree and start working in it"],
+    [
+      "git.worktree.new",
+      (args: string[]) => newWorktree(neosh, args),
+      "Create a worktree and start working in it — `git.worktree.new <branch> [path]`",
+    ],
     ["git.worktree.remove", () => removeWorktree(neosh), "Remove a worktree"],
   ];
   for (const [name, fn, desc] of cmds) {
@@ -555,32 +559,40 @@ async function pickWorktree(neosh: Neosh): Promise<void> {
   neosh.notify(`new conversation in ${chosen.branch ?? chosen.path}`);
 }
 
-async function newWorktree(neosh: Neosh): Promise<void> {
+/**
+ * Make a worktree and start working in it.
+ *
+ * **One question.** It used to ask twice — the branch, then the path, prefilled with the answer it
+ * had already worked out. That second prompt was the whole point of `worktree.root` being a
+ * setting, asked again: somebody who has configured where their worktrees go has said where their
+ * worktrees go. The path is still reachable — `git.worktree.new <branch> <path>` takes it — but
+ * from the palette or a key, the location follows from the configuration and the message says
+ * where it landed.
+ *
+ * Landing in it is the point. Creating a directory you then have to go and find is not a feature,
+ * it is a chore with extra steps.
+ */
+async function newWorktree(neosh: Neosh, args: string[] = []): Promise<void> {
   const status = await repoStatus(neosh);
   if (!status) return;
 
-  const branch = await prompt(neosh, "Branch for the new worktree", { width: 70 });
-  if (!branch || !branch.trim()) return;
-  const name = slug(branch);
-
-  const path = await worktreePath(neosh, status.repo.root, name);
+  const asked = args[0] ?? (await prompt(neosh, "Branch for the new worktree", { width: 70 }));
+  if (!asked || !asked.trim()) return;
+  const name = slug(asked);
+  const where = (args[1] ?? (await worktreePath(neosh, status.repo.root, name))).trim();
+  if (where === "") return;
 
   const taken = new Set((await neosh.git.branches({ includeRemote: true })).map((b) => b.name));
   const create = !taken.has(name);
 
-  const where = await prompt(neosh, "Create worktree at", { initial: path, width: 78 });
-  if (!where || !where.trim()) return;
-
   try {
-    await neosh.git.addWorktree(where.trim(), name, { create });
+    await neosh.git.addWorktree(where, name, { create });
   } catch (e) {
     neosh.notify(String(e), "error");
     return;
   }
-  // Landing in it is the point. Creating a directory you then have to find yourself is not a
-  // feature, it is a chore with extra steps.
-  await neosh.session.create({ cwd: where.trim() });
-  neosh.notify(`working in ${name}`);
+  await neosh.session.create({ cwd: where });
+  neosh.notify(`${create ? "branched" : "checked out"} ${name} in ${where}`);
 }
 
 /**

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -822,7 +822,11 @@ function group(sessions: SessionInfo[], arrangement: Arrangement): Project[][] {
 
   const projects: Project[] = [...by.entries()].map(([cwd, list]) => ({
     cwd,
-    name: basename(cwd),
+    // What the host decided to call it. For a worktree that is the repository and the branch,
+    // rather than whatever the directory happens to be named — a row reading `wt-fe3c0d93`
+    // tells you nothing about which checkout it is, and reads as somebody else's directory having
+    // wandered into your workspace.
+    name: list[0]?.project || basename(cwd),
     favorite: arrangement.isFavorite(cwd),
     sessions: list,
   }));
@@ -995,7 +999,7 @@ function sessionRow(s: SessionInfo, now: number, opts: DrawOptions): ListRow<Tar
  * its own does not say which checkout it belongs to.
  */
 function archivedRow(s: SessionInfo, opts: DrawOptions): ListRow<Target> {
-  const project = basename(s.cwd);
+  const project = s.project || basename(s.cwd);
   const width = Math.max(8, opts.width - 10 - project.length);
   return {
     text: `     ${opts.ascii ? "-" : "┈"} ${clip(s.label, width)}`,


### PR DESCRIPTION
## Why a directory you did not create shows up in the panel

Nothing here references any other tool. A project was named by the last segment of its path, and that is a name somebody else chose — a worktree created by another program is a directory like `wt-fe3c0d93`, so the panel showed that. A list of those says nothing about which checkout is which, and reads as a stranger's directory having wandered into your workspace.

A checkout is now named after the repository it belongs to, and a linked worktree adds its branch: `neosh` for the original, `neosh · fix/thing` for a worktree of it. The original gets no branch, because that would put a word which changes on every `git switch` beside a name that never does.

Worked out once, when a directory is first seen, from a single `rev-parse` rather than a full `git status`. The repository's own name is not `--show-toplevel` — in a worktree that is the worktree — but the parent of `--git-common-dir`.

## Pickers say what they answer to

They said nothing at all, which makes a modal you have to guess your way out of, and every one of them is a list you arrived at by pressing something. The strip along the foot is written from the bindings rather than from a string, so rebinding `ui.keys.accept` changes what it says instead of making it a lie. The float also stopped reserving a row for a separator it does not draw.

## Making a worktree asks one question

It asked twice: the branch, then the path, prefilled with the answer it had already worked out. That second prompt was the whole point of `worktree.root` being a setting, asked again. `git.worktree.new <branch> <path>` still takes an explicit path; from a key, the location follows from the configuration and the message says where it landed.

## AGENTS.md

The whole key table in one place — chat, the transcript reader, the project panel, the pickers — alongside the layout and the rules that are not negotiable. `CLAUDE.md` is a symlink to it.