### PR TITLE
A turn belongs to a conversation, not to the program

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ registry — this table is what ships.
 | `^E` | Reasoning effort and the other per-model options |
 | `⌥↑` `⌥↓` | One rung up or down the capability ladder, same provider |
 | `⇧⇥` | Permission mode — ask, allow-listed, full access, deny |
-| `^T` | Projects and conversations |
+| `^T` | Projects and conversations. Switching is never refused — turns keep running where they are |
 | `^N` | New conversation. In a repository it asks where: here, a new worktree, an existing one, elsewhere |
 | `^O` | Add a project |
 | `^B` | Toggle the sidebar |
@@ -96,7 +96,7 @@ registry — this table is what ships.
 | `^R` | Reload configuration |
 | `^Q` | Quit |
 | `F1` | Every binding, live |
-| `Esc` | Interrupt what is running |
+| `Esc` | Interrupt the turn in this conversation |
 
 Composer editing is a text field: `←`/`→` by character and `^←`/`^→` by word, `Home`/`End` and
 `^Home`/`^End` for the ends, shift with any of them to select, `^W` and `^U` to delete a word or

--- a/crates/neosh-agent/src/agent.rs
+++ b/crates/neosh-agent/src/agent.rs
@@ -12,12 +12,13 @@
 //! * **A driver that runs its own loop gets no tool list.** Sending ours to an agent driver would
 //!   advertise tools it cannot call.
 
+use std::path::Path;
 use std::sync::Arc;
 
 use futures::StreamExt;
 use neosh_proto::{
     ContentBlock, HookName, HookOutcome, HookPayload, Message, MessageLevel, ModelSelection, Role,
-    StopReason, ToolCall, ToolCallId, ToolResult, TurnId, TurnRequest, Usage,
+    SessionId, StopReason, ToolCall, ToolCallId, ToolResult, TurnId, TurnRequest, Usage,
 };
 use neosh_provider::ProviderRegistry;
 use tokio::sync::mpsc;
@@ -38,21 +39,42 @@ use crate::PluginBridge;
 const MAX_TOOL_ROUNDS: usize = 32;
 
 /// Everything the host needs to render or forward.
+///
+/// Every variant says which conversation it came from. Turns run per conversation and several can
+/// be in flight at once, so a receiver that assumed "the current one" would write one
+/// conversation's answer into another's transcript — which is exactly the bug switching used to be
+/// refused in order to avoid.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AgentEvent {
-    TurnStarted { turn: TurnId },
-    Token { turn: TurnId, text: String },
-    Thinking { turn: TurnId, text: String },
-    ToolStarted { turn: TurnId, call: ToolCall },
-    ToolFinished { turn: TurnId, call: ToolCall, result: ToolResult },
-    TurnEnded { turn: TurnId, stop_reason: StopReason, usage: Usage },
+    TurnStarted { session: SessionId, turn: TurnId },
+    Token { session: SessionId, turn: TurnId, text: String },
+    Thinking { session: SessionId, turn: TurnId, text: String },
+    ToolStarted { session: SessionId, turn: TurnId, call: ToolCall },
+    ToolFinished { session: SessionId, turn: TurnId, call: ToolCall, result: ToolResult },
+    TurnEnded { session: SessionId, turn: TurnId, stop_reason: StopReason, usage: Usage },
     /// A message typed while the turn was running has been taken into it.
     ///
     /// Emitted at the moment it enters the conversation rather than when it was typed, because
     /// until then it is a draft the user can still change their mind about — and a transcript that
     /// shows a question the model has not been told about is a transcript that is lying.
-    Steered { turn: TurnId, text: String },
-    Notice { level: MessageLevel, text: String },
+    Steered { session: SessionId, turn: TurnId, text: String },
+    Notice { session: SessionId, level: MessageLevel, text: String },
+}
+
+impl AgentEvent {
+    /// Which conversation this belongs to, for a receiver deciding whether to draw it.
+    pub fn session(&self) -> &SessionId {
+        match self {
+            Self::TurnStarted { session, .. }
+            | Self::Token { session, .. }
+            | Self::Thinking { session, .. }
+            | Self::ToolStarted { session, .. }
+            | Self::ToolFinished { session, .. }
+            | Self::TurnEnded { session, .. }
+            | Self::Steered { session, .. }
+            | Self::Notice { session, .. } => session,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -76,11 +98,6 @@ pub struct Agent {
     /// Swappable, because a config reload can tighten permissions and a layer fixed at launch
     /// would report success while changing nothing.
     permissions: Arc<std::sync::RwLock<Arc<PermissionLayer>>>,
-    /// Things typed while a turn was running, waiting for a gap to be said in.
-    ///
-    /// Its own lock, and never held across an await: the turn loop drains it between rounds, and
-    /// the keyboard adds to it from a completely different task.
-    steering: Arc<std::sync::Mutex<Vec<String>>>,
     events: mpsc::UnboundedSender<AgentEvent>,
 }
 
@@ -98,7 +115,6 @@ impl Agent {
                 hooks: Arc::new(std::sync::RwLock::new(HookRegistry::new())),
                 providers: Arc::new(std::sync::RwLock::new(providers)),
                 permissions: Arc::new(std::sync::RwLock::new(permissions)),
-                steering: Arc::default(),
                 events: tx,
             },
             rx,
@@ -169,6 +185,15 @@ impl Agent {
         let _ = self.events.send(ev);
     }
 
+    /// Reach one conversation by id, whether or not it is the one on screen.
+    ///
+    /// `None` means it has been closed. That can happen while its own turn is still running, and
+    /// it is a reason for the turn to stop rather than a reason to panic.
+    fn with<T>(&self, id: &SessionId, f: impl FnOnce(&mut Session) -> T) -> Option<T> {
+        let mut store = self.sessions();
+        store.get_mut(id).map(f)
+    }
+
     /// Say something to a turn that is already running.
     ///
     /// It is taken into the conversation at the next gap — between one round of tool calls and the
@@ -178,23 +203,39 @@ impl Agent {
     /// Not injected into the provider stream, because a stream in flight cannot be interrupted
     /// without discarding what has already been generated. The gap between rounds is the earliest
     /// honest moment.
-    pub fn steer(&self, text: String) {
-        self.steering.lock().expect("steering lock poisoned").push(text);
+    ///
+    /// Addressed to a conversation, because what you type belongs to the one you typed it in — not
+    /// to whichever turn happens to reach a gap first.
+    pub fn steer(&self, session: &SessionId, text: String) {
+        self.with(session, |s| s.steering.push(text));
     }
 
     /// Whether anything is waiting to be said.
-    pub fn steering_count(&self) -> usize {
-        self.steering.lock().expect("steering lock poisoned").len()
+    pub fn steering_count(&self, session: &SessionId) -> usize {
+        self.with(session, |s| s.steering.len()).unwrap_or(0)
     }
 
     /// What is waiting, without taking it. For drawing it.
-    pub fn steering_texts(&self) -> Vec<String> {
-        self.steering.lock().expect("steering lock poisoned").clone()
+    pub fn steering_texts(&self, session: &SessionId) -> Vec<String> {
+        self.with(session, |s| s.steering.clone()).unwrap_or_default()
     }
 
     /// Take what is waiting, leaving the queue empty.
-    pub fn take_steering(&self) -> Vec<String> {
-        std::mem::take(&mut *self.steering.lock().expect("steering lock poisoned"))
+    pub fn take_steering(&self, session: &SessionId) -> Vec<String> {
+        self.with(session, |s| std::mem::take(&mut s.steering)).unwrap_or_default()
+    }
+
+    /// The policy, rooted at the directory a turn is running in.
+    ///
+    /// The shared layer's root follows the conversation on screen, which is right for a plugin
+    /// asking a question and wrong for a turn: the turn may not be the one on screen, and by the
+    /// time it finishes it may not be the one on screen either.
+    fn permissions_in(&self, cwd: &Path) -> Arc<PermissionLayer> {
+        let base = self.permissions();
+        if cwd.as_os_str().is_empty() || base.workspace() == cwd {
+            return base;
+        }
+        Arc::new(base.rooted_at(cwd))
     }
 
     pub fn selection(&self) -> Option<ModelSelection> {
@@ -319,25 +360,44 @@ impl Agent {
         }
     }
 
-    /// Run one user turn to completion, with a caller-supplied cancellation token.
-    ///
-    /// The host owns the token so it can interrupt a turn without taking the lock the turn itself
-    /// holds — otherwise `<Esc>` would have to wait for the thing it is trying to stop.
+    /// Run one user turn to completion in the conversation on screen.
     pub async fn run_turn(&self, bridge: &dyn PluginBridge, text: String) -> TurnOutcome {
         self.run_turn_with(bridge, text, CancellationToken::new()).await
     }
 
+    /// The same, with a caller-supplied cancellation token.
+    ///
+    /// The host owns the token so it can interrupt a turn without taking the lock the turn itself
+    /// holds — otherwise `<Esc>` would have to wait for the thing it is trying to stop.
     pub async fn run_turn_with(
         &self,
         bridge: &dyn PluginBridge,
         text: String,
         cancel: CancellationToken,
     ) -> TurnOutcome {
+        let session = self.sessions().active_id().clone();
+        self.run_turn_in(bridge, session, text, cancel).await
+    }
+
+    /// Run one user turn to completion **in a named conversation**.
+    ///
+    /// Every read and write goes through the id rather than through "the active session", so the
+    /// turn is unaffected by switching, and several turns can be in flight in different
+    /// conversations at once. The conversation may even be closed underneath it; that reads as a
+    /// cancellation, because there is nowhere left to put the answer.
+    pub async fn run_turn_in(
+        &self,
+        bridge: &dyn PluginBridge,
+        session: SessionId,
+        text: String,
+        cancel: CancellationToken,
+    ) -> TurnOutcome {
         let turn = TurnId::new();
-        self.session().active_turn = Some(turn.clone());
+        self.with(&session, |s| s.active_turn = Some(turn.clone()));
 
         let end = |me: &Self, stop: StopReason, usage: Usage| {
             me.emit(AgentEvent::TurnEnded {
+                session: session.clone(),
                 turn: turn.clone(),
                 stop_reason: stop.clone(),
                 usage,
@@ -355,8 +415,9 @@ impl Agent {
         )
         .await;
         if let HookOutcome::Veto { reason } = outcome {
-            self.session().active_turn = None;
+            self.with(&session, |s| s.active_turn = None);
             self.emit(AgentEvent::Notice {
+                session: session.clone(),
                 level: MessageLevel::Warn,
                 text: format!("turn blocked: {reason}"),
             });
@@ -371,11 +432,12 @@ impl Agent {
             text: text.clone(),
         });
 
-        self.emit(AgentEvent::TurnStarted { turn: turn.clone() });
-        self.session().push_user_text(text);
+        self.emit(AgentEvent::TurnStarted { session: session.clone(), turn: turn.clone() });
+        self.with(&session, |s| s.push_user_text(text));
 
-        let Some(selection) = self.selection() else {
-            self.session().active_turn = None;
+        let selection = self.with(&session, |s| s.selection.clone()).flatten();
+        let Some(selection) = selection else {
+            self.with(&session, |s| s.active_turn = None);
             return end(
                 self,
                 StopReason::Error { message: "no model selected".into() },
@@ -409,13 +471,18 @@ impl Agent {
 
             // One guard, not two: temporaries in a struct literal live to the end of the
             // statement, so taking the session lock twice here would deadlock against itself.
-            let (cwd, system, messages) = {
-                let sess = self.session();
-                (sess.cwd.clone(), sess.system.clone(), sess.messages.clone())
+            let Some((cwd, system, messages)) =
+                self.with(&session, |s| (s.cwd.clone(), s.system.clone(), s.messages.clone()))
+            else {
+                // Closed while its own turn was running. There is nowhere to put the answer, so
+                // this is a cancellation rather than an error to report into a transcript that no
+                // longer exists.
+                stop = StopReason::Cancelled;
+                break;
             };
             let request = TurnRequest {
                 selection: selection.clone(),
-                cwd,
+                cwd: cwd.clone(),
                 system,
                 messages,
                 // An agent driver brings its own tools; advertising ours would list tools it
@@ -440,13 +507,18 @@ impl Agent {
                 let Some(ev) = next else { break };
                 for update in assembler.push(ev) {
                     match update {
-                        TurnUpdate::Text { text } => {
-                            self.emit(AgentEvent::Token { turn: turn.clone(), text })
-                        }
-                        TurnUpdate::Thinking { text } => {
-                            self.emit(AgentEvent::Thinking { turn: turn.clone(), text })
-                        }
+                        TurnUpdate::Text { text } => self.emit(AgentEvent::Token {
+                            session: session.clone(),
+                            turn: turn.clone(),
+                            text,
+                        }),
+                        TurnUpdate::Thinking { text } => self.emit(AgentEvent::Thinking {
+                            session: session.clone(),
+                            turn: turn.clone(),
+                            text,
+                        }),
                         TurnUpdate::Error { message, .. } => self.emit(AgentEvent::Notice {
+                            session: session.clone(),
                             level: MessageLevel::Error,
                             text: message,
                         }),
@@ -462,11 +534,10 @@ impl Agent {
             let calls = assembler.tool_calls();
             let (message, this_stop, usage) = assembler.finish();
             total.merge(&usage);
-            {
-                let mut sess = self.session();
-                sess.add_usage(&usage);
-                sess.push_assistant(message);
-            }
+            self.with(&session, |s| {
+                s.add_usage(&usage);
+                s.push_assistant(message);
+            });
 
             if cancelled {
                 stop = StopReason::Cancelled;
@@ -477,7 +548,7 @@ impl Agent {
                 // Nothing left to do — unless somebody typed while it was working. Carrying on
                 // rather than ending is the whole point: a follow-up that starts a new turn has
                 // lost the chance to change what this one does.
-                if cancel.is_cancelled() || !self.take_steering_into(&turn) {
+                if cancel.is_cancelled() || !self.take_steering_into(&session, &turn) {
                     break;
                 }
                 continue;
@@ -489,12 +560,12 @@ impl Agent {
                     break;
                 }
                 let call = ToolCall { id: id.clone(), turn: turn.clone(), name, input };
-                results.push((id, self.run_tool(bridge, call, &cancel).await));
+                results.push((id, self.run_tool(bridge, &session, &cwd, call, &cancel).await));
             }
-            self.session().push_tool_results(results);
+            self.with(&session, |s| s.push_tool_results(results));
             // The gap between rounds: the model is about to be asked again anyway, so anything
             // typed since the last one rides along with the tool results.
-            self.take_steering_into(&turn);
+            self.take_steering_into(&session, &turn);
 
             if round + 1 == MAX_TOOL_ROUNDS {
                 stop = StopReason::Error {
@@ -503,7 +574,7 @@ impl Agent {
             }
         }
 
-        self.session().active_turn = None;
+        self.with(&session, |s| s.active_turn = None);
         self.observe(bridge, HookName::TurnPost, HookPayload::TurnPost {
             turn: turn.clone(),
             stop_reason: stop.clone(),
@@ -513,14 +584,18 @@ impl Agent {
     }
 
     /// Move anything queued into the conversation. Returns whether there was anything.
-    fn take_steering_into(&self, turn: &TurnId) -> bool {
-        let queued = self.take_steering();
+    fn take_steering_into(&self, session: &SessionId, turn: &TurnId) -> bool {
+        let queued = self.take_steering(session);
         if queued.is_empty() {
             return false;
         }
         for text in queued {
-            self.session().push_user_text(text.clone());
-            self.emit(AgentEvent::Steered { turn: turn.clone(), text });
+            self.with(session, |s| s.push_user_text(text.clone()));
+            self.emit(AgentEvent::Steered {
+                session: session.clone(),
+                turn: turn.clone(),
+                text,
+            });
         }
         true
     }
@@ -529,6 +604,8 @@ impl Agent {
     async fn run_tool(
         &self,
         bridge: &dyn PluginBridge,
+        session: &SessionId,
+        cwd: &Path,
         call: ToolCall,
         cancel: &CancellationToken,
     ) -> ToolResult {
@@ -552,6 +629,7 @@ impl Agent {
             // The model is told, so it can explain or route around the refusal rather than
             // silently losing the call.
             self.emit(AgentEvent::ToolFinished {
+                session: session.clone(),
                 turn: call.turn.clone(),
                 call: call.clone(),
                 result: result.clone(),
@@ -569,7 +647,11 @@ impl Agent {
             _ => call,
         };
 
-        self.emit(AgentEvent::ToolStarted { turn: call.turn.clone(), call: call.clone() });
+        self.emit(AgentEvent::ToolStarted {
+            session: session.clone(),
+            turn: call.turn.clone(),
+            call: call.clone(),
+        });
 
         // Resolve the handler and release the registry lock before running it: a tool that
         // calls back into the API must not find the registry it came from locked.
@@ -584,7 +666,10 @@ impl Agent {
                         turn: Some(call.turn.clone()),
                     };
                     let ctx = ToolCtx {
-                        permissions: self.permissions(),
+                        // Rooted at the conversation this turn belongs to, not at whichever one is
+                        // on screen: `src/main.rs` has to mean the same file for the whole turn,
+                        // however much switching happens while it runs.
+                        permissions: self.permissions_in(cwd),
                         // Only offer to ask if something is actually listening; otherwise `permit`
                         // would wait on a hook nobody registered.
                         approve: (!approver.hooks.is_empty()).then_some(&approver as &dyn crate::tools::Approver),
@@ -604,6 +689,7 @@ impl Agent {
         };
 
         self.emit(AgentEvent::ToolFinished {
+            session: session.clone(),
             turn: call.turn.clone(),
             call: call.clone(),
             result: result.clone(),

--- a/crates/neosh-agent/src/permission.rs
+++ b/crates/neosh-agent/src/permission.rs
@@ -81,6 +81,17 @@ impl PermissionLayer {
         self.workspace = workspace.into();
     }
 
+    /// The same policy, resolving relative paths against a different root.
+    ///
+    /// [`set_workspace`](Self::set_workspace) moves the one shared layer, which is the right answer
+    /// for a plugin asking a question outside any turn. It is the wrong answer for a turn: several
+    /// conversations can be running at once, in different projects, and a root set by whichever
+    /// switch happened last would let one turn's `src/main.rs` resolve into another turn's tree.
+    /// A turn takes a view rooted at its own conversation instead.
+    pub fn rooted_at(&self, workspace: impl Into<PathBuf>) -> Self {
+        Self { workspace: workspace.into(), ..self.clone() }
+    }
+
     /// Resolve a possibly-relative path and confirm it stays inside an allowed root.
     ///
     /// Returns the resolved path on success. `None` means the path escapes every root, by any

--- a/crates/neosh-agent/src/session.rs
+++ b/crates/neosh-agent/src/session.rs
@@ -19,6 +19,12 @@ pub struct Session {
     /// The prompt size of the most recent request: how full the window actually is.
     pub context_tokens: u64,
     pub active_turn: Option<TurnId>,
+    /// Things said to *this* conversation while its turn was running, waiting for a gap to be
+    /// taken in.
+    ///
+    /// Per conversation rather than per process: several turns can be in flight at once, and a
+    /// single queue would hand what you typed here to whichever one reached a gap first.
+    pub steering: Vec<String>,
     /// When the running turn started, in seconds since the epoch. Stamped by whoever starts the
     /// turn, for the same reason `created_at` is: this type does not read a clock.
     pub turn_started_at: Option<i64>,
@@ -48,6 +54,7 @@ impl Session {
             usage: Usage::default(),
             context_tokens: 0,
             active_turn: None,
+            steering: Vec::new(),
             turn_started_at: None,
             title: None,
             created_at: 0,

--- a/crates/neosh-agent/src/store.rs
+++ b/crates/neosh-agent/src/store.rs
@@ -143,7 +143,9 @@ impl SessionStore {
         &self.active.id == id || self.idle.contains_key(id)
     }
 
-    fn get_mut(&mut self, id: &SessionId) -> Option<&mut Session> {
+    /// Public because a turn reaches its own conversation by id: it may not be the active one, and
+    /// by the time the turn ends it may not even be the one on screen.
+    pub fn get_mut(&mut self, id: &SessionId) -> Option<&mut Session> {
         if &self.active.id == id { Some(&mut self.active) } else { self.idle.get_mut(id) }
     }
 

--- a/crates/neosh-agent/tests/agent_loop.rs
+++ b/crates/neosh-agent/tests/agent_loop.rs
@@ -345,3 +345,74 @@ async fn usage_accumulates_across_turns() {
     assert_eq!(usage.input_tokens, 200, "two turns, summed");
     assert_eq!(usage.output_tokens, 20);
 }
+
+// ---------------------------------------------------------------------------
+// A turn belongs to a conversation
+// ---------------------------------------------------------------------------
+
+/// One scripted turn that says `text` and stops.
+fn text_script(text: &str) -> Vec<neosh_proto::ProviderEvent> {
+    MockProvider::text_turn(&[text])
+}
+
+#[tokio::test]
+async fn a_turn_runs_in_the_conversation_it_names_not_in_whichever_is_on_screen() {
+    // The whole point of addressing a turn by id: you can switch away from it, and it keeps
+    // writing where it started rather than into whatever you are now reading.
+    let (agent, mut rx) = agent_with_script(vec![text_script("answered")]);
+    let on_screen = agent.sessions().active_id().clone();
+
+    let mut other = Session::new(std::env::temp_dir());
+    other.selection = agent.selection();
+    let elsewhere = other.id.clone();
+    agent.sessions().insert(other);
+
+    agent
+        .run_turn_in(
+            &TestBridge::default(),
+            elsewhere.clone(),
+            "ask the other one".into(),
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await;
+
+    let store = agent.sessions();
+    assert_eq!(store.active_id(), &on_screen, "running a turn does not switch conversations");
+    assert!(
+        store.get(&on_screen).expect("still there").messages.is_empty(),
+        "the conversation on screen was not part of this and must be untouched"
+    );
+    let ran_in = store.get(&elsewhere).expect("still there");
+    assert_eq!(ran_in.messages.len(), 2, "the question and the answer landed where they belong");
+    drop(store);
+
+    assert!(
+        drain(&mut rx).iter().all(|e| e.session() == &elsewhere),
+        "every event says which conversation it came from, and it is not the one on screen"
+    );
+}
+
+#[tokio::test]
+async fn steering_is_taken_by_the_conversation_it_was_typed_in() {
+    // A single queue would hand what you typed here to whichever turn reached a gap first.
+    let (agent, _rx) = agent_with_script(vec![]);
+    let here = agent.sessions().active_id().clone();
+    let there = {
+        let s = Session::new(std::env::temp_dir());
+        let id = s.id.clone();
+        agent.sessions().insert(s);
+        id
+    };
+
+    agent.steer(&here, "wait, not that file".into());
+    agent.steer(&there, "and rename it too".into());
+
+    assert_eq!(agent.steering_count(&here), 1);
+    assert_eq!(agent.steering_count(&there), 1);
+    assert_eq!(agent.take_steering(&here), vec!["wait, not that file".to_string()]);
+    assert_eq!(
+        agent.steering_texts(&there),
+        vec!["and rename it too".to_string()],
+        "taking one conversation's queue must not empty another's"
+    );
+}

--- a/crates/neosh-proto/src/plugin.rs
+++ b/crates/neosh-proto/src/plugin.rs
@@ -104,16 +104,25 @@ pub enum PluginEvent {
         old_end: u32,
         new_end: u32,
     },
+    /// A turn has begun.
+    ///
+    /// Every turn event says which conversation it belongs to. A workspace runs several at once,
+    /// so a plugin that assumed "the one on screen" would attribute one conversation's answer to
+    /// another — and by the time a turn ends, the conversation it ran in may not be on screen at
+    /// all.
     TurnStarted {
+        session: SessionId,
         turn: TurnId,
     },
     /// One streamed chunk of assistant text. Chunks are provider-sized, not character-sized.
     Token {
+        session: SessionId,
         turn: TurnId,
         text: String,
     },
     /// One streamed chunk of reasoning, where the provider exposes it.
     ThinkingToken {
+        session: SessionId,
         turn: TurnId,
         text: String,
     },
@@ -121,15 +130,18 @@ pub enum PluginEvent {
     /// call may proceed and can veto it, this one is told that it is happening. A transcript wants
     /// the telling, not the asking.
     ToolStarted {
+        session: SessionId,
         turn: TurnId,
         call: ToolCall,
     },
     ToolFinished {
+        session: SessionId,
         turn: TurnId,
         call: ToolCall,
         result: ToolResult,
     },
     TurnEnded {
+        session: SessionId,
         turn: TurnId,
         stop_reason: StopReason,
         usage: Usage,

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -171,11 +171,12 @@ pub struct Host {
     /// Separate from the status line's so that redrawing the working line — which happens several
     /// times a second — cannot clear a mark on a message from ten turns ago.
     chat_ns: neosh_proto::NamespaceId,
-    /// The row the working line is on while a turn is in flight, and what it says.
+    /// Whether the working line is currently the last row of the chat buffer.
     ///
-    /// Held rather than searched for: the transcript grows underneath it as tools report in, and
-    /// scanning for "the line that looks like a spinner" is how you end up rewriting a message.
-    working: Option<Working>,
+    /// A fact about the buffer on screen, not about a turn: what the line *says* lives on the
+    /// [`Round`], because the turn it reports on may be running in a conversation you are not
+    /// looking at.
+    working: bool,
     /// What plugins put in the status line, by key.
     ///
     /// A `BTreeMap` so iteration order is deterministic; the render sorts by priority anyway, but a
@@ -183,7 +184,19 @@ pub struct Host {
     /// redraws.
     status_segments: std::collections::BTreeMap<String, neosh_proto::StatusSegment>,
 
-    active_turn: Option<CancellationToken>,
+    /// One cancellation token per conversation with a turn in flight.
+    ///
+    /// A map rather than an `Option`, because a turn belongs to a conversation and not to the
+    /// program. Switching used to be refused while one ran; now switching is just switching, and
+    /// `<Esc>` cancels the turn of the conversation you are looking at.
+    turns: std::collections::HashMap<neosh_proto::SessionId, CancellationToken>,
+    /// What each conversation with a turn in flight is doing, and what it has said so far in the
+    /// round it is in the middle of.
+    ///
+    /// Kept for every running conversation, on screen or not: a round's text only reaches
+    /// `session.messages` when its stream closes, so a transcript rebuilt from messages alone would
+    /// show a conversation that is visibly working and has said nothing.
+    rounds: std::collections::HashMap<neosh_proto::SessionId, Round>,
     /// Set while a multi-key sequence is half typed, so the loop knows to arm the timeout that
     /// eventually gives up on it.
     keys_pending: bool,
@@ -313,18 +326,27 @@ fn subject_of(_name: &str, input: &serde_json::Value) -> String {
     String::new()
 }
 
-/// The line that says a turn is in flight.
+/// A turn in flight, in whichever conversation it belongs to.
 ///
-/// It exists because the gap between pressing Enter and the first token is the longest silence in
-/// the program, and a still screen and a wedged process look identical. It carries an elapsed
-/// clock for the same reason: "working" with no number is indistinguishable from "stuck".
-struct Working {
+/// The working line exists because the gap between pressing Enter and the first token is the
+/// longest silence in the program, and a still screen and a wedged process look identical. It
+/// carries an elapsed clock for the same reason: "working" with no number is indistinguishable
+/// from "stuck".
+///
+/// This is per conversation rather than per screen, so that switching away from a turn and back
+/// shows the same clock it would have shown had you never left.
+struct Round {
     /// The word this turn is using. Chosen once per turn — a verb that changes every tick is a
     /// slot machine, and you end up watching it instead of thinking.
     verb: &'static str,
     started: std::time::Instant,
     /// What it is waiting on, when that is something other than the model.
     note: Option<String>,
+    /// Text streamed in the round now in progress.
+    ///
+    /// Cleared the moment that round's assistant message lands in the conversation, because from
+    /// then on the messages are the truth and this would be a second copy of them.
+    text: String,
 }
 
 // Deliberately no row index. The working line is *always the last line of the transcript* and
@@ -439,13 +461,14 @@ impl Host {
             status_ns,
             chat_ns,
             composer_ns,
-            working: None,
+            working: false,
             status_segments: Default::default(),
             hints: Default::default(),
             welcome_rows: 0,
             selection_pinned: false,
             acp_drivers: Vec::new(),
-            active_turn: None,
+            turns: std::collections::HashMap::new(),
+            rounds: std::collections::HashMap::new(),
             keys_pending: false,
             keys_touched: false,
             reading: false,
@@ -606,9 +629,7 @@ impl Host {
                 Ok(ApiOk::Unit)
             }
             ApiCall::AgentCancel => {
-                if let Some(t) = self.active_turn.take() {
-                    t.cancel();
-                }
+                self.cancel_turn_here();
                 Ok(ApiOk::Unit)
             }
             ApiCall::AgentGetSelection => {
@@ -701,14 +722,11 @@ impl Host {
                 self.persist_sessions();
                 Ok(ApiOk::Session { session: info })
             }
+            // Switching is never refused, including while a turn is running. A turn belongs to its
+            // conversation: it keeps streaming into that one's transcript, and what you see is
+            // rebuilt from the conversation you switched to. Waiting for a model to finish before
+            // you may look at something else is the workspace refusing to be a workspace.
             ApiCall::SessionSwitch { session } => {
-                if self.active_turn.is_some() {
-                    // The turn writes into the chat buffer as it streams; switching underneath it
-                    // would interleave one conversation's output into another's transcript.
-                    return Err(ApiError::Busy {
-                        message: "a turn is running — interrupt it first".into(),
-                    });
-                }
                 self.agent
                     .sessions()
                     .switch(&session)
@@ -720,11 +738,13 @@ impl Host {
             }
             ApiCall::SessionClose { session } => {
                 let closing_active = self.agent.sessions().active_id() == &session;
-                if closing_active && self.active_turn.is_some() {
-                    return Err(ApiError::Busy {
-                        message: "a turn is running — interrupt it first".into(),
-                    });
+                // Closing is the one case that does stop a turn: there is about to be nowhere to
+                // put its answer, and a stream writing into a conversation that no longer exists is
+                // a subprocess nobody can reach.
+                if let Some(t) = self.turns.remove(&session) {
+                    t.cancel();
                 }
+                self.rounds.remove(&session);
                 self.agent.sessions().remove(&session).map_err(|e| match e {
                     neosh_agent::store::StoreError::LastSession => {
                         ApiError::InvalidArgument { message: e.to_string() }
@@ -740,13 +760,11 @@ impl Host {
                 self.persist_sessions();
                 Ok(ApiOk::Unit)
             }
+            // Archiving does not stop a turn. Putting a conversation away is about the list you
+            // read, not about the work: it keeps its messages, and it keeps whatever it was in the
+            // middle of saying.
             ApiCall::SessionArchive { session, archived } => {
                 let leaving = archived && self.agent.sessions().active_id() == &session;
-                if leaving && self.active_turn.is_some() {
-                    return Err(ApiError::Busy {
-                        message: "a turn is running — interrupt it first".into(),
-                    });
-                }
                 // Archiving the only conversation you have is a reasonable thing to want, and
                 // "there is nowhere to go" is a bad answer to it. Somewhere to go is one line.
                 if leaving && self.agent.sessions().list().len() <= 1 {
@@ -907,33 +925,80 @@ impl Host {
         }
     }
 
+    /// The conversation on screen. Cloned rather than borrowed: everything that asks this goes on
+    /// to touch the store again, and holding the lock across that is how a deadlock is written.
+    fn active_session(&self) -> neosh_proto::SessionId {
+        self.agent.sessions().active_id().clone()
+    }
+
     fn start_turn(&mut self, text: String) {
+        let here = self.active_session();
+        self.start_turn_in(here, text);
+    }
+
+    /// Start a turn in a named conversation, drawing it only if it is the one on screen.
+    ///
+    /// Named rather than implied, because the caller is not always the keyboard: a turn that ends
+    /// with something still queued starts the next one, and by then you may be reading something
+    /// else entirely.
+    fn start_turn_in(&mut self, session: neosh_proto::SessionId, text: String) {
+        let on_screen = self.active_session() == session;
         // Typing while it works is steering, not an error. The old behaviour — refuse, and make you
         // wait with the sentence already written — is the one moment in the program where you know
         // exactly what you want to say and cannot say it.
-        if self.active_turn.is_some() {
-            self.agent.steer(text);
-            self.draw_working();
-            self.refresh_composer();
+        if self.turns.contains_key(&session) {
+            self.agent.steer(&session, text);
+            if on_screen {
+                self.draw_working();
+                self.refresh_composer();
+            }
             return;
         }
         let token = CancellationToken::new();
-        self.active_turn = Some(token.clone());
+        self.turns.insert(session.clone(), token.clone());
+        // Not random: the turn id would be ideal but is not known yet, and a clock read is the one
+        // varying thing already to hand. Per turn, so it does not change under you mid-answer.
+        let verb = VERBS
+            .get(now_secs().unsigned_abs() as usize % VERBS.len())
+            .copied()
+            .unwrap_or("Working");
+        self.rounds.insert(session.clone(), Round {
+            verb,
+            started: std::time::Instant::now(),
+            note: None,
+            text: String::new(),
+        });
         // Stamped here rather than inside the agent so `Session` stays clock-free and testable.
         // The turn id itself is set by the agent a moment later; a list only reads this while the
         // turn id is present, so the ordering is not observable.
-        self.agent.session().turn_started_at = Some(now_secs());
-        // Asking a question means you want to see the answer: scrolled-back state does not survive
-        // sending, or the reply arrives somewhere off screen.
-        self.scroll_chat(0);
-        self.chat_question(&text);
-        self.begin_working();
+        if let Some(s) = self.agent.sessions().get_mut(&session) {
+            s.turn_started_at = Some(now_secs());
+        }
+        if on_screen {
+            // Asking a question means you want to see the answer: scrolled-back state does not
+            // survive sending, or the reply arrives somewhere off screen.
+            self.scroll_chat(0);
+            self.chat_question(&text);
+            self.begin_working();
+        }
 
         let agent = self.agent.clone();
         let bridge = self.bridge.clone();
         tokio::spawn(async move {
-            agent.run_turn_with(&*bridge, text, token).await;
+            agent.run_turn_in(&*bridge, session, text, token).await;
         });
+    }
+
+    /// Stop the turn in the conversation on screen, if there is one.
+    fn cancel_turn_here(&mut self) -> bool {
+        let here = self.active_session();
+        match self.turns.remove(&here) {
+            Some(t) => {
+                t.cancel();
+                true
+            }
+            None => false,
+        }
     }
 
     /// Start an empty conversation without switching to it.
@@ -1317,7 +1382,7 @@ impl Host {
 
         // What you typed while it was working, waiting for a gap to be said in. This outranks the
         // shortcut row: an unsent sentence of yours is more urgent than a list of keys.
-        let queued = self.agent.steering_texts();
+        let queued = self.agent.steering_texts(&self.active_session());
         for (i, text) in queued.iter().take(2).enumerate() {
             let more = queued.len().saturating_sub(2);
             let tail = if i == 1 && more > 0 { format!("  (+{more} more)") } else { String::new() };
@@ -1662,8 +1727,7 @@ impl Host {
             return;
         }
         if key.code == KeyCode::Esc {
-            if let Some(t) = self.active_turn.take() {
-                t.cancel();
+            if self.cancel_turn_here() {
                 self.editor_message(MessageLevel::Info, "interrupted");
             }
             return;
@@ -2633,6 +2697,7 @@ impl Host {
         // that are on their way out would write into the conversation being left behind.
         self.answer = None;
         self.streaming = None;
+        self.working = false;
         self.chat_top = 0;
         let ascii = self.option_bool("ui.ascii_only");
         let (lines, marks, label) = {
@@ -2666,11 +2731,34 @@ impl Host {
         self.welcome_rows = 0;
         self.ensure_usable_selection();
         self.draw_welcome();
+        self.replay_round();
         self.set_composer("");
         self.refresh_status();
         self.bridge.broadcast(PluginEvent::SessionChanged {
             session: self.agent.sessions().active_id().clone(),
         });
+    }
+
+    /// Put back what a turn already said, for a conversation that is still mid-turn.
+    ///
+    /// The transcript is rebuilt from messages, and the round in progress is not in them yet — its
+    /// assistant message only lands when the stream closes. Without this, switching into a
+    /// conversation that is halfway through an answer shows the answer's first half missing and
+    /// the second half arriving out of nowhere.
+    ///
+    /// Text or the working line, never both, because that is what the live path does: the first
+    /// token takes the working line away.
+    fn replay_round(&mut self) {
+        let here = self.active_session();
+        if !self.turns.contains_key(&here) {
+            return;
+        }
+        let said = self.rounds.get(&here).map(|r| r.text.clone()).unwrap_or_default();
+        if said.is_empty() {
+            self.begin_working();
+        } else {
+            self.answer_text(&said);
+        }
     }
 
     /// Append streamed output, starting a new line when the kind of output changes.
@@ -2700,7 +2788,7 @@ impl Host {
     /// Where new content goes: the end, or the line above the working line when there is one.
     fn chat_end(&self) -> i64 {
         let n = self.editor.buffer(self.chat).map(|b| b.line_count() as i64).unwrap_or(0);
-        if self.working.is_some() { (n - 1).max(0) } else { n }
+        if self.working { (n - 1).max(0) } else { n }
     }
 
     /// Highlight a span of one transcript row.
@@ -2862,15 +2950,16 @@ impl Host {
     }
 
     /// Begin the working line, and pick this turn's word for it.
+    /// Put the working line at the end of the transcript, for the conversation on screen.
+    ///
+    /// Says nothing about starting a turn: the turn's own state is the [`Round`], which exists
+    /// whether or not you are looking at it. This is only the line.
     fn begin_working(&mut self) {
-        // Not random: the turn id would be ideal but is not known yet, and a clock read is the one
-        // varying thing already to hand. Per turn, so it does not change under you mid-answer.
-        let verb = VERBS
-            .get(now_secs().unsigned_abs() as usize % VERBS.len())
-            .copied()
-            .unwrap_or("Working");
+        if self.working {
+            return;
+        }
         self.chat_push(vec![String::new()]);
-        self.working = Some(Working { verb, started: std::time::Instant::now(), note: None });
+        self.working = true;
         self.draw_working();
     }
 
@@ -2881,7 +2970,11 @@ impl Host {
     /// here at all — the shimmer is the frontend's, running at its own rate over whatever this
     /// last wrote.
     fn draw_working(&mut self) {
-        let Some(w) = self.working.as_ref() else { return };
+        if !self.working {
+            return;
+        }
+        let here = self.active_session();
+        let Some(w) = self.rounds.get(&here) else { return };
         let (verb, note) = (w.verb, w.note.clone());
         let secs = w.started.elapsed().as_secs();
         let row = self.working_row();
@@ -2894,7 +2987,7 @@ impl Host {
         let label = note.as_deref().unwrap_or(verb);
         let mut text = format!("{glyph} {label}\u{2026}  {elapsed}");
         // What you typed while it was working, and the fact that it has not been said yet.
-        match self.agent.steering_count() {
+        match self.agent.steering_count(&here) {
             0 => {}
             1 => text.push_str("  \u{b7}  1 queued"),
             n => text.push_str(&format!("  \u{b7}  {n} queued")),
@@ -2921,11 +3014,11 @@ impl Host {
     /// Removed rather than blanked: it was never content, and a transcript that accumulates one
     /// empty row per turn is a transcript with a growing hole in it.
     fn end_working(&mut self) {
-        if self.working.is_none() {
+        if !self.working {
             return;
         }
         let row = self.working_row();
-        self.working = None;
+        self.working = false;
         let plugin = PluginId::from(BUILTIN);
         let _ = self.editor.apply(&plugin, ApiCall::MarkClear {
             ns: self.chat_ns,
@@ -2972,23 +3065,45 @@ impl Host {
         });
     }
 
+    /// Route one thing a turn did.
+    ///
+    /// Two jobs, and they are deliberately separate. *Bookkeeping* — what a conversation has said
+    /// so far, whether its turn is still running, what to persist — happens for every event
+    /// whatever is on screen. *Drawing* happens only when the event came from the conversation you
+    /// are looking at. That split is what lets several turns run at once without one of them
+    /// writing into another's transcript.
     fn handle_agent_event(&mut self, ev: AgentEvent) {
+        let on_screen = &self.active_session() == ev.session();
         match ev {
-            AgentEvent::TurnStarted { turn } => {
-                self.bridge.broadcast(PluginEvent::TurnStarted { turn });
+            AgentEvent::TurnStarted { session, turn } => {
+                self.bridge.broadcast(PluginEvent::TurnStarted { session, turn });
             }
-            AgentEvent::Token { turn, text } => {
-                self.answer_text(&text);
-                self.bridge.broadcast(PluginEvent::Token { turn, text });
+            AgentEvent::Token { session, turn, text } => {
+                if let Some(r) = self.rounds.get_mut(&session) {
+                    r.text.push_str(&text);
+                }
+                if on_screen {
+                    self.answer_text(&text);
+                }
+                self.bridge.broadcast(PluginEvent::Token { session, turn, text });
             }
-            AgentEvent::Thinking { turn, text } => {
-                if self.option_bool("chat.show_thinking") {
+            AgentEvent::Thinking { session, turn, text } => {
+                // Not accumulated, for the same reason `transcript` does not replay it: reasoning
+                // is shown live and reprinting it on a switch would bury the answer under the
+                // working out.
+                if on_screen && self.option_bool("chat.show_thinking") {
                     self.stream_into_chat(Stream::Thinking, &text);
                 }
-                self.bridge.broadcast(PluginEvent::ThinkingToken { turn, text });
+                self.bridge.broadcast(PluginEvent::ThinkingToken { session, turn, text });
             }
-            AgentEvent::ToolStarted { turn, call } => {
-                if self.option_bool("chat.show_tools") {
+            AgentEvent::ToolStarted { session, turn, call } => {
+                // The round's assistant message has landed in the conversation by now, so what was
+                // streamed is on record and this copy of it would only go stale.
+                if let Some(r) = self.rounds.get_mut(&session) {
+                    r.text.clear();
+                    r.note = Some(format!("Running {}", call.name));
+                }
+                if on_screen && self.option_bool("chat.show_tools") {
                     let glyph = self.glyphs().tool;
                     let text = format!("  {glyph} {}{}", call.name, tool_subject(&call));
                     let row = self.chat_push(vec![text.clone()]);
@@ -3001,21 +3116,21 @@ impl Host {
                     );
                     // The tool is what the turn is doing now, so the working line should say so
                     // rather than keep claiming the model is thinking.
-                    if let Some(w) = self.working.as_mut() {
-                        w.note = Some(format!("Running {}", call.name));
-                    }
                     self.draw_working();
                 }
-                self.bridge.broadcast(PluginEvent::ToolStarted { turn, call });
+                self.bridge.broadcast(PluginEvent::ToolStarted { session, turn, call });
             }
-            AgentEvent::ToolFinished { turn, call, result } => {
+            AgentEvent::ToolFinished { session, turn, call, result } => {
                 // Every call gets an answer under it, not just the failures. A card that says what
                 // ran and nothing about what came back is a card you have to take on trust, and
                 // "it ran" is not the thing you wanted to know.
                 //
                 // Errors show even with tool cards off: a tool that failed silently is a debugging
                 // session, and the setting is about noise, not about hiding failures.
-                if result.is_error || self.option_bool("chat.show_tools") {
+                if let Some(r) = self.rounds.get_mut(&session) {
+                    r.note = None;
+                }
+                if on_screen && (result.is_error || self.option_bool("chat.show_tools")) {
                     let g = self.glyphs();
                     let glyph = if result.is_error { g.fail } else { g.result };
                     let summary = tool_summary(&result);
@@ -3024,39 +3139,48 @@ impl Host {
                     let hl = if result.is_error { "Agent.ToolError" } else { "Agent.Usage" };
                     self.chat_mark(row, 0, text.len(), hl);
                 }
-                if let Some(w) = self.working.as_mut() {
-                    w.note = None;
+                if on_screen {
+                    self.draw_working();
                 }
-                self.draw_working();
-                self.bridge.broadcast(PluginEvent::ToolFinished { turn, call, result });
+                self.bridge.broadcast(PluginEvent::ToolFinished { session, turn, call, result });
             }
-            AgentEvent::TurnEnded { turn, stop_reason, usage } => {
-                self.close_answer();
-                self.end_working();
+            AgentEvent::TurnEnded { session, turn, stop_reason, usage } => {
+                if on_screen {
+                    self.close_answer();
+                    self.end_working();
+                    self.streaming = None;
+                }
                 // Queued after the last gap this turn had. It is a question that was asked and not
                 // yet answered, so it becomes the next turn rather than being quietly dropped.
-                let leftover = self.agent.take_steering();
-                self.active_turn = None;
-                {
-                    let mut s = self.agent.session();
+                let leftover = self.agent.take_steering(&session);
+                self.turns.remove(&session);
+                self.rounds.remove(&session);
+                if let Some(s) = self.agent.sessions().get_mut(&session) {
                     s.updated_at = now_secs();
                 }
                 self.persist_sessions();
-                self.streaming = None;
-                self.bridge.broadcast(PluginEvent::TurnEnded { turn, stop_reason, usage });
+                self.bridge.broadcast(PluginEvent::TurnEnded {
+                    session: session.clone(),
+                    turn,
+                    stop_reason,
+                    usage,
+                });
                 if !leftover.is_empty() {
-                    self.start_turn(leftover.join("\n"));
+                    self.start_turn_in(session, leftover.join("\n"));
                 }
             }
             AgentEvent::Steered { text, .. } => {
                 // Drawn now rather than when it was typed: until the model has been told, a
                 // transcript showing the question is a transcript that is lying about what was
-                // asked.
-                self.chat_question(&text);
-                self.draw_working();
-                self.refresh_composer();
+                // asked. Off screen it needs no drawing at all — it is in the conversation's
+                // messages, which is what a switch back rebuilds from.
+                if on_screen {
+                    self.chat_question(&text);
+                    self.draw_working();
+                    self.refresh_composer();
+                }
             }
-            AgentEvent::Notice { level, text } => self.editor_message(level, text),
+            AgentEvent::Notice { level, text, .. } => self.editor_message(level, text),
         }
     }
 
@@ -3306,7 +3430,7 @@ impl Host {
                     keys.as_mut().reset(Instant::now() + Duration::from_millis(ms));
                 }
             }
-            if self.working.is_some() && !ticking {
+            if self.working && !ticking {
                 clock.as_mut().reset(Instant::now() + Duration::from_secs(1));
                 ticking = true;
             }
@@ -3656,8 +3780,7 @@ impl Host {
             self.quit_armed = None;
             return;
         }
-        if let Some(t) = self.active_turn.take() {
-            t.cancel();
+        if self.cancel_turn_here() {
             self.quit_armed = None;
             self.editor_message(MessageLevel::Info, "interrupted");
             return;

--- a/crates/neosh/tests/sessions.rs
+++ b/crates/neosh/tests/sessions.rs
@@ -256,6 +256,17 @@ export async function activate({ neosh }: PluginContext) {
       neosh.notify(`switch failed: ${e}`);
     }
   });
+  await neosh.cmd.register("t.other", async () => {
+    const all = await neosh.session.list();
+    const other = all.find((s) => !s.is_active);
+    if (!other) { neosh.notify("nowhere else to go"); return; }
+    try {
+      await neosh.session.switch(other.id);
+      neosh.notify(`switched to ${other.label}`);
+    } catch (e) {
+      neosh.notify(`switch failed: ${e}`);
+    }
+  });
   await neosh.cmd.register("t.list", async () => {
     const all = await neosh.session.list();
     neosh.notify(`sessions: ${all.map((s) => `${s.is_active ? "*" : ""}${s.label}`).join(" | ")}`);
@@ -595,12 +606,9 @@ fn clean_neither_reads_nor_writes_conversations() {
     );
 }
 
-#[test]
-fn switching_while_a_turn_is_running_is_refused_rather_than_interleaved() {
-    // The turn streams into the chat buffer; switching underneath it would put one conversation's
-    // output into another's transcript.
-    let sb = Sandbox::new("busy");
-    install_driver(&sb);
+/// A conversation with a model that says one word and then never finishes, and a second one that
+/// answers straight away. Between them they can prove a turn is a property of a conversation.
+fn install_slow(sb: &Sandbox) {
     let dir = sb.root.join("config/plugins/slow");
     std::fs::create_dir_all(&dir).expect("mkdir");
     std::fs::write(
@@ -613,24 +621,45 @@ fn switching_while_a_turn_is_running_is_refused_rather_than_interleaved() {
         r#"
 import type { PluginContext } from "@neosh/api";
 export async function activate({ neosh }: PluginContext) {
-  // Starts a turn and never finishes it, so the turn is reliably still in flight.
   await neosh.provider.register("slow", [{
     id: "slow", driver: "slow", display_name: "Slow",
-    models: [{ id: "slow", display_name: "Slow" }],
-  }], async (_req, emit) => {
-    emit({ type: "message_start", model: "slow", usage: {} });
+    models: [{ id: "slow", display_name: "Slow" }, { id: "quick", display_name: "Quick" }],
+  }], async (req, emit) => {
+    emit({ type: "message_start", model: req.selection.model, usage: {} });
     emit({ type: "block_start", index: 0, block: { kind: "text" } });
+    if (req.selection.model === "quick") {
+      emit({ type: "text_delta", index: 0, text: "answered right away" });
+      emit({ type: "block_stop", index: 0 });
+      emit({ type: "message_delta", stop_reason: { kind: "end_turn" }, usage: {} });
+      emit({ type: "message_stop" });
+      return;
+    }
+    // Says one word and then never finishes, so the turn is reliably still in flight.
     emit({ type: "text_delta", index: 0, text: "thinking" });
   });
   await neosh.cmd.register("t.useSlow", async () => {
     await neosh.agent.setSelection({ instance: "slow", model: "slow", options: [] });
     neosh.notify("using slow");
   });
+  await neosh.cmd.register("t.useQuick", async () => {
+    await neosh.agent.setSelection({ instance: "slow", model: "quick", options: [] });
+    neosh.notify("using quick");
+  });
   neosh.notify("slow ready");
 }
 "#,
     )
     .expect("plugin");
+}
+
+#[test]
+fn switching_away_from_a_running_turn_leaves_it_running_where_it_belongs() {
+    // Switching used to be refused while a turn ran, to stop one conversation's output landing in
+    // another's transcript. The refusal was the wrong half of the fix: route the output, and
+    // switching is just switching.
+    let sb = Sandbox::new("switch-busy");
+    install_driver(&sb);
+    install_slow(&sb);
 
     let mut s = sb.start();
     s.wait_for("driver ready");
@@ -644,8 +673,74 @@ export async function activate({ neosh }: PluginContext) {
     s.enter();
     s.wait_for("thinking");
 
-    s.command("t.oldest");
-    s.wait_for("a turn is running");
+    s.command("t.other");
+    s.wait_for("switched to");
+    assert!(
+        s.pump(|s| !s.chat_now().iter().any(|l| l.contains("hang please"))),
+        "the other conversation is not asked the question\n{:?}",
+        s.chat_now()
+    );
+    assert!(
+        !s.chat_now().iter().any(|l| l.contains("thinking")),
+        "and does not receive its answer either\n{:?}",
+        s.chat_now()
+    );
+
+    s.command("t.other");
+    assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("thinking"))),
+        "coming back puts you in the middle of the answer, not before it\n{:?}",
+        s.chat_now()
+    );
+    assert!(
+        s.chat_now().iter().any(|l| l.contains("hang please")),
+        "with the question that started it\n{:?}",
+        s.chat_now()
+    );
+}
+
+#[test]
+fn a_second_conversation_answers_while_the_first_is_still_working() {
+    // The point of the whole change: a model that never finishes stops one conversation, not the
+    // workspace.
+    let sb = Sandbox::new("concurrent");
+    install_driver(&sb);
+    install_slow(&sb);
+
+    let mut s = sb.start();
+    s.wait_for("driver ready");
+    s.wait_for("slow ready");
+    s.command("t.new");
+    s.wait_for("created");
+    s.command("t.useSlow");
+    s.wait_for("using slow");
+    s.type_text("hang please");
+    s.enter();
+    s.wait_for("thinking");
+
+    s.command("t.other");
+    s.wait_for("switched to");
+    s.command("t.useQuick");
+    s.wait_for("using quick");
+    s.type_text("and this one?");
+    s.enter();
+    assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("answered right away"))),
+        "the second conversation got its answer with the first still in flight\n{:?}",
+        s.chat_now()
+    );
+
+    s.command("t.other");
+    assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("thinking"))),
+        "and the first is where it was left\n{:?}",
+        s.chat_now()
+    );
+    assert!(
+        !s.chat_now().iter().any(|l| l.contains("answered right away")),
+        "with none of the other one's answer in it\n{:?}",
+        s.chat_now()
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/adr/0000-index.md
+++ b/docs/adr/0000-index.md
@@ -35,3 +35,4 @@ implementation — and in two cases (0005, 0008) it did not, which is itself rec
 | [0027](0027-one-driver-for-every-agent-that-speaks-acp.md) | One driver for every agent that speaks ACP | Accepted |
 | [0028](0028-the-transcript-is-a-place-you-go.md) | The transcript is a place you go, not a pane you focus | Accepted |
 | [0029](0029-a-conversation-carries-its-directory.md) | A conversation carries its directory, and everything follows it | Accepted |
+| [0030](0030-a-turn-belongs-to-a-conversation.md) | A turn belongs to a conversation, not to the program | Accepted |

--- a/docs/adr/0030-a-turn-belongs-to-a-conversation.md
+++ b/docs/adr/0030-a-turn-belongs-to-a-conversation.md
@@ -1,0 +1,92 @@
+# 0030 — A turn belongs to a conversation, not to the program
+
+**Status:** accepted
+
+## Context
+
+Everything about a turn was singular. The host held one `active_turn: Option<CancellationToken>`.
+The agent held one `steering: Vec<String>`. Every read and write inside the turn loop went through
+`self.session()`, which means *the conversation on screen*. `AgentEvent` said which turn an event
+belonged to and never which conversation.
+
+That last omission is what made the rest inevitable. If a `Token` event does not say where it came
+from, the only thing the host can do with it is append it to whatever transcript is open — so a turn
+running in a conversation you are not looking at would write its answer into the one you are. Rather
+than fix the event, we forbade the situation: switching, closing and archiving all returned `Busy`
+while a turn was running, with the message *"a turn is running — interrupt it first"*.
+
+The comment on that check was honest about what it was for:
+
+> The turn writes into the chat buffer as it streams; switching underneath it would interleave one
+> conversation's output into another's transcript.
+
+True, and the wrong conclusion. It made a model that takes four minutes to answer into four minutes
+in which the workspace holds one conversation — you cannot read the thread next to it, cannot start
+the unrelated thing you thought of while waiting, and cannot go and look at yesterday's answer. A
+workspace that runs one thing at a time is a terminal with extra steps, and `neosh` groups
+conversations by project on the assumption that you have several.
+
+It also produced a subtler wrong answer. `PermissionLayer` has one workspace root, moved by
+[ADR 0029](0029-a-conversation-carries-its-directory.md) whenever the active conversation changes.
+With one turn at a time that is exactly right. With two, `src/main.rs` inside a running turn would
+resolve against whichever project you had most recently *looked at*.
+
+## Decision
+
+**A turn is addressed by conversation, at every layer.**
+
+- `Agent::run_turn_in(bridge, session, text, cancel)` is the real entry point. It reaches its
+  conversation by id through `SessionStore::get_mut`, so switching does not move it, and a
+  conversation closed underneath it reads as a cancellation — there is nowhere left to put the
+  answer. `run_turn_with` remains, meaning "in the one on screen".
+- **Every `AgentEvent` variant carries its `SessionId`**, and so do the six `PluginEvent` turn
+  variants. A plugin drawing a transcript has the same problem the host had, and needs the same
+  answer.
+- **Steering lives on the `Session`.** What you type belongs to the conversation you typed it in,
+  not to whichever turn reaches a gap first.
+- **The host keeps a map, not an `Option`**: `turns: HashMap<SessionId, CancellationToken>` and
+  `rounds: HashMap<SessionId, Round>`. `<Esc>` and `^C` cancel the turn of the conversation you are
+  looking at, which is the only one you could have meant.
+- **A turn's permission layer is rooted at its own conversation** — `PermissionLayer::rooted_at` —
+  rather than at the shared root, which follows the screen.
+- **Switching and archiving are never refused. Closing cancels.** Closing is the one case where
+  there is about to be nowhere to put the answer.
+
+The host now separates two jobs that used to be one. *Bookkeeping* — what a conversation has said,
+whether its turn is still running, what to persist — happens for every event whatever is on screen.
+*Drawing* happens only for events from the conversation you are looking at. One `on_screen` boolean
+at the top of `handle_agent_event`, and the interleaving the `Busy` check existed to prevent is
+prevented by construction instead.
+
+## The round that is not in the messages yet
+
+`enter_session` rebuilds the transcript from `session.messages`, deliberately: the messages are the
+truth, and replaying a log of UI edits would drift the moment anything else touched the buffer.
+
+But a round's assistant message only lands in `messages` when its stream closes. Switching into a
+conversation halfway through an answer would therefore show the question, no answer, and then the
+second half of the answer arriving out of nowhere — the failure looks like corruption, not like a
+missing feature.
+
+So the host keeps, per running conversation, the text streamed in the round now in progress, and
+`replay_round` puts it back on entry. It is cleared the moment that round's message lands — which is
+`ToolStarted`, or the end of the turn — because from then on it would be a second copy of something
+already recorded, and a second copy is a copy that can go stale.
+
+Text or the working line, never both, because that is exactly what the live path does: the first
+token takes the working line away. The elapsed clock is per conversation too, so coming back shows
+the time the turn has actually been running rather than restarting at zero.
+
+## Consequences
+
+- Several conversations answer at once. The sidebar already drew this — `◍` and an elapsed clock on
+  any working row, not just the active one — it was simply unreachable.
+- `PluginEvent::Token` and friends gained a field. Additive for a listener that ignores it, and
+  required for one that draws.
+- The steering queue is no longer visible process-wide. `agent.steering_count()` became
+  `agent.steering_count(&session)`, which is a better question anyway.
+- A turn whose conversation is closed is cancelled rather than orphaned. Archiving is not closing
+  and does not stop anything: putting a conversation away is about the list you read, not the work.
+- Nothing here makes *one* conversation run two turns. Sending while one is running is still
+  steering, and still the right answer — a follow-up that starts a second turn has lost the chance
+  to change what the first one does.

--- a/docs/config.md
+++ b/docs/config.md
@@ -460,6 +460,35 @@ Drivers that run their own loop (`claude-cli`, `codex-cli`) have exactly one rou
 so steering them means the message lands as the next turn. That is a property of those CLIs, not a
 setting.
 
+What is queued belongs to the conversation you typed it in. Switch away and it stays there, waiting
+for that turn's next gap.
+
+### Working on more than one thing at once
+
+A turn belongs to its conversation, not to the program. Several run at once, and switching between
+them is never refused — `^T` to move, or `↵` on any row of the project panel, with a model still
+answering behind you.
+
+A conversation that is working says so wherever it appears. In the panel it carries `◍` and the time
+its turn has been running; the one you are in gets the spinner:
+
+```
+ ♥ ▾ neosh                        3
+     ▸ the flaky test in ci     1m 4s
+       ◍ rename the extmark api    22s
+       a question from yesterday   3h
+```
+
+Switching back puts you in the middle of the answer rather than before it: what the turn has already
+said is redrawn, with the elapsed clock still counting from when it started. `Esc` and `^C` interrupt
+the turn of the conversation you are looking at — the only one you could have meant.
+
+Closing a conversation cancels its turn, because there is about to be nowhere to put the answer.
+Archiving does not: putting a conversation away is about the list you read, not about the work.
+
+Sending twice in *one* conversation is still steering rather than a second turn. That is a different
+question, and the answer to it is above.
+
 ### What the agent may do
 
 The footer says what the agent is allowed to do without asking, and `⇧⇥` changes it:

--- a/plugins/api/src/generated/PluginEvent.ts
+++ b/plugins/api/src/generated/PluginEvent.ts
@@ -28,18 +28,20 @@ export type PluginEvent =
     old_end: number;
     new_end: number;
   }
-  | { "type": "turn_started"; turn: TurnId }
-  | { "type": "token"; turn: TurnId; text: string }
-  | { "type": "thinking_token"; turn: TurnId; text: string }
-  | { "type": "tool_started"; turn: TurnId; call: ToolCall }
+  | { "type": "turn_started"; session: SessionId; turn: TurnId }
+  | { "type": "token"; session: SessionId; turn: TurnId; text: string }
+  | { "type": "thinking_token"; session: SessionId; turn: TurnId; text: string }
+  | { "type": "tool_started"; session: SessionId; turn: TurnId; call: ToolCall }
   | {
     "type": "tool_finished";
+    session: SessionId;
     turn: TurnId;
     call: ToolCall;
     result: ToolResult;
   }
   | {
     "type": "turn_ended";
+    session: SessionId;
     turn: TurnId;
     stop_reason: StopReason;
     usage: Usage;

--- a/plugins/api/src/index.ts
+++ b/plugins/api/src/index.ts
@@ -516,11 +516,20 @@ export interface AgentApi {
    * its window — wants this one.
    */
   onSelectionChange(cb: (e: { selection: ModelSelection }) => void): Disposable;
-  onTurnStart(cb: (e: { turn: string }) => void): Disposable;
+  /**
+   * A turn has begun.
+   *
+   * Every turn event says which conversation it belongs to. A workspace runs several at once, so
+   * anything that draws a turn has to check: by the time one ends, the conversation it ran in may
+   * not be the one on screen. `neosh.session.list()` flags the active one.
+   */
+  onTurnStart(cb: (e: { session: string; turn: string }) => void): Disposable;
   /** One streamed chunk of assistant text. Chunks are provider-sized, not characters. */
-  onToken(cb: (e: { turn: string; text: string }) => void): Disposable;
-  onThinking(cb: (e: { turn: string; text: string }) => void): Disposable;
-  onTurnEnd(cb: (e: { turn: string; stopReason: StopReason; usage: Usage }) => void): Disposable;
+  onToken(cb: (e: { session: string; turn: string; text: string }) => void): Disposable;
+  onThinking(cb: (e: { session: string; turn: string; text: string }) => void): Disposable;
+  onTurnEnd(
+    cb: (e: { session: string; turn: string; stopReason: StopReason; usage: Usage }) => void,
+  ): Disposable;
   /**
    * A tool is about to run.
    *
@@ -528,8 +537,10 @@ export interface AgentApi {
    * veto it. This is told that it is happening, cannot influence it, and is therefore what a
    * transcript wants.
    */
-  onToolStart(cb: (e: { turn: string; call: ToolCall }) => void): Disposable;
-  onToolEnd(cb: (e: { turn: string; call: ToolCall; result: ToolResult }) => void): Disposable;
+  onToolStart(cb: (e: { session: string; turn: string; call: ToolCall }) => void): Disposable;
+  onToolEnd(
+    cb: (e: { session: string; turn: string; call: ToolCall; result: ToolResult }) => void,
+  ): Disposable;
 }
 
 export interface ToolApi {
@@ -651,11 +662,19 @@ export interface SessionApi {
    * `cwd` opens it against another checkout, which is how a second project becomes visible.
    */
   create(opts?: { cwd?: string; title?: string; activate?: boolean }): Promise<SessionInfo>;
-  /** Rejects with `busy` while a turn is streaming: its output would land in the wrong transcript. */
+  /**
+   * Look at another conversation.
+   *
+   * Never refused, including while a turn is running. A turn belongs to its conversation and keeps
+   * streaming into it; what you see is rebuilt from whichever one you switched to, and switching
+   * back puts you in the middle of the answer where you left it.
+   */
   switch(session: SessionId): Promise<void>;
   /**
    * Close one. Closing the active conversation moves to the most recently used other; closing the
    * last one is an error, because there is always somewhere for the next thing you type.
+   *
+   * A turn running in it is cancelled: there is about to be nowhere to put its answer.
    */
   close(session: SessionId): Promise<void>;
   /** Pass `null` to clear a title and go back to the first-message label. */
@@ -1237,15 +1256,31 @@ export function __createContext(plugin: string, config: unknown, version: number
         await c({ call: "provider_forget_credential", instance });
       },
       onSelectionChange: (cb) => listener(r.selectionListeners, cb),
-      onTurnStart: (cb) => listener(r.agentListeners.turnStart as Array<(e: { turn: string }) => void>, cb),
-      onToken: (cb) => listener(r.agentListeners.token as Array<(e: { turn: string; text: string }) => void>, cb),
-      onThinking: (cb) => listener(r.agentListeners.thinking as Array<(e: { turn: string; text: string }) => void>, cb),
+      onTurnStart: (cb) =>
+        listener(r.agentListeners.turnStart as Array<(e: { session: string; turn: string }) => void>, cb),
+      onToken: (cb) =>
+        listener(r.agentListeners.token as Array<(e: { session: string; turn: string; text: string }) => void>, cb),
+      onThinking: (cb) =>
+        listener(r.agentListeners.thinking as Array<(e: { session: string; turn: string; text: string }) => void>, cb),
       onTurnEnd: (cb) =>
-        listener(r.agentListeners.turnEnd as Array<(e: { turn: string; stopReason: StopReason; usage: Usage }) => void>, cb),
+        listener(
+          r.agentListeners.turnEnd as Array<
+            (e: { session: string; turn: string; stopReason: StopReason; usage: Usage }) => void
+          >,
+          cb,
+        ),
       onToolStart: (cb) =>
-        listener(r.agentListeners.toolStart as Array<(e: { turn: string; call: ToolCall }) => void>, cb),
+        listener(
+          r.agentListeners.toolStart as Array<(e: { session: string; turn: string; call: ToolCall }) => void>,
+          cb,
+        ),
       onToolEnd: (cb) =>
-        listener(r.agentListeners.toolEnd as Array<(e: { turn: string; call: ToolCall; result: ToolResult }) => void>, cb),
+        listener(
+          r.agentListeners.toolEnd as Array<
+            (e: { session: string; turn: string; call: ToolCall; result: ToolResult }) => void
+          >,
+          cb,
+        ),
     },
     tool: {
       async register(def, handler) {
@@ -1512,25 +1547,38 @@ export async function __dispatch(plugin: string, msg: Record<string, unknown>): 
         break;
       }
       case "turn_started":
-        for (const cb of r.agentListeners.turnStart) (cb as (e: unknown) => void)({ turn: ev.turn });
+        for (const cb of r.agentListeners.turnStart)
+          (cb as (e: unknown) => void)({ session: ev.session, turn: ev.turn });
         break;
       case "token":
-        for (const cb of r.agentListeners.token) (cb as (e: unknown) => void)({ turn: ev.turn, text: ev.text });
+        for (const cb of r.agentListeners.token)
+          (cb as (e: unknown) => void)({ session: ev.session, turn: ev.turn, text: ev.text });
         break;
       case "thinking_token":
-        for (const cb of r.agentListeners.thinking) (cb as (e: unknown) => void)({ turn: ev.turn, text: ev.text });
+        for (const cb of r.agentListeners.thinking)
+          (cb as (e: unknown) => void)({ session: ev.session, turn: ev.turn, text: ev.text });
         break;
       case "turn_ended":
         for (const cb of r.agentListeners.turnEnd)
-          (cb as (e: unknown) => void)({ turn: ev.turn, stopReason: ev.stop_reason, usage: ev.usage });
+          (cb as (e: unknown) => void)({
+            session: ev.session,
+            turn: ev.turn,
+            stopReason: ev.stop_reason,
+            usage: ev.usage,
+          });
         break;
       case "tool_started":
         for (const cb of r.agentListeners.toolStart)
-          (cb as (e: unknown) => void)({ turn: ev.turn, call: ev.call });
+          (cb as (e: unknown) => void)({ session: ev.session, turn: ev.turn, call: ev.call });
         break;
       case "tool_finished":
         for (const cb of r.agentListeners.toolEnd)
-          (cb as (e: unknown) => void)({ turn: ev.turn, call: ev.call, result: ev.result });
+          (cb as (e: unknown) => void)({
+            session: ev.session,
+            turn: ev.turn,
+            call: ev.call,
+            result: ev.result,
+          });
         break;
       case "hook_observed": {
         const h = r.hooks.get(ev.hook);


### PR DESCRIPTION
Switching, closing and archiving a conversation were all refused while a turn was running — *"a turn is running — interrupt it first"*. That turned a model taking four minutes to answer into four minutes in which the workspace held exactly one conversation.

The refusal was the wrong half of the fix. It existed because an `AgentEvent` said which *turn* it came from and never which *conversation*, so the only thing the host could do with a token was append it to whatever transcript was open.

## What changed

- `Agent::run_turn_in(bridge, session, text, cancel)` reaches its conversation by id. Switching does not move it; a conversation closed underneath it reads as a cancellation.
- Every `AgentEvent` variant, and the six `PluginEvent` turn variants, carry their `SessionId`. A plugin drawing a transcript had the same problem the host had.
- Steering lives on the `Session` — what you type belongs to the conversation you typed it in, not to whichever turn reaches a gap first.
- The host keeps `turns: HashMap<SessionId, CancellationToken>` and `rounds: HashMap<SessionId, Round>`. `handle_agent_event` separates bookkeeping (every event) from drawing (only the conversation on screen).
- A turn's permission layer is rooted at its own conversation. With two turns running, `src/main.rs` would otherwise resolve against whichever project you had most recently *looked at*.
- Switching back puts you in the middle of the answer: the transcript is rebuilt from messages, and the round in progress is not in them yet, so the host replays what has been streamed — cleared the moment that round is recorded.
- Closing cancels the turn; archiving does not.

The sidebar already drew concurrent turns — `◍` and an elapsed clock on any working row. It was simply unreachable.

[ADR 0030](docs/adr/0030-a-turn-belongs-to-a-conversation.md).

## Tests

New:
- `a_turn_runs_in_the_conversation_it_names_not_in_whichever_is_on_screen`
- `steering_is_taken_by_the_conversation_it_was_typed_in`
- `switching_away_from_a_running_turn_leaves_it_running_where_it_belongs` — verified to fail with `replay_round` reverted
- `a_second_conversation_answers_while_the_first_is_still_working`

`switching_while_a_turn_is_running_is_refused_rather_than_interleaved` is gone; it asserted the behaviour this removes.

All per-crate suites green, `export_bindings` clean, `tsc --noEmit` clean.