### PR TITLE
Ask the terminal for the keys it can actually send

### DIFF
--- a/crates/neosh-tui/src/terminal.rs
+++ b/crates/neosh-tui/src/terminal.rs
@@ -8,7 +8,8 @@ use std::io::{self, Stdout};
 
 use crossterm::event::{
     DisableBracketedPaste, EnableBracketedPaste, Event, KeyCode as CtCode, KeyEvent,
-    KeyEventKind, KeyModifiers,
+    KeyEventKind, KeyModifiers, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
+    PushKeyboardEnhancementFlags,
 };
 use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode};
 use crossterm::{execute, ExecutableCommand};
@@ -81,6 +82,43 @@ pub fn to_input_event(ev: Event) -> Option<InputEvent> {
 pub struct TerminalFrontend {
     terminal: Terminal<CrosstermBackend<Stdout>>,
     theme: Theme,
+    /// Whether the keyboard enhancement flags were pushed, and therefore have to be popped.
+    ///
+    /// Kept rather than re-asked on the way out: `supports_keyboard_enhancement` queries the
+    /// terminal and waits for a reply, and doing that while tearing down — possibly on a panic
+    /// path, possibly after the terminal has gone away — is how an exit hangs.
+    enhanced: bool,
+}
+
+/// Ask the terminal for unambiguous keys, if it knows how.
+///
+/// Without this, three things are impossible rather than merely awkward. `Cmd`/`Super` never
+/// arrives at all, so a `<D-…>` binding is accepted, listed, shown in the footer and never fires.
+/// `Ctrl` with anything that is not a letter collapses onto the C0 control it shares a byte with —
+/// `Ctrl+/` is indistinguishable from `Ctrl+7`, which is why neither is a key anybody can usefully
+/// bind. And `Esc` is ambiguous with the start of an escape sequence, which is what makes a
+/// terminal wait before deciding you pressed it.
+///
+/// Failure is not an error. Most terminals do not implement this, `execute` on an unsupported
+/// sequence is a no-op there, and the answer is simply the keyboard everyone has always had.
+fn enable_enhanced_keys(stdout: &mut Stdout) -> bool {
+    // An environment variable rather than an option, because this runs before there is any config:
+    // the terminal has to be in the right mode before the first keystroke, and config arrives from
+    // a plugin runtime that has not started yet. It exists because "my terminal claims to support
+    // this and is wrong about it" is a thing that happens, and the symptom — every key arriving
+    // twice, or `Esc` never arriving — is one you cannot fix from inside a program you cannot type
+    // into.
+    if std::env::var_os("NEOSH_NO_ENHANCED_KEYS").is_some() {
+        return false;
+    }
+    if !matches!(crossterm::terminal::supports_keyboard_enhancement(), Ok(true)) {
+        return false;
+    }
+    // Deliberately not `REPORT_EVENT_TYPES`: it adds key-release events, which this frontend
+    // discards, so the only thing it would buy is twice the input to throw half of away.
+    let flags = KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+        | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS;
+    execute!(stdout, PushKeyboardEnhancementFlags(flags)).is_ok()
 }
 
 impl TerminalFrontend {
@@ -89,8 +127,9 @@ impl TerminalFrontend {
         enable_raw_mode()?;
         let mut stdout = io::stdout();
         execute!(stdout, EnterAlternateScreen, EnableBracketedPaste)?;
+        let enhanced = enable_enhanced_keys(&mut stdout);
         let terminal = Terminal::new(CrosstermBackend::new(stdout))?;
-        Ok(Self { terminal, theme: Theme::new(ColorDepth::detect()) })
+        Ok(Self { terminal, theme: Theme::new(ColorDepth::detect()), enhanced })
     }
 
     pub fn size(&self) -> io::Result<(u16, u16)> {
@@ -164,6 +203,12 @@ impl TerminalFrontend {
     /// type `reset`.
     pub fn leave(&mut self) -> io::Result<()> {
         disable_raw_mode()?;
+        // Before leaving the alternate screen, and only if we pushed: popping a stack we never
+        // pushed to would take away whatever the *shell* had set, and a terminal left in enhanced
+        // mode after neosh exits is a shell where `Esc` behaves differently than it did.
+        if self.enhanced {
+            let _ = self.terminal.backend_mut().execute(PopKeyboardEnhancementFlags);
+        }
         self.terminal.backend_mut().execute(DisableBracketedPaste)?;
         self.terminal.backend_mut().execute(LeaveAlternateScreen)?;
         self.terminal.show_cursor()?;

--- a/crates/neosh-tui/tests/attaching.rs
+++ b/crates/neosh-tui/tests/attaching.rs
@@ -23,11 +23,11 @@ fn a_workspace() -> (Editor, BufferId, neosh_proto::WindowId) {
     let mut e = Editor::new();
     let p = plugin();
 
-    let chat = match e.apply(&p, ApiCall::BufCreate { name: Some("[chat]".into()), scratch: true }) {
+    let chat = match e.apply(&p, ApiCall::BufCreate { name: Some("[chat]".into()), scratch: true, kind: None }) {
         Ok(neosh_proto::ApiOk::Buf { buf }) => buf,
         other => panic!("{other:?}"),
     };
-    let composer = match e.apply(&p, ApiCall::BufCreate { name: Some("[composer]".into()), scratch: true })
+    let composer = match e.apply(&p, ApiCall::BufCreate { name: Some("[composer]".into()), scratch: true, kind: None })
     {
         Ok(neosh_proto::ApiOk::Buf { buf }) => buf,
         other => panic!("{other:?}"),

--- a/docs/config.md
+++ b/docs/config.md
@@ -274,6 +274,46 @@ a string, so rebinding `ui.keys.*` changes what the strip says rather than makin
 
 `AGENTS.md` at the root of the repository has the whole key table in one place.
 
+### Your terminal decides which keys it can send
+
+A key neosh never receives is a key no amount of rebinding will fix, and two of the defaults are in
+that position on a Mac out of the box. Neither is a neosh setting — both are your terminal's.
+
+**`F1` needs `fn` on macOS.** Apple's top row controls brightness and volume by default, so `F1`
+dims the screen and `fn`+`F1` is what reaches an application. Either press `fn`+`F1`, or turn on
+*System Settings → Keyboard → Keyboard Shortcuts → Function Keys → Use F1, F2, etc. as standard
+function keys*. Everything `F1` shows is also in `^K`, which needs no such arrangement.
+
+**`⌥↑` / `⌥↓` need Option-as-Alt.** macOS treats Option as a compose key — `⌥p` is `π`, not
+`Alt+p` — so a terminal has to be told to send it as a modifier instead:
+
+| Terminal | Setting |
+|---|---|
+| Terminal.app | Settings → Profiles → Keyboard → *Use Option as Meta key* |
+| iTerm2 | Settings → Profiles → Keys → Left Option key → *Esc+* |
+| Ghostty | `macos-option-as-alt = left` |
+| Alacritty | `option_as_alt = "Left"` |
+| kitty | `macos_option_as_alt left` |
+
+Setting the *left* Option key only, where that is offered, keeps the right one for typing `£` and
+`—`.
+
+**Enhanced keys, where the terminal has them.** On startup neosh asks the terminal for the
+[Kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) — supported by kitty,
+Ghostty, WezTerm, foot, rio, Alacritty, iTerm2 and Windows Terminal — and quietly does without on
+terminals that lack it. It buys three things that are otherwise impossible rather than awkward:
+
+- **`⌘` arrives at all.** Without it `Super` is never sent, so a `<D-k>` binding is accepted,
+  listed, shown in the footer and never fires.
+- **`Ctrl` with punctuation is distinguishable.** In a plain terminal `Ctrl+/` and `Ctrl+7` are the
+  same byte, which is why neither is a key worth binding.
+- **`Esc` is unambiguous**, so nothing waits to find out whether more of a sequence is coming.
+
+`NEOSH_NO_ENHANCED_KEYS=1` turns the request off. It is an environment variable rather than an
+option because the terminal has to be in the right mode before the first keystroke, which is before
+there is any config — and because the symptom of a terminal that answers this question wrongly is
+one you cannot fix from inside a program you can no longer type into.
+
 ### Adding a project
 
 `^O` anywhere, `o` in the project panel, or `Enter` on the `+ Add project` row. It offers the

--- a/scripts/shot.py
+++ b/scripts/shot.py
@@ -29,11 +29,16 @@ def encode(tok: str) -> str:
     name = tok[1:-1].lower()
     if name in NAMED:
         return NAMED[name]
-    if name.startswith("c-") and len(name) == 3:
+    if name.startswith("c-") and len(name) == 3 and name[2].isalpha():
         return chr(ord(name[2].upper()) - 64)
     if name.startswith("a-"):
         rest = name[2:]
         return "\x1b" + (NAMED.get(rest, rest))
+    # Raw bytes, as hex: <raw:1b5b313b3341>. The escape hatch for keys whose encoding is the
+    # question — a control character no name covers, or the sequence one particular terminal sends
+    # for a chord. Without it, "does neosh see Ctrl+/" is unanswerable except by pressing it.
+    if name.startswith("raw:"):
+        return bytes.fromhex(name[4:]).decode("latin-1")
     raise SystemExit(f"unknown key {tok}")
 
 def desc(key):


### PR DESCRIPTION
Three documented bindings could not fire, and one could not fire anywhere.

## Findings

Measured by feeding real terminal byte sequences through a pty (`shot.py` grew a `<raw:HEX>` token for this — without it "does neosh see Ctrl+/" is unanswerable except by pressing it):

| Sent | neosh saw | |
|---|---|---|
| `1b4f50` (`F1`) | opens the key list | works — but macOS sends brightness unless you hold `fn` |
| `1f` (`Ctrl+/`) | `Ctrl+7` | same byte; neither is bindable |
| `1d` (`Ctrl+]`) | `Ctrl+5` | same |
| `1b5b3130373b3975` (`Cmd+k`, CSI-u) | `Cmd+k` | parses correctly — but nothing ever sends it |

That last row is the bug: `<D-…>` bindings are accepted, listed by `F1`, shown in the footer, and dead, because `Super` only arrives under the Kitty keyboard protocol and neosh never pushed the flags.

## Change

Push `DISAMBIGUATE_ESCAPE_CODES | REPORT_ALTERNATE_KEYS` when the terminal says it supports them, pop on exit, no-op otherwise. `REPORT_EVENT_TYPES` is deliberately excluded — this frontend discards key releases, so it would only double the input.

`NEOSH_NO_ENHANCED_KEYS=1` opts out. Env var rather than option: the terminal must be in the right mode before the first keystroke, which is before there is any config, and a terminal that answers the support query wrongly leaves you unable to type into the program that would fix it.

The two macOS defaults (`F1`, `⌥↑`/`⌥↓`) are the OS and the terminal declining to send the key, not neosh mishandling it. Documented per terminal in `config.md` — Terminal.app, iTerm2, Ghostty, Alacritty, kitty — rather than papered over with a second default nobody asked for.

## Also

`crates/neosh-tui/tests/attaching.rs` was left uncompilable by `BufCreate` growing a `kind` in #10 — my sweep there ran the crates per the project's own instructions and never ran `-p neosh-tui`. Fixed, and every crate's tests compile now.

## Verification

`neosh-tui` 88/88. Panel focus and keys re-checked under a pty with the flags on. Per-crate test compilation green for `neosh-proto`, `neosh-core`, `neosh-tui`, `neosh-script`.