### PR TITLE
feat(ui): composer wraps long prompts; sidebar favourites get a red heart

### DIFF
--- a/crates/neosh-core/src/palette.rs
+++ b/crates/neosh-core/src/palette.rs
@@ -73,6 +73,10 @@ struct Roles {
     plan: Color,
     /// The one hue used for emphasis that is not a state.
     accent: Color,
+    /// The favourite marker. Not a fourth state hue: the heart glyph carries the whole meaning,
+    /// and the world has already decided what colour a heart is — painting it anything else reads
+    /// as a decision the user has to decode.
+    favorite: Color,
 }
 
 const DARK: Roles = Roles {
@@ -87,6 +91,7 @@ const DARK: Roles = Roles {
     success: rgb(0x6e, 0xe7, 0xb7),
     plan: rgb(0xc4, 0xb5, 0xfd),
     accent: rgb(0xa5, 0xb4, 0xfc),
+    favorite: rgb(0xfb, 0x64, 0x7b),
 };
 
 const LIGHT: Roles = Roles {
@@ -101,6 +106,7 @@ const LIGHT: Roles = Roles {
     success: rgb(0x05, 0x96, 0x69),
     plan: rgb(0x7c, 0x3a, 0xed),
     accent: rgb(0x4f, 0x46, 0xe5),
+    favorite: rgb(0xe1, 0x1d, 0x48),
 };
 
 fn fg(c: Color) -> HighlightSpec {
@@ -260,6 +266,7 @@ pub fn groups(variant: Variant) -> Vec<(&'static str, HighlightDef)> {
         ("Sidebar.Heading", link("Title")),
         ("Sidebar.Dim", link("Comment")),
         ("Sidebar.Selected", link("CursorLine")),
+        ("Sidebar.Favorite", spec(fg(r.favorite))),
         ("Status.Line", link("Comment")),
         // ---- the composer -------------------------------------------------
         // The field you type into is chrome, not content: it should read as furniture at the

--- a/crates/neosh-core/tests/key_capture.rs
+++ b/crates/neosh-core/tests/key_capture.rs
@@ -25,7 +25,7 @@ fn setup() -> (Editor, PluginId, WindowId) {
     let mut e = Editor::new();
     let plugin = PluginId::from("picker");
     let buf = e.create_buffer("[picker]");
-    let win = e.open_window(buf, WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start });
+    let win = e.open_window(buf, WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start, wrap: None });
     e.apply(&plugin, ApiCall::CmdRegister { name: "picker.key".into(), desc: None })
         .expect("registers");
     e.apply(&plugin, ApiCall::FocusPush { win }).expect("focuses");
@@ -106,7 +106,7 @@ fn without_a_capture_the_key_is_reported_unhandled_as_before() {
 fn a_capture_only_applies_to_the_focused_window() {
     let (mut e, plugin, win) = setup();
     let other = e.create_buffer("[other]");
-    let other_win = e.open_window(other, WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start });
+    let other_win = e.open_window(other, WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start, wrap: None });
     e.apply(&plugin, ApiCall::KeymapCapture { win, command: "picker.key".into() }).unwrap();
     e.apply(&plugin, ApiCall::FocusPush { win: other_win }).unwrap();
     e.drain_effects();
@@ -217,6 +217,7 @@ fn closing_a_window_takes_the_keys_it_claimed_with_it() {
         dock: neosh_proto::Dock::Bottom,
         size: Some(3),
         gravity: Gravity::Start,
+        wrap: None,
     });
 
     e.apply(&plugin, ApiCall::KeymapSet {

--- a/crates/neosh-proto/src/ui.rs
+++ b/crates/neosh-proto/src/ui.rs
@@ -164,6 +164,13 @@ pub enum WindowLayout {
         /// Which end content settles against when there is not enough of it to fill the window.
         #[serde(default)]
         gravity: Gravity,
+        /// Whether long lines wrap rather than clip. The main dock always wraps; every other dock
+        /// clips unless it says otherwise, because a text field is the only chrome whose content
+        /// is prose. A bottom dock that wraps also grows to fit what wrapped, `size` becoming its
+        /// floor — a field that wraps a long line and then hides the wrapped rows has clipped it
+        /// with extra steps.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        wrap: Option<bool>,
     },
     Float {
         config: FloatConfig,

--- a/crates/neosh-tui/src/mirror.rs
+++ b/crates/neosh-tui/src/mirror.rs
@@ -299,7 +299,7 @@ mod tests {
         m.apply(UiEvent::WindowOpened {
             win: WindowId(1),
             buf: BufferId(1),
-            layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start },
+            layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start, wrap: None },
         });
         let float = |z: i32| WindowLayout::Float {
             config: FloatConfig {
@@ -321,7 +321,7 @@ mod tests {
         m.apply(UiEvent::WindowOpened {
             win: WindowId(1),
             buf: BufferId(1),
-            layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start },
+            layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start, wrap: None },
         });
         m.apply(UiEvent::SurfaceClaimed {
             surface: SurfaceId(1),

--- a/crates/neosh-tui/src/render.rs
+++ b/crates/neosh-tui/src/render.rs
@@ -400,7 +400,29 @@ pub fn resolve_layout_with_rules(
                     if avail == 0 {
                         continue;
                     }
-                    let h = size.unwrap_or(main.height / 4).clamp(1, avail);
+                    let base = size.unwrap_or(main.height / 4);
+                    // A wrapping bottom dock grows to fit what wrapped, its declared size becoming
+                    // a floor: folding a long prompt and then hiding the folded rows would be
+                    // clipping with extra steps. Capped at half of what is left, because the
+                    // transcript above is the thing the prompt is answering.
+                    //
+                    // Counted with a bare theme rather than the live one, so layout does not need
+                    // the styling pipeline threaded through it: colours cannot change how many
+                    // rows a line folds into — only the text and the window's width can.
+                    let h = match mirror.windows.get(&win) {
+                        Some(w) if w.wraps() => {
+                            let rows = rendered_lines(
+                                mirror,
+                                w,
+                                &Theme::new(crate::theme::ColorDepth::Ansi16),
+                                main.width,
+                            )
+                            .len() as u16;
+                            rows.clamp(base, (avail / 2).max(base))
+                        }
+                        _ => base,
+                    };
+                    let h = h.clamp(1, avail);
                     out.push((win, Rect { y: main.y + main.height - h, height: h, ..main }));
                     main = Rect { height: main.height - h, ..main };
                 }
@@ -827,12 +849,17 @@ impl LayoutExt for crate::mirror::MirrorWindow {
 
     /// Prose wraps; everything else clips.
     ///
-    /// Only the main dock. A side panel that wrapped a long path would reflow every row below it, a
-    /// status line that wrapped would eat the screen, and a picker that wrapped would push its own
-    /// last row off the bottom. A float that genuinely wants wrapped prose knows its own width —
-    /// it set it — and can wrap its text before writing it.
+    /// The main dock always, and any dock that asked. By default a side panel clips because a long
+    /// path would reflow every row below it, and a status line clips because wrapping would eat the
+    /// screen — but a text field like the composer is prose, and it opts in with `wrap`. A float
+    /// that genuinely wants wrapped prose knows its own width — it set it — and can wrap its text
+    /// before writing it.
     fn wraps(&self) -> bool {
-        matches!(self.layout, WindowLayout::Docked { dock: Dock::Main, .. })
+        matches!(
+            self.layout,
+            WindowLayout::Docked { dock: Dock::Main, .. }
+                | WindowLayout::Docked { wrap: Some(true), .. }
+        )
     }
 
     /// Whether an over-long buffer shows its end rather than its beginning.

--- a/crates/neosh-tui/tests/rendering.rs
+++ b/crates/neosh-tui/tests/rendering.rs
@@ -180,12 +180,12 @@ fn mirror_with_windows() -> Mirror {
     m.apply(UiEvent::WindowOpened {
         win: WindowId(1),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start, wrap: None },
     });
     m.apply(UiEvent::WindowOpened {
         win: WindowId(2),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Left, size: Some(20), gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Left, size: Some(20), gravity: Gravity::Start, wrap: None },
     });
     m
 }
@@ -215,7 +215,7 @@ fn a_side_dock_is_separated_from_what_is_beside_it() {
     m.apply(UiEvent::WindowOpened {
         win: WindowId(1),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Left, size: Some(8), gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Left, size: Some(8), gravity: Gravity::Start, wrap: None },
     });
     m.apply(UiEvent::BufferOpened { buf: BufferId(2), name: "main".into() });
     m.apply(UiEvent::BufferLines {
@@ -227,7 +227,7 @@ fn a_side_dock_is_separated_from_what_is_beside_it() {
     m.apply(UiEvent::WindowOpened {
         win: WindowId(2),
         buf: BufferId(2),
-        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start, wrap: None },
     });
 
     let cells = cells_of(&m, 20, 3);
@@ -244,12 +244,12 @@ fn the_rule_is_the_first_thing_given_up_when_space_runs_out() {
     m.apply(UiEvent::WindowOpened {
         win: WindowId(1),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Left, size: Some(9), gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Left, size: Some(9), gravity: Gravity::Start, wrap: None },
     });
     m.apply(UiEvent::WindowOpened {
         win: WindowId(2),
         buf: BufferId(2),
-        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start, wrap: None },
     });
     let rects = resolve_layout(&m, Rect::new(0, 0, 10, 4));
     let left = rects.iter().find(|(w, _)| *w == WindowId(1)).unwrap().1;
@@ -436,7 +436,7 @@ fn a_float_draws_over_its_dock() {
     m.apply(UiEvent::WindowOpened {
         win: WindowId(1),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start, wrap: None },
     });
     m.apply(UiEvent::BufferOpened { buf: BufferId(2), name: "float".into() });
     m.apply(UiEvent::BufferLines {
@@ -484,13 +484,13 @@ fn docked_mirror(bottom: &[(u32, Option<u16>)]) -> Mirror {
     m.apply(UiEvent::WindowOpened {
         win: WindowId(1),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start, wrap: None },
     });
     for (id, size) in bottom {
         m.apply(UiEvent::WindowOpened {
             win: WindowId(*id),
             buf: BufferId(1),
-            layout: WindowLayout::Docked { dock: Dock::Bottom, size: *size, gravity: Gravity::Start },
+            layout: WindowLayout::Docked { dock: Dock::Bottom, size: *size, gravity: Gravity::Start, wrap: None },
         });
     }
     m
@@ -585,7 +585,7 @@ fn main_window_with(lines: Vec<&str>) -> Mirror {
     m.apply(UiEvent::WindowOpened {
         win: WindowId(1),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start, wrap: None },
     });
     m
 }
@@ -779,12 +779,12 @@ fn a_side_panel_clips_instead_of_wrapping() {
     m.apply(UiEvent::WindowOpened {
         win: WindowId(1),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Left, size: Some(20), gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Left, size: Some(20), gravity: Gravity::Start, wrap: None },
     });
     m.apply(UiEvent::WindowOpened {
         win: WindowId(2),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start, wrap: None },
     });
     let rows = rows_of(&m, 60, 5);
     assert!(rows[1].starts_with("second row"), "row two is still row two: {rows:?}");
@@ -803,7 +803,7 @@ fn the_caret_lands_where_typing_goes() {
     m.apply(UiEvent::WindowOpened {
         win: WindowId(1),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Bottom, size: Some(1), gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Bottom, size: Some(1), gravity: Gravity::Start, wrap: None },
     });
     m.apply(UiEvent::CursorMoved { win: WindowId(1), row: 0, col: 5 });
 
@@ -829,7 +829,7 @@ fn the_caret_measures_columns_not_bytes() {
     m.apply(UiEvent::WindowOpened {
         win: WindowId(1),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Bottom, size: Some(1), gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Bottom, size: Some(1), gravity: Gravity::Start, wrap: None },
     });
     // Three bytes for 日, one for x: byte offset 4 is the end of the line, screen column 3.
     m.apply(UiEvent::CursorMoved { win: WindowId(1), row: 0, col: 4 });
@@ -854,7 +854,7 @@ fn a_focused_float_takes_the_caret() {
     m.apply(UiEvent::WindowOpened {
         win: WindowId(1),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Bottom, size: Some(1), gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Bottom, size: Some(1), gravity: Gravity::Start, wrap: None },
     });
     m.apply(UiEvent::BufferOpened { buf: BufferId(2), name: "prompt".into() });
     m.apply(UiEvent::BufferLines {
@@ -918,7 +918,7 @@ fn right_aligned_virtual_text_sits_against_the_window_edge() {
     m.apply(UiEvent::WindowOpened {
         win: WindowId(1),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start, wrap: None },
     });
     let rows = rows_of(&m, 20, 3);
     assert_eq!(rows[0], "a thread          2m", "flush right on a 20-wide pane: {rows:?}");
@@ -939,7 +939,7 @@ fn right_alignment_measures_columns_not_bytes() {
     m.apply(UiEvent::WindowOpened {
         win: WindowId(1),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start, wrap: None },
     });
     // Read cells rather than the joined string: the backend pads a wide glyph with a blank
     // continuation cell, so counting characters would measure the harness, not the layout.
@@ -962,7 +962,7 @@ fn right_aligned_text_that_does_not_fit_follows_the_line_instead_of_overflowing(
     m.apply(UiEvent::WindowOpened {
         win: WindowId(1),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start, wrap: None },
     });
     let rows = rows_of(&m, 20, 4);
     assert!(rows.join("").contains("status"), "the annotation is still shown: {rows:?}");
@@ -984,7 +984,7 @@ fn a_row_can_carry_both_a_right_aligned_and_a_trailing_annotation() {
     m.apply(UiEvent::WindowOpened {
         win: WindowId(1),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start, wrap: None },
     });
     // The grammar: `Eol` means "after the text", `Right` means "at the edge". Both fit on one row.
     let rows = rows_of(&m, 20, 3);
@@ -1080,7 +1080,7 @@ fn the_caret_moves_past_chrome_drawn_in_front_of_it() {
     m.apply(UiEvent::WindowOpened {
         win: WindowId(1),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Bottom, size: Some(1), gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Bottom, size: Some(1), gravity: Gravity::Start, wrap: None },
     });
     m.apply(UiEvent::CursorMoved { win: WindowId(1), row: 0, col: 2 });
 
@@ -1104,7 +1104,7 @@ fn a_line_drawn_above_the_first_row_pushes_the_caret_down() {
     m.apply(UiEvent::WindowOpened {
         win: WindowId(1),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Bottom, size: Some(2), gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Bottom, size: Some(2), gravity: Gravity::Start, wrap: None },
     });
     m.apply(UiEvent::CursorMoved { win: WindowId(1), row: 0, col: 2 });
 
@@ -1130,7 +1130,7 @@ fn short_content_settles_against_the_end_when_told_to() {
     m.apply(UiEvent::WindowOpened {
         win: WindowId(1),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::End },
+        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::End, wrap: None },
     });
 
     let mut terminal = Terminal::new(TestBackend::new(10, 5)).unwrap();
@@ -1157,7 +1157,7 @@ fn the_default_gravity_leaves_content_where_it_has_always_been() {
     m.apply(UiEvent::WindowOpened {
         win: WindowId(1),
         buf: BufferId(1),
-        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start },
+        layout: WindowLayout::Docked { dock: Dock::Main, size: None, gravity: Gravity::Start, wrap: None },
     });
 
     let mut terminal = Terminal::new(TestBackend::new(10, 4)).unwrap();

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -398,20 +398,22 @@ impl Host {
                 // the eye has to travel the whole window between what was said and where you say
                 // the next thing.
                 gravity: Gravity::End,
+                wrap: None,
             });
 
         // Docked before the composer, so it takes the bottom-most row and the composer sits above
         // it. Without a status line the startup screen renders literally nothing — two empty
         // buffers — and "it opened an empty terminal" is indistinguishable from "it crashed".
         let status = editor.create_buffer("[status]");
-        editor.open_window(status, WindowLayout::Docked { dock: Dock::Bottom, size: Some(1), gravity: Gravity::Start });
+        editor.open_window(status, WindowLayout::Docked { dock: Dock::Bottom, size: Some(1), gravity: Gravity::Start, wrap: None });
 
         let composer = editor.create_buffer("[composer]");
-        // Four rows: a rule, up to three lines of what you are writing, and the shortcut row that
-        // lives on the last of them as a virtual line. The rule is what makes the composer read as
-        // a field rather than as the last paragraph of the transcript.
+        // Four rows at rest: a rule, up to three lines of what you are writing, and the shortcut
+        // row that lives on the last of them as a virtual line. The rule is what makes the composer
+        // read as a field rather than as the last paragraph of the transcript. `wrap` is what makes
+        // a long prompt fold and the window grow to show it, instead of running off the right edge.
         let composer_win =
-            editor.open_window(composer, WindowLayout::Docked { dock: Dock::Bottom, size: Some(4), gravity: Gravity::Start });
+            editor.open_window(composer, WindowLayout::Docked { dock: Dock::Bottom, size: Some(4), gravity: Gravity::Start, wrap: Some(true) });
         editor.set_mode(Mode::Chat);
 
         let mut namespace = |name: &str| {

--- a/plugins/api/src/generated/WindowLayout.ts
+++ b/plugins/api/src/generated/WindowLayout.ts
@@ -17,4 +17,12 @@ export type WindowLayout = {
    * Which end content settles against when there is not enough of it to fill the window.
    */
   gravity: Gravity;
+  /**
+   * Whether long lines wrap rather than clip. The main dock always wraps; every other dock
+   * clips unless it says otherwise, because a text field is the only chrome whose content
+   * is prose. A bottom dock that wraps also grows to fit what wrapped, `size` becoming its
+   * floor — a field that wraps a long line and then hides the wrapped rows has clipped it
+   * with extra steps.
+   */
+  wrap?: boolean | null;
 } | { "kind": "float"; config: FloatConfig };

--- a/plugins/api/src/index.ts
+++ b/plugins/api/src/index.ts
@@ -353,11 +353,16 @@ export interface WindowApi {
    * `gravity` is which end short content settles against: `"start"` (the default) pins it to the
    * top, `"end"` to the bottom, which is what makes a transcript read as a conversation rather
    * than as a document that happens to be in a window.
+   *
+   * `wrap` makes long lines fold rather than clip. Docks clip by default — a side panel that
+   * wrapped a long path would reflow every row below it — but a text field is prose and wants
+   * this on. A bottom dock that wraps also grows to show the folded rows, `size` acting as its
+   * floor.
    */
   open(
     buf: BufferId,
     dock: Dock,
-    opts?: { size?: number; gravity?: Gravity },
+    opts?: { size?: number; gravity?: Gravity; wrap?: boolean },
   ): Promise<WindowId>;
   close(win: WindowId): Promise<void>;
   setBuf(win: WindowId, buf: BufferId): Promise<void>;
@@ -1081,6 +1086,7 @@ export function __createContext(plugin: string, config: unknown, version: number
           dock,
           size: opts?.size ?? null,
           gravity: opts?.gravity ?? "start",
+          wrap: opts?.wrap ?? null,
         };
         return expect(await c({ call: "win_open", buf, layout }), "win").win;
       },

--- a/plugins/api/src/ui.ts
+++ b/plugins/api/src/ui.ts
@@ -1108,6 +1108,12 @@ export interface ListRow<T = unknown> {
   text: string;
   /** Highlight group for the whole row. Link to one the theme defines. */
   hl?: string;
+  /**
+   * Highlights for pieces of the row, over the top of `hl`: a favourite marker, a state glyph, a
+   * matched substring. `from`/`to` are UTF-8 byte offsets into `text` — the same unit every column
+   * on the wire uses — so build them with {@link byteLength} rather than `.length`.
+   */
+  spans?: Array<{ from: number; to: number; hl: string }>;
   /** Flush-right status: a timestamp, a count, a state word. */
   right?: { text: string; hl?: string };
   /** Rows that cannot be landed on: headings, separators, blanks. */
@@ -1234,6 +1240,16 @@ export class CursoredList<T = unknown> {
       }
       if (row.hl && eol > 0) {
         await this.neosh.ns.mark(this.ns, this.buf, i, 0, { hlGroup: row.hl, endCol: eol });
+      }
+      // Above the row's own highlight, below the cursor's 200: a marker keeps its colour on an
+      // ordinary row and yields to the selection, which is the row the eye is already on.
+      for (const s of row.spans ?? []) {
+        if (s.to <= s.from || s.from >= eol) continue;
+        await this.neosh.ns.mark(this.ns, this.buf, i, s.from, {
+          hlGroup: s.hl,
+          endCol: Math.min(s.to, eol),
+          priority: 100,
+        });
       }
       if (row.right) {
         await this.neosh.ns.mark(this.ns, this.buf, i, 0, {

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -20,6 +20,7 @@
  * off, and a sidebar of your own loads after this one and wins.
  */
 
+import { byteLength } from "@neosh/api";
 import type { Disposable, Neosh, PluginContext, SessionInfo, WindowId, WorktreeInfo } from "@neosh/api";
 import {
   confirmDestructive,
@@ -952,12 +953,14 @@ function projectRow(
       : { text: "" };
 
   // The heart sits before the fold arrow rather than after the name: it is what you scan the
-  // column for, and a marker at the ragged right edge is not a column.
+  // column for, and a marker at the ragged right edge is not a column. It gets its own highlight
+  // because a heart is red — a grey one reads as a heart that has stopped.
   const heart = p.favorite ? (opts.ascii ? "*" : "♥") : " ";
 
   return {
     text: ` ${heart} ${arrow} ${clip(p.name, opts.width - 8)}`,
     hl: here ? "Directory" : "Sidebar.Dim",
+    spans: p.favorite ? [{ from: 1, to: 1 + byteLength(heart), hl: "Sidebar.Favorite" }] : undefined,
     right,
     value: { kind: "project", cwd: p.cwd },
   };


### PR DESCRIPTION
## What

Two visible fixes, both shipped on the public API rather than a private hatch.

### Long prompts now wrap in the composer
The frontend only wrapped the main (chat) dock; the composer is a bottom dock, so a long prompt clipped at the right edge and disappeared.

- `WindowLayout::Docked` gains a `wrap` field (`neosh-proto`, TS bindings regenerated, exposed through `neosh.win.open` as `wrap?: boolean`).
- The TUI honours it, and a wrapping bottom dock **grows to fit** the folded rows — its declared `size` becomes a floor, capped at half the remaining height so the transcript keeps the screen.
- The host opens the composer with `wrap: true`.

### Red heart for sidebar favourites
The ♥ inherited the row's grey.

- New `Sidebar.Favorite` palette group, themed for dark (`#fb647b`) and light (`#e11d48`).
- `ListRow` in `@neosh/api/ui` gains `spans` — per-segment highlights, byte-offset convention, priority above the row highlight and below the cursor — so any plugin list can colour a glyph or substring.
- The sidebar marks the heart with it.

## Verification

- `cargo test -p neosh-core`, `-p neosh-tui`, `-p neosh-proto export_bindings`: pass; generated diff is the intentional `wrap` field.
- `tsc --noEmit` clean in `plugins/api` and `plugins/builtin`.
- `builtin_plugins`: 96 pass; the 2 failures (`a_turn_runs_in_the_project…`, `switching_conversations…`) fail identically on a clean checkout — pre-existing macOS `/var` vs `/private/var` canonicalisation issue, not touched here.
- Driven under a pty with `scripts/shot.py`: a 200-char prompt folds across 4 rows, the composer grows 4→6 rows, the caret lands exactly after the last typed character, and the heart cell's foreground reads back as `fb647b`.