### PR TITLE
feat(chat): a card says what happened, and a mode's keys are its own

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,12 @@ per decision, and records the *reasoning*, not the choice.
   per turn, and never one per driver — several conversations run at once, and a driver holding a
   single session id resumes the second into the first one's history. (ACP is the exception and says
   why: its session lives on the agent's side.)
+- **What a driver calls a conversation is the conversation's, not the process's.** A vendor CLI
+  keeps the history and hands back a handle; a driver that only remembers it in memory remembers it
+  until the workspace stops, and then reopening a conversation starts an agent that has never heard
+  of it — full transcript, empty model, and nothing on either side that reports it. It travels as
+  `Activity::Resume`, is kept in `Session::resume`, and comes back as `TurnRequest::resume`. See ADR
+  0039.
 - **The workspace is a process; the terminal is a viewer of it.** `neosh` attaches to the workspace
   for your config directory, starting one if there is none. Closing a terminal detaches — turns keep
   running. `neosh stop` is what ends a workspace, and `^Q` must never be able to. `UiEvent` is a
@@ -108,8 +114,18 @@ per decision, and records the *reasoning*, not the choice.
   you can filter — because a flat list of dim rows is not a way to find anything. See ADR 0039.
 - **A card is a row until you ask for more.** A call that only *looked* at something folds to its
   header with the size of what came back on the end of it; a command keeps its output, an edit keeps
-  its diff, and a failure always shows. A turn that read six files should read as six rows. See ADR
-  0033.
+  its diff, and a failure always shows. See ADR 0033.
+- **A run of calls that only looked at things is one row**, naming as many of them as fit and
+  counting the rest — a turn that read six files reads as one. A run is calls with *nothing drawn
+  between them*, asked the same way by the live path and the replay, or switching away and back
+  re-folds the conversation. Only a mark that is news gets drawn: `▸` while a call is out, `✗` if it
+  failed, and nothing at all when it worked. See ADR 0040.
+- **A card says what happened, not which tool did it.** `Ran cargo test`, not `Bash cargo test` —
+  read off the arguments, like the colour. A call nothing here classifies keeps the name its author
+  gave it, so a plugin's tool is never renamed. **A command's output folds from the middle**: the
+  head is how it started and the tail is what it decided, and it is the second one you were waiting
+  for. And **one row of air between actions**, which is the cheapest structure there is. See ADR
+  0040.
 - **Redrawing a row means clearing its marks first.** A mark clamps rather than dies when the line
   under it is replaced, and at equal priority the *narrower* one wins — so a row rewritten every
   tick accumulates marks and ends up painted by the shortest one from several seconds ago.
@@ -167,7 +183,7 @@ registry — this table is what ships.
 |---|---|
 | `⏎` | Send. While a turn is running, **steer** it: the message is held and taken in at the next gap. |
 | `⇧⏎` | Newline, so a pasted snippet stays one message |
-| `⇧↑` | Take the last thing you queued back into the composer, to change it or drop it |
+| `^Y` | Take the last thing you queued back into the composer, to change it or drop it. Readline's yank: `^U`/`^W` kill, `^Y` brings it back |
 | `^P` | Pick a model. Mid-turn too — the running agent is told, and thinks the rest with it |
 | `^E` | Reasoning effort and the other per-model options |
 | `⌥↑` `⌥↓` | One rung up or down the capability ladder, same provider |
@@ -197,6 +213,20 @@ back to the start of the line.
 ## Reading the transcript — `^S`
 
 The answer is the artefact; this is how you get a piece of it out. See ADR 0028.
+
+**A mode's keys are the mode's keys.** `^S` puts the editor in `Normal`, so `chat`'s bindings —
+the ones that compose a message — stop firing and these get their keys back. Only four things are
+bound in every mode, and they are the escape hatches: `^C`, `^Q`, `^R`, `^S`. Everything that acts
+on the composer or scrolls without the cursor is `Chat` alone. A plugin that wants a key here binds
+it in `normal`.
+
+Two corollaries, both of which were bugs:
+
+- **A chord is not the letter it is made of.** Chords are matched before the plain keys, and a
+  chord this mode does not define does nothing at all. `^B` used to move a word left, `^A` used to
+  put you back in the composer.
+- **A key another mode claimed never arrives.** Reading's keys come through the *unbound* path,
+  which is the last thing consulted — so `^D` was whatever the git plugin bound it to.
 
 | Key | Does |
 |---|---|

--- a/crates/neosh-agent/src/agent.rs
+++ b/crates/neosh-agent/src/agent.rs
@@ -351,6 +351,8 @@ impl Agent {
             // has nothing to keep.
             conversation: SessionId::from(""),
             cwd: self.session().cwd.clone(),
+            // Nobody's conversation, so there is nothing to pick up and nothing to leave behind.
+            resume: None,
             system,
             messages: vec![Message {
                 role: Role::User,
@@ -546,9 +548,9 @@ impl Agent {
 
             // One guard, not two: temporaries in a struct literal live to the end of the
             // statement, so taking the session lock twice here would deadlock against itself.
-            let Some((cwd, system, messages)) =
-                self.with(&session, |s| (s.cwd.clone(), s.system.clone(), s.messages.clone()))
-            else {
+            let Some((cwd, system, messages, resume)) = self.with(&session, |s| {
+                (s.cwd.clone(), s.system.clone(), s.messages.clone(), s.resume.clone())
+            }) else {
                 // Closed while its own turn was running. There is nowhere to put the answer, so
                 // this is a cancellation rather than an error to report into a transcript that no
                 // longer exists.
@@ -559,6 +561,9 @@ impl Agent {
                 selection: selection.clone(),
                 conversation: session.clone(),
                 cwd: cwd.clone(),
+                // What this driver called the conversation last time it ran one, which is the only
+                // thing standing between reopening it and an agent that has forgotten it.
+                resume,
                 system,
                 messages,
                 // An agent driver brings its own tools; advertising ours would list tools it

--- a/crates/neosh-agent/src/session.rs
+++ b/crates/neosh-agent/src/session.rs
@@ -49,6 +49,11 @@ pub struct Session {
     /// has chosen one here and the configured default applies, which is what makes changing that
     /// default in `config.toml` reach every conversation that has not overridden it.
     pub permission_mode: Option<PermissionMode>,
+    /// What the driver calls this conversation, kept so a later process can pick it up.
+    ///
+    /// See [`neosh_proto::TurnRequest::resume`]. Held here rather than in the driver because the
+    /// driver is a process and this is not: the whole point of the value is that it survives one.
+    pub resume: Option<String>,
 }
 
 impl Session {
@@ -71,6 +76,7 @@ impl Session {
             archived: false,
             archived_at: None,
             permission_mode: None,
+            resume: None,
         }
     }
 

--- a/crates/neosh-core/src/palette.rs
+++ b/crates/neosh-core/src/palette.rs
@@ -284,11 +284,11 @@ pub fn groups(variant: Variant) -> Vec<(&'static str, HighlightDef)> {
         ("Agent.Tool", spec(fg(r.active))),
         ("Agent.ToolError", spec(bold(fg(r.danger)))),
         ("Agent.Usage", spec(dim(fg(r.muted)))),
-        // The dot beside a tool call, which is the only place in the transcript that says whether
-        // something is still happening. Pulsing while it runs and settling into a colour when it is
-        // over: a call that stopped moving is a call you can stop watching.
+        // The mark beside a tool call, which appears only when the state is news: while the call
+        // is out, and if it failed. Pulsing while it runs, because a card that stopped moving is a
+        // card you can stop watching — and there is deliberately no group for one that finished,
+        // since a finished call is drawn with no mark at all.
         ("Agent.ToolRunning", spec(pulse(fg(r.attention), 2600))),
-        ("Agent.ToolDone", spec(fg(r.success))),
         ("Agent.ToolFailed", spec(bold(fg(r.danger)))),
         // The subject of a call that has not come back: the command, the path, the query. A sweep
         // rather than the dot's pulse, because this is a *run* of text — a band travelling along
@@ -443,7 +443,11 @@ pub fn groups(variant: Variant) -> Vec<(&'static str, HighlightDef)> {
         ("Composer.Prompt", spec(bold(fg(r.accent)))),
         ("Composer.Placeholder", link("NonText")),
         ("Composer.Hint", link("Comment")),
-        ("Composer.HintKey", spec(fg(r.muted))),
+        // The same group the welcome screen's keys wear, and for the same reason: `Composer.Hint`
+        // is `Comment`, so a key one dim-step brighter than the words around it is a key nobody
+        // sees. `\u{21e7}\u{2191} edit` sat at the end of a queued message and read as the end of the
+        // sentence.
+        ("Composer.HintKey", link("Key")),
         // ---- provider marks -----------------------------------------------
         // One group per vendor, so a provider rail is legible at a glance and a theme can restyle
         // the lot. These are the *only* groups tied to something outside neosh, which is why they
@@ -528,7 +532,6 @@ mod tests {
         let names: BTreeSet<_> = contract().into_iter().collect();
         for required in [
             "Agent.ToolRunning",
-            "Agent.ToolDone",
             "Agent.ToolFailed",
             "Agent.ToolLive",
             "Agent.ToolRead",

--- a/crates/neosh-proto/src/provider.rs
+++ b/crates/neosh-proto/src/provider.rs
@@ -593,6 +593,22 @@ pub struct TurnRequest {
     #[serde(default)]
     #[ts(type = "string")]
     pub cwd: std::path::PathBuf,
+    /// What the driver called this conversation last time, if it named it.
+    ///
+    /// A vendor CLI keeps the history on its side and hands back a handle — `claude`'s session id,
+    /// ACP's session, `codex`'s conversation. A driver that only remembers that handle in its own
+    /// process remembers it exactly as long as the workspace lives: restart, reopen a conversation
+    /// with a hundred messages in it, and the agent is started fresh and told only the newest one.
+    /// The transcript looks full and the model has never heard of any of it, which is not a thing
+    /// either side reports as an error — it is simply an agent that has forgotten, and the first
+    /// visible sign of it is `/compact` finishing instantly with nothing to compact.
+    ///
+    /// So the handle belongs to the conversation, which is the thing that outlives the process.
+    /// The driver hands it over with [`Activity::Resume`] and is given it back here. `None` means
+    /// this conversation has never been run by this driver, which is the only case where starting
+    /// fresh is right.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resume: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub system: Option<String>,
     pub messages: Vec<Message>,
@@ -726,6 +742,13 @@ pub enum Activity {
     },
     /// What this driver accepts as a slash command, learned at handshake.
     Commands { commands: Vec<DriverCommand> },
+    /// The driver's own name for this conversation, which it wants back next time.
+    ///
+    /// Said whenever it changes, which for a vendor CLI is on the first line of the first turn a
+    /// process produces. The receiver's job is to *keep* it: see [`TurnRequest::resume`] for what
+    /// forgetting it costs. It is an account of the driver's loop rather than a content block, and
+    /// like everything else here `TurnAssembler` never reads it.
+    Resume { token: String },
     /// How full the context window is, as of now.
     Context {
         #[ts(type = "number")]

--- a/crates/neosh-provider/src/drivers/acp.rs
+++ b/crates/neosh-provider/src/drivers/acp.rs
@@ -1264,6 +1264,7 @@ mod tests {
             extra_headers: vec![],
         };
         let req = TurnRequest {
+            resume: None,
             conversation: neosh_proto::SessionId::from("test"),
             cwd: std::path::PathBuf::new(),
             selection: ModelSelection {

--- a/crates/neosh-provider/src/drivers/anthropic.rs
+++ b/crates/neosh-provider/src/drivers/anthropic.rs
@@ -289,6 +289,7 @@ mod tests {
 
     fn request(options: Vec<OptionSelection>) -> TurnRequest {
         TurnRequest {
+            resume: None,
             conversation: neosh_proto::SessionId::from("test"),
             cwd: std::path::PathBuf::new(),
             selection: ModelSelection {

--- a/crates/neosh-provider/src/drivers/claude_cli.rs
+++ b/crates/neosh-provider/src/drivers/claude_cli.rs
@@ -429,9 +429,19 @@ impl Provider for ClaudeCliProvider {
             // Held for the whole turn. Two turns in one conversation share one process and one
             // stdin, so running them at once would interleave two answers down one pipe.
             let mut guard = slot.live.lock().await;
-            let turn = Turn { request, mode, asker };
-            if let Err(message) =
-                run_turn(&program, &slot, &mut guard, turn, cancel, &tx).await
+            let mut turn = Turn { request, mode, asker };
+            // Retried exactly once, and only for the one failure a retry can fix: the conversation
+            // this driver was told to pick up is not there any more — the CLI's own history was
+            // cleared, or the project directory moved out from under it. Starting fresh loses what
+            // the agent remembered, which is already lost; reporting it instead would fail a turn
+            // over a stale value neither side can do anything about.
+            let mut result = run_turn(&program, &slot, &mut guard, turn.clone(), cancel.clone(), &tx).await;
+            if matches!(result, Ok(Outcome::Stale)) {
+                *guard = None;
+                turn.request.resume = None;
+                result = run_turn(&program, &slot, &mut guard, turn, cancel, &tx).await;
+            }
+            if let Err(message) = result
             {
                 // A turn that failed for a reason the process cannot recover from leaves nothing
                 // worth keeping: the next one starts a fresh CLI rather than writing into a pipe
@@ -449,10 +459,20 @@ impl Provider for ClaudeCliProvider {
 ///
 /// A struct rather than three more arguments: they are the parts of one question and they travel
 /// together everywhere.
+#[derive(Clone)]
 struct Turn {
     request: TurnRequest,
     mode: PermissionMode,
     asker: Option<Arc<dyn PermissionAsker>>,
+}
+
+/// How a turn ended, for the one caller that can do something about it.
+enum Outcome {
+    /// The turn ran. Whatever the CLI made of it is already in the stream.
+    Done,
+    /// It never started: the conversation this driver was asked to resume is gone. Nothing has
+    /// been forwarded, so the caller may simply try again without it.
+    Stale,
 }
 
 /// One turn, on a CLI that is either already running or about to be.
@@ -466,7 +486,7 @@ async fn run_turn(
     turn: Turn,
     cancel: CancellationToken,
     tx: &mpsc::Sender<ProviderEvent>,
-) -> Result<(), String> {
+) -> Result<Outcome, String> {
     let Turn { request, mode, asker } = turn;
     // Only offered when somebody can answer it. Passing the flag with nobody behind it would route
     // every decision to a pipe nothing ever writes to, and the turn would hang instead of being
@@ -477,6 +497,10 @@ async fn run_turn(
 
     // The one thing a running session cannot be talked out of. Everything else below is a control
     // request on the process that is already there.
+    // Whether this process is being started on a handle that outlived a workspace, which is the
+    // only kind that can be stale: one taken from a process this one is replacing was valid a
+    // moment ago.
+    let mut borrowed = false;
     if slot.as_ref().is_none_or(|live| live.launched != launch) {
         let resume = match slot.take() {
             Some(live) => {
@@ -484,7 +508,12 @@ async fn run_turn(
                 live.close().await;
                 id
             }
-            None => None,
+            // Nothing is running for this conversation, which after a restart is every
+            // conversation. What the driver called it last time is the whole of its memory.
+            None => {
+                borrowed = request.resume.is_some();
+                request.resume.clone()
+            }
         };
         *slot = Some(Live::spawn(program, &launch, &model, resume.as_deref()).await?);
     }
@@ -569,7 +598,7 @@ async fn run_turn(
                 if interrupted {
                     let _ = live.child.start_kill();
                     *slot = None;
-                    return Ok(());
+                    return Ok(Outcome::Done);
                 }
                 break;
             }
@@ -584,17 +613,32 @@ async fn run_turn(
                             retryable: false,
                         }).await;
                         *slot = None;
-                        return Ok(());
+                        return Ok(Outcome::Done);
                     }
                 };
                 let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) else {
                     continue; // non-JSON chatter on stdout is not fatal
                 };
-                // Every line carries it, and it is what a replacement process resumes into.
-                if live.session.is_none()
-                    && let Some(id) = v.get("session_id").and_then(|s| s.as_str())
+                // The CLI declined to pick up where it left off. Nothing has been forwarded and
+                // the turn has not begun, so this is not a failure to report — it is a token to
+                // throw away, said to the caller who is holding it.
+                if borrowed && stale_resume(&v) {
+                    return Ok(Outcome::Stale);
+                }
+                // Every line carries it, and it is what a replacement process resumes into — this
+                // one, and, once it has been said out loud, one started a week from now. Compared
+                // rather than set once: resuming does not always keep the id it was given, and a
+                // conversation stored under the id the CLI has stopped using is one that resumes
+                // into a history missing everything since.
+                if let Some(id) = v.get("session_id").and_then(|s| s.as_str()).filter(|s| !s.is_empty())
+                    && live.session.as_deref() != Some(id)
                 {
                     live.session = Some(id.to_string());
+                    let _ = tx
+                        .send(ProviderEvent::Activity {
+                            activity: Activity::Resume { token: id.to_string() },
+                        })
+                        .await;
                 }
                 // A question, which the CLI is now blocked on. Answered inline: the turn genuinely
                 // is waiting on a person, and the transcript's spinner says so.
@@ -636,7 +680,7 @@ async fn run_turn(
                         // The receiver is gone: the turn was abandoned. The process is not — it
                         // holds the conversation, and there is every chance the next turn is about
                         // to ask it something.
-                        return Ok(());
+                        return Ok(Outcome::Done);
                     }
                 }
                 // The turn is over, and the process is not. Before letting it go back to waiting,
@@ -692,7 +736,26 @@ async fn run_turn(
             })
             .await;
     }
-    Ok(())
+    Ok(Outcome::Done)
+}
+
+/// The CLI refusing to resume a conversation it no longer has.
+///
+/// It says so in the ordinary way — a `result` line with `is_error` — which is also how it reports
+/// every other failure, so the sentence is what tells them apart. Matched loosely on purpose: this
+/// only decides whether to try once more without the handle, and being wrong in either direction
+/// costs a turn that starts fresh instead of one that fails.
+fn stale_resume(v: &Value) -> bool {
+    if v.get("type").and_then(Value::as_str) != Some("result")
+        || v.get("is_error").and_then(Value::as_bool) != Some(true)
+    {
+        return false;
+    }
+    let gone = |s: &str| s.contains("No conversation found");
+    v.get("errors")
+        .and_then(Value::as_array)
+        .is_some_and(|e| e.iter().filter_map(Value::as_str).any(gone))
+        || v.get("result").and_then(Value::as_str).is_some_and(gone)
 }
 
 /// How full the CLI says its context is.
@@ -907,6 +970,7 @@ mod tests {
 
     fn req(model: &str) -> TurnRequest {
         TurnRequest {
+            resume: None,
             conversation: neosh_proto::SessionId::from("test"),
             cwd: std::path::PathBuf::new(),
             selection: ModelSelection {

--- a/crates/neosh-provider/src/drivers/codex_cli.rs
+++ b/crates/neosh-provider/src/drivers/codex_cli.rs
@@ -1435,6 +1435,7 @@ mod tests {
         let p = CodexCliProvider::new("definitely-not-a-real-binary-xyzzy");
         assert!(!p.available());
         let req = TurnRequest {
+            resume: None,
             conversation: SessionId::from("test"),
             cwd: std::path::PathBuf::new(),
             selection: ModelSelection {

--- a/crates/neosh-provider/src/drivers/google.rs
+++ b/crates/neosh-provider/src/drivers/google.rs
@@ -256,6 +256,7 @@ mod tests {
 
     fn req(msgs: Vec<Message>) -> TurnRequest {
         TurnRequest {
+            resume: None,
             conversation: neosh_proto::SessionId::from("test"),
             cwd: std::path::PathBuf::new(),
             selection: ModelSelection {

--- a/crates/neosh-provider/src/drivers/mock.rs
+++ b/crates/neosh-provider/src/drivers/mock.rs
@@ -151,6 +151,7 @@ mod tests {
 
     fn req() -> TurnRequest {
         TurnRequest {
+            resume: None,
             conversation: neosh_proto::SessionId::from("test"),
             cwd: std::path::PathBuf::new(),
             selection: ModelSelection {

--- a/crates/neosh-provider/src/drivers/openai.rs
+++ b/crates/neosh-provider/src/drivers/openai.rs
@@ -360,6 +360,7 @@ mod tests {
     #[test]
     fn usage_reporting_is_requested_explicitly() {
         let r = TurnRequest {
+            resume: None,
             conversation: neosh_proto::SessionId::from("test"),
             cwd: std::path::PathBuf::new(),
             selection: ModelSelection {

--- a/crates/neosh-provider/src/sse.rs
+++ b/crates/neosh-provider/src/sse.rs
@@ -192,11 +192,24 @@ pub fn claude_cli_line(v: &Value, state: &mut ClaudeState) -> Vec<ProviderEvent>
             out
         }
         // Whole assistant messages, which `stream_event` has already said everything about — with
-        // one exception. A tool call arrives here with its arguments *complete*, where the stream
+        // two exceptions. A tool call arrives here with its arguments *complete*, where the stream
         // delivers them as JSON fragments that are only parsed at block close. The plan is read out
         // of ordinary tool calls, so this is the copy that can be read without reassembling
         // anything.
-        "assistant" => state.plan.saw_calls(v.get("message").unwrap_or(&Value::Null)),
+        //
+        // The other is a message the CLI wrote itself. `<synthetic>` is its own marker for a
+        // sentence no model produced — the answer to a slash command it handled locally, a refusal,
+        // an explanation of why it did nothing — and those never stream, because there was no
+        // request to stream. Dropping them is how `/compact` on a conversation with nothing to
+        // compact arrived as a question with a blank under it: the CLI said *Error: No messages to
+        // compact*, on this line and nowhere else, and the `result` line that usually rescues an
+        // unsaid turn carried an empty string.
+        "assistant" => {
+            let message = v.get("message").unwrap_or(&Value::Null);
+            let mut out = state.plan.saw_calls(message);
+            out.extend(synthetic_text(message, state));
+            out
+        }
         "system" => system_line(v, state),
         // A `result` with is_error signals the CLI itself failed (auth, spawn, quota).
         "result" if v.get("is_error").and_then(Value::as_bool) == Some(true) => {
@@ -232,6 +245,48 @@ pub fn claude_cli_line(v: &Value, state: &mut ClaudeState) -> Vec<ProviderEvent>
         }
         _ => Vec::new(),
     }
+}
+
+/// The text of a message the CLI wrote itself, as the message it never streamed.
+///
+/// Only for `<synthetic>`, which is the CLI's own word for it. Reading text off *every* whole
+/// assistant message would say each ordinary answer twice, once as it arrived and again when the
+/// message it was assembled from turned up.
+///
+/// `said` is set for the same reason the streamed path sets it: some of these are repeated on the
+/// `result` line, and the fallback there exists to rescue a turn that said nothing — not to say
+/// this one a second time.
+fn synthetic_text(message: &Value, state: &mut ClaudeState) -> Vec<ProviderEvent> {
+    if message.get("model").and_then(Value::as_str) != Some("<synthetic>") {
+        return Vec::new();
+    }
+    let text = message
+        .get("content")
+        .and_then(Value::as_array)
+        .map(|blocks| {
+            blocks
+                .iter()
+                .filter(|b| b.get("type").and_then(Value::as_str) == Some("text"))
+                .filter_map(|b| b.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("")
+        })
+        .unwrap_or_default();
+    let text = text.trim();
+    if text.is_empty() {
+        return Vec::new();
+    }
+    state.said = true;
+    // A message of its own, for the reason the `result` fallback opens one: block indices are
+    // unique only within a message, so a bare block 0 lands on top of whatever block 0 the last
+    // message had.
+    vec![
+        ProviderEvent::MessageStart { model: None, usage: Usage::default() },
+        ProviderEvent::BlockStart { index: 0, block: BlockStartKind::Text },
+        ProviderEvent::TextDelta { index: 0, text: text.to_string() },
+        ProviderEvent::BlockStop { index: 0 },
+        ProviderEvent::MessageStop,
+    ]
 }
 
 /// What reading the CLI's stream needs to remember between lines.
@@ -974,6 +1029,63 @@ mod tests {
         assert_eq!(plans[0].len(), 3);
         assert_eq!(plans[0][1].state, PlanState::Active);
         assert_eq!(plans[1].len(), 1, "the newest call is the plan, not an addition to it");
+    }
+
+    /// Recorded from a real `claude --print --input-format stream-json` run: `/compact` on a
+    /// conversation with nothing in it yet. The sentence exists once, on the `assistant` line, and
+    /// the `result` that usually rescues a turn that said nothing carries an empty string.
+    #[test]
+    fn a_sentence_the_cli_wrote_itself_is_said_rather_than_dropped() {
+        let events = cli(&[
+            r#"{"type":"assistant","message":{"id":"6e7aacf5","model":"<synthetic>","role":"assistant","stop_reason":"end_turn","type":"message","content":[{"type":"text","text":"Error: No messages to compact"}]},"parent_tool_use_id":null,"session_id":"s"}"#,
+            r#"{"type":"result","subtype":"success","is_error":false,"num_turns":0,"result":"","session_id":"s"}"#,
+        ]);
+        let text: String = events
+            .iter()
+            .filter_map(|e| match e {
+                ProviderEvent::TextDelta { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            text, "Error: No messages to compact",
+            "without this the turn is a question with a blank under it"
+        );
+    }
+
+    /// The same sentence on both lines, which is the other way the CLI reports one of these.
+    #[test]
+    fn a_sentence_the_cli_repeats_on_the_result_line_is_still_said_once() {
+        let events = cli(&[
+            r#"{"type":"assistant","message":{"model":"<synthetic>","role":"assistant","type":"message","content":[{"type":"text","text":"Not enough messages to compact."}]},"session_id":"s"}"#,
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"Not enough messages to compact.","session_id":"s"}"#,
+        ]);
+        let texts: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                ProviderEvent::TextDelta { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(texts, vec!["Not enough messages to compact."]);
+    }
+
+    /// The guard that keeps the above from saying every ordinary answer twice.
+    #[test]
+    fn a_streamed_answer_is_not_repeated_by_the_message_it_came_from() {
+        let events = cli(&[
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"1, 2, 3"}},"session_id":"s"}"#,
+            r#"{"type":"assistant","message":{"model":"claude-opus-5","role":"assistant","type":"message","content":[{"type":"text","text":"1, 2, 3"}]},"session_id":"s"}"#,
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"1, 2, 3","session_id":"s"}"#,
+        ]);
+        let texts: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                ProviderEvent::TextDelta { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(texts, vec!["1, 2, 3"], "said as it arrived, and not again afterwards");
     }
 
     #[test]

--- a/crates/neosh-provider/tests/codex_app_server.rs
+++ b/crates/neosh-provider/tests/codex_app_server.rs
@@ -123,6 +123,7 @@ fn inst() -> InstanceConfig {
 
 fn req(dir: &std::path::Path) -> TurnRequest {
     TurnRequest {
+        resume: None,
         conversation: SessionId::from("c1"),
         cwd: dir.to_path_buf(),
         selection: ModelSelection {

--- a/crates/neosh/src/cards.rs
+++ b/crates/neosh/src/cards.rs
@@ -66,10 +66,17 @@ impl Row {
 pub struct Glyphs {
     /// The bar down the left of a question.
     pub bar: &'static str,
-    /// The state of a tool call: one dot, which changes colour rather than shape. Shape says
-    /// *what*, colour says *how it went* — a glyph that changes to mean "finished" makes the
-    /// column impossible to scan.
-    pub dot: &'static str,
+    /// The mark on a call that has not come back. It sweeps, because that is the one thing about
+    /// a running call worth watching, and it is the only card in the column that moves.
+    pub live: &'static str,
+    /// The mark on a call that failed.
+    ///
+    /// There is deliberately no mark for one that *worked*. A glyph beside every row of a column
+    /// is a glyph the eye stops reading by the third card — it was the widest thing on a card that
+    /// is otherwise one line, and it said "this happened", which is what a card being there
+    /// already says. What is news is a call still out and a call that went wrong, so those are the
+    /// two that get a mark and finished ones get the blank of the same width.
+    pub fail: &'static str,
     /// The rule down the left of what a tool came back with.
     ///
     /// A rule and not an elbow. An elbow marks where a body *starts*, which is the one thing a
@@ -80,6 +87,8 @@ pub struct Glyphs {
     pub rule: &'static str,
     /// Unchanged lines a diff is not showing.
     pub fold: &'static str,
+    /// The mark on the row that stands in for what is not being shown.
+    pub elision: &'static str,
     /// The join between two edits to the same file in one call.
     pub between: &'static str,
     /// The working line's mark.
@@ -99,9 +108,11 @@ impl Glyphs {
         if ascii {
             Self {
                 bar: "|",
-                dot: "*",
+                live: ">",
+                fail: "x",
                 rule: "|",
                 fold: ":",
+                elision: "...",
                 between: "...",
                 work: "*",
                 tab: "Tab",
@@ -113,9 +124,11 @@ impl Glyphs {
         } else {
             Self {
                 bar: "\u{258c}",
-                dot: "\u{23fa}",
+                live: "\u{25b8}",
+                fail: "\u{2717}",
                 rule: "\u{2502}",
                 fold: "\u{22ee}",
+                elision: "\u{2026}",
                 between: "\u{22ef}",
                 work: "\u{2733}",
                 tab: "\u{21e5}",
@@ -133,6 +146,18 @@ impl Glyphs {
     fn margin(&self) -> String {
         format!("  {} ", self.rule)
     }
+
+    /// The two columns a card's header opens with: a mark, when the state is news, and a space.
+    ///
+    /// Always two columns wide, so the names line up down the column whatever each card is doing,
+    /// and so the rule under a card sits directly beneath the name it belongs to.
+    fn mark(&self, state: ToolState) -> (&'static str, &'static str) {
+        match state {
+            ToolState::Running => (self.live, "Agent.ToolRunning"),
+            ToolState::Failed => (self.fail, "Agent.ToolFailed"),
+            ToolState::Done => (" ", "Agent.Usage"),
+        }
+    }
 }
 
 /// How a tool call is going, which is the only thing the dot beside it says.
@@ -141,16 +166,6 @@ pub enum ToolState {
     Running,
     Done,
     Failed,
-}
-
-impl ToolState {
-    pub fn hl(self) -> &'static str {
-        match self {
-            Self::Running => "Agent.ToolRunning",
-            Self::Done => "Agent.ToolDone",
-            Self::Failed => "Agent.ToolFailed",
-        }
-    }
 }
 
 /// How much of a body to show before it folds.
@@ -374,6 +389,49 @@ pub struct Head<'a> {
     pub output: Option<usize>,
 }
 
+/// What the call *did*, in a word, when its arguments say plainly enough.
+///
+/// `Ran cargo test` rather than `Bash cargo test`. The card is an account of what happened, and a
+/// tool name is the mechanism it happened through — which is a fact about the wire and not about
+/// the work. A column of `Bash`, `Agent`, `Grep`, `WebFetch` asks the reader to know what each of
+/// those *is* before it says anything; a column of `Ran`, `Searched`, `Read`, `Fetched` is a list
+/// of things that were done.
+///
+/// `None` for a call this cannot classify, and then the tool's own name stands. That is ADR 0033's
+/// rule and the part of it that was load-bearing: nothing here invents a friendlier word for a
+/// tool it does not understand, and a plugin's `frobnicate` is called `frobnicate` for ever. What
+/// changed is only that a call whose arguments *do* say what it did gets to say it — read off
+/// those arguments, in the same pass and by the same rule as [`Kind::of`] reads the colour.
+pub fn did(input: &serde_json::Value) -> Option<&'static str> {
+    let map = input.as_object()?;
+    // Edits first, exactly as `Kind::of` orders them: a write is `content` and a path, which
+    // would otherwise read as a read.
+    if !edits_of(input).is_empty() {
+        // A write has no "before". `Wrote` and `Edited` are different enough to be worth telling
+        // apart — one of them replaced a file you may not have read.
+        let overwrote = map.contains_key("content")
+            && !["old_string", "old_text", "oldText", "edits", "diff", "changes"]
+                .iter()
+                .any(|k| map.contains_key(*k));
+        return Some(if overwrote { "Wrote" } else { "Edited" });
+    }
+    if map.contains_key("command") {
+        return Some("Ran");
+    }
+    if map.contains_key("url") {
+        return Some("Fetched");
+    }
+    // Told apart by which argument the call is *about*, the same question [`subject`] answers:
+    // `Read fn header` is not what a grep did.
+    if map.contains_key("pattern") || map.contains_key("query") {
+        return Some("Searched");
+    }
+    if PATH_KEYS.iter().any(|k| map.contains_key(*k)) {
+        return Some("Read");
+    }
+    None
+}
+
 /// Whether a call is one that *looked at* something rather than changing it.
 ///
 /// The rule that decides how much room its card gets. A read, a grep, a listing: the answer to
@@ -429,12 +487,21 @@ pub fn exit_code(content: &str) -> Option<i64> {
     digits.parse().ok()
 }
 
-/// The header line of a tool card: a state dot, the tool's name, what it is about, and a tail of
-/// whatever else is known — what an edit changed, what a command exited with, how long it took.
+/// The header line of a tool card: what state it is in when that is news, the tool's name, what it
+/// is about, and a tail of whatever else is known — what an edit changed, what a command exited
+/// with, how long it took.
 ///
-/// `⏺ Edit  src/main.rs  +3 -1  0.1s`. One line however large the arguments are — a card that
+/// `  Edit  src/main.rs  +3 -1  0.1s`. One line however large the arguments are — a card that
 /// grows with its input buries the answer it was gathered for, and the arguments are in the
 /// conversation anyway.
+///
+/// **A finished call carries no mark.** It used to open with a filled circle, in a colour that
+/// said how it went, and a turn that read six files was six identical circles down the left of six
+/// rows. A mark on every row is a mark that answers a question nobody asked twice: the card being
+/// there is already the claim that the call happened. So the column holds a mark only while the
+/// call is out — where it sweeps, and is then the one moving thing in the transcript — or when the
+/// call failed. Otherwise it is two blanks of the same width, which keeps the names in a column
+/// and puts the body's rule directly under the name it belongs to.
 ///
 /// The subject sits after the name with a gap, rather than inside brackets. `Edit(src/main.rs)`
 /// reads as a function call, which is what it is on the wire and not what it is on screen: what
@@ -453,6 +520,23 @@ pub fn exit_code(content: &str) -> Option<i64> {
 /// The stats appear only on a call that finished well: a failed edit changed nothing, and a
 /// running one has not changed anything yet.
 pub fn header(g: &Glyphs, head: &Head, root: &std::path::Path, width: usize) -> Row {
+    let (mark, mark_hl) = g.mark(head.state);
+    let lead = mark.chars().count() + 1;
+    let (rest, spans) = label(head, root, width.saturating_sub(lead));
+    let mut text = format!("{mark} ");
+    let at = text.len();
+    text.push_str(&rest);
+    let mut all = vec![(0, mark.len(), mark_hl)];
+    all.extend(spans.into_iter().map(|(a, b, hl)| (at + a, at + b, hl)));
+    Row::new(text, all)
+}
+
+/// A header without its mark: the name, the subject, and the tail.
+///
+/// Split out because three things draw it — a card of its own, a row inside an opened group, and
+/// nothing else may ever disagree with either about what a call is called or how much room its
+/// subject gets.
+fn label(head: &Head, root: &std::path::Path, width: usize) -> (String, Vec<Span>) {
     let stats = match head.state {
         ToolState::Done => Stats::of(&edits_of(head.input)),
         _ => Stats::default(),
@@ -487,28 +571,22 @@ pub fn header(g: &Glyphs, head: &Head, root: &std::path::Path, width: usize) -> 
         .map(|g| 2 + g.iter().map(|(t, _)| t.chars().count()).sum::<usize>() + g.len() - 1)
         .sum();
 
-    let name = head.name;
-    // What is left for the subject once the dot, the name, the gap and the tail have had their
-    // share.
-    let fixed = g.dot.chars().count() + 1 + name.chars().count() + 2 + tail_width;
+    let name = did(head.input).unwrap_or(head.name);
+    // What is left for the subject once the name, the gap and the tail have had their share.
+    let fixed = name.chars().count() + 2 + tail_width;
     let room = width.saturating_sub(fixed).max(8);
     let subject = subject_of(head.input, root, room);
-    let mut text = if subject.is_empty() {
-        format!("{} {name}", g.dot)
-    } else {
-        format!("{} {name}  {subject}", g.dot)
-    };
-    let after_dot = g.dot.len();
-    let name_end = after_dot + 1 + name.len();
-    let mut spans: Vec<Span> =
-        vec![(0, after_dot, head.state.hl()), (after_dot, name_end, Kind::of(head.input).hl())];
-    // The subject is the part that moves. A band travelling along the command you are waiting on
-    // is the difference between "still going" and "wedged", and on a card with no body yet it is
-    // the only thing that could say which. It settles the moment the call lands.
-    if name_end < text.len() {
-        let hl =
-            if head.state == ToolState::Running { "Agent.ToolLive" } else { "Agent.Usage" };
-        spans.push((name_end, text.len(), hl));
+    let mut text = name.to_string();
+    let mut spans: Vec<Span> = vec![(0, name.len(), Kind::of(head.input).hl())];
+    if !subject.is_empty() {
+        text.push_str("  ");
+        let from = text.len();
+        text.push_str(&subject);
+        // The subject is the part that moves. A band travelling along the command you are waiting
+        // on is the difference between "still going" and "wedged", and on a card with no body yet
+        // it is the only thing that could say which. It settles the moment the call lands.
+        let hl = if head.state == ToolState::Running { "Agent.ToolLive" } else { "Agent.Usage" };
+        spans.push((from, text.len(), hl));
     }
     for group in tail {
         text.push_str("  ");
@@ -521,7 +599,146 @@ pub fn header(g: &Glyphs, head: &Head, root: &std::path::Path, width: usize) -> 
             spans.push((from, text.len(), hl));
         }
     }
+    (text, spans)
+}
+
+// ---------------------------------------------------------------------------
+// A run of calls that only looked at things
+// ---------------------------------------------------------------------------
+
+/// What a run of read-only calls is called, once there is more than one of them.
+///
+/// Their own name when they all share one — the rule everywhere else here is that a tool is called
+/// whatever it calls itself, and three `Read`s are still reads. `Explored` only for a mixture,
+/// where there is no one name that would be true.
+fn verb<'a>(heads: &'a [Head<'a>], live: bool) -> &'a str {
+    let said = |h: &'a Head<'a>| did(h.input).unwrap_or(h.name);
+    match heads {
+        [] => "",
+        [one] => said(one),
+        _ if heads.iter().all(|h| said(h) == said(&heads[0])) => said(&heads[0]),
+        _ if live => "Exploring",
+        _ => "Explored",
+    }
+}
+
+/// The one row a run of read-only calls folds to.
+///
+/// ```text
+///   Read  host.rs, cards.rs, diff.rs, +2 more
+/// ▸ Exploring  host.rs, cards.rs, diff.rs
+/// ```
+///
+/// A turn that reads six files and greps twice was eight cards, which is eight rows of a screen
+/// spent on the part of the turn nobody asked about — and the thing you actually wanted, *the list
+/// of what it looked at*, was the eight names those rows were holding apart. So the run is one
+/// card: the names, comma-separated, as many as fit, and `+N more` for the rest. `⇥` while reading
+/// opens it back into a row per call.
+///
+/// Only calls that *looked* at something ever join a run. A command keeps its output and an edit
+/// keeps its diff, and neither has anything to gain from being summarised into a list of names.
+pub fn group_header(g: &Glyphs, heads: &[Head], root: &std::path::Path, width: usize) -> Row {
+    let live = heads.iter().any(|h| h.state == ToolState::Running);
+    let failed = heads.iter().any(|h| h.state == ToolState::Failed);
+    let state = if live {
+        ToolState::Running
+    } else if failed {
+        ToolState::Failed
+    } else {
+        ToolState::Done
+    };
+    let (mark, mark_hl) = g.mark(state);
+    let name = verb(heads, live);
+
+    let mut text = format!("{mark} {name}");
+    let mut spans = vec![(0, mark.len(), mark_hl), (mark.len() + 1, text.len(), Kind::Read.hl())];
+
+    // The names, then as much of the list as fits. Counting what was dropped rather than clipping
+    // the last one mid-word: `+2 more` is a fact, and `cards.r…` is a name that does not exist.
+    //
+    // Each name is coloured by *its own* call, so a run in flight reads as progress: the ones that
+    // came back are quiet and the ones still out sweep. Sweeping the whole list would be more
+    // movement saying less — the question a live run raises is which of these you are waiting on.
+    let names: Vec<String> = heads.iter().map(|h| short_subject_of(h.input, root)).collect();
+    let room = width.saturating_sub(text.chars().count() + 2).max(8);
+    let at = text.len() + 2;
+    let mut shown = 0usize;
+    let mut so_far = 0usize;
+    let mut list: Vec<Span> = Vec::new();
+    let mut listed = String::new();
+    for (i, n) in names.iter().enumerate() {
+        let rest = names.len() - i - 1;
+        // Room for this name, its separator, and the `+N more` that would follow if any are left.
+        let more = if rest > 0 { format!(", +{rest} more").chars().count() } else { 0 };
+        let sep = if i == 0 { 0 } else { 2 };
+        if so_far + sep + n.chars().count() + more > room && i > 0 {
+            break;
+        }
+        if i > 0 {
+            listed.push_str(", ");
+        }
+        let from = listed.len();
+        listed.push_str(n);
+        list.push((at + from, at + listed.len(), match heads[i].state {
+            ToolState::Running => "Agent.ToolLive",
+            ToolState::Failed => "Agent.ToolFailed",
+            ToolState::Done => "Agent.Usage",
+        }));
+        so_far += sep + n.chars().count();
+        shown += 1;
+    }
+    let rest = names.len() - shown;
+    if rest > 0 {
+        let from = listed.len();
+        listed.push_str(&format!(", +{rest} more"));
+        list.push((at + from, at + listed.len(), "Agent.Usage"));
+    }
+    if !listed.is_empty() {
+        text.push_str("  ");
+        text.push_str(&listed);
+        spans.extend(list);
+    }
     Row::new(text, spans)
+}
+
+/// What an opened run shows: one row per call, under the rule.
+///
+/// ```text
+///   │ Read  crates/neosh/src/host.rs  620 lines
+///   │ Grep  fn header  12 lines
+/// ```
+///
+/// The full subject rather than the short name the folded row uses, because "which file" is the
+/// question the fold answered loosely and this is where it gets answered exactly. Nothing else:
+/// the *contents* of six files is what the fold existed to keep out of the transcript, and a
+/// single read that was never part of a run is still an ordinary card with an ordinary body.
+pub fn group_body(
+    g: &Glyphs,
+    heads: &[Head],
+    root: &std::path::Path,
+    expanded: bool,
+    width: usize,
+) -> Vec<Row> {
+    if !expanded {
+        return Vec::new();
+    }
+    let margin = g.margin();
+    let room = width.saturating_sub(margin.chars().count()).max(8);
+    heads
+        .iter()
+        .map(|h| {
+            let (text, spans) = label(h, root, room);
+            let at = margin.len();
+            let mut all = vec![(0, at, "Agent.Usage")];
+            all.extend(spans.into_iter().map(|(a, b, hl)| (at + a, at + b, hl)));
+            Row::new(format!("{margin}{text}"), all)
+        })
+        .collect()
+}
+
+/// Whether two calls may share one card: both only looked at something.
+pub fn groups_with(a: &serde_json::Value, b: &serde_json::Value) -> bool {
+    looks_at_something(a) && looks_at_something(b)
 }
 
 /// The agent's own checklist, drawn.
@@ -598,13 +815,14 @@ pub fn tasks(g: &Glyphs, rows: &[TaskRow], width: usize) -> Vec<Row> {
 /// was just replaced by a summary of itself, and that is the single most useful thing to be able to
 /// scroll back to when an answer later seems to have forgotten something.
 pub fn compaction(g: &Glyphs, before: Option<u64>, after: Option<u64>) -> Row {
-    let mut text = format!("{} Compacted the conversation", g.dot);
+    let (mark, hl) = g.mark(ToolState::Done);
+    let mut text = format!("{mark} Compacted the conversation");
     let span = text.len();
     if let (Some(a), Some(b)) = (before, after) {
         text.push_str(&format!("  {} \u{2192} {}", tokens(a), tokens(b)));
     }
     let end = text.len();
-    Row::new(text, vec![(0, g.dot.len(), "Agent.ToolDone"), (span, end, "Agent.Usage")])
+    Row::new(text, vec![(0, mark.len(), hl), (span, end, "Agent.Usage")])
 }
 
 /// A token count, short enough to sit at the end of a line.
@@ -622,19 +840,48 @@ fn tokens(n: u64) -> String {
 /// you already know, and once it is clipped to fit, the part you already know is *all* you can
 /// see — which is how a card ends up saying `/home/you/projects/thing/crates/neosh/src/…`.
 pub fn subject_of(input: &serde_json::Value, root: &std::path::Path, room: usize) -> String {
-    const KEYS: &[&str] =
-        &["path", "file_path", "file", "pattern", "query", "command", "url", "prompt"];
-    let Some(map) = input.as_object() else { return String::new() };
-    for key in KEYS {
-        if let Some(v) = map.get(*key).and_then(|v| v.as_str()) {
-            let one = v.lines().next().unwrap_or(v).trim();
-            if one.is_empty() {
-                continue;
-            }
-            return clip(&relative_to(one, root), room);
-        }
+    match subject(input) {
+        Some((_, v)) => clip(&relative_to(&v, root), room),
+        None => String::new(),
     }
-    String::new()
+}
+
+/// Which argument a call is about, and what it says.
+///
+/// What it *searched for* before where it searched. A grep is `{pattern, path}` and the answer to
+/// "what was that call" is the pattern — the path is a directory the model chose, usually the one
+/// you are already in, and a column of cards reading `src`, `src`, `src` says nothing about a turn
+/// that grepped three different things. Reading and writing name no pattern, so a path is still
+/// what they get.
+fn subject(input: &serde_json::Value) -> Option<(&'static str, String)> {
+    const KEYS: &[&str] =
+        &["pattern", "query", "command", "url", "path", "file_path", "file", "prompt"];
+    let map = input.as_object()?;
+    KEYS.iter().find_map(|key| {
+        let v = map.get(*key)?.as_str()?;
+        let one = v.lines().next().unwrap_or(v).trim();
+        (!one.is_empty()).then(|| (*key, one.to_string()))
+    })
+}
+
+/// What a call is about, in as little room as a list of them can spare.
+///
+/// The last component of a path, and the whole of anything that is not one. In a folded run the
+/// names sit side by side, and `crates/neosh/src/host.rs, crates/neosh/src/cards.rs` is two
+/// directory listings with the two facts buried at the ends of them. The full path is one `\u{21e5}`
+/// away, on the row that call gets when the run is opened.
+pub fn short_subject_of(input: &serde_json::Value, root: &std::path::Path) -> String {
+    let Some((key, value)) = subject(input) else { return String::new() };
+    let full = relative_to(&value, root);
+    // Only where it is a path. A pattern's last component is not a shorter pattern — `**/*.rs`
+    // would come out as `*.rs`, which is a different glob.
+    if !PATH_KEYS.contains(&key) {
+        return full;
+    }
+    std::path::Path::new(&full)
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or(full)
 }
 
 /// A path inside the conversation's directory, said the short way.
@@ -713,16 +960,36 @@ pub fn body(
     result_rows(g, result, limits.output_lines, expanded, width)
 }
 
-/// The trailer under a folded body.
+/// The row that stands in for what is not being shown.
+///
+/// `+N lines` rather than `+N more lines`: this now appears in the *middle* of an output as often
+/// as at the end of one, and "more" is only true at the end. The count and the key are the whole
+/// content either way.
 fn trailer(g: &Glyphs, margin: &str, rest: usize, what: &str) -> Row {
     let word = if rest == 1 { what.trim_end_matches('s').to_string() } else { what.to_string() };
     Row::plain(
-        format!("{margin}\u{2026} +{rest} more {word} (^S {} to expand)", g.tab),
+        format!("{margin}{} +{rest} {word} (^S {} to expand)", g.elision, g.tab),
         "Agent.Usage",
     )
 }
 
 /// What a tool wrote, however much of it fits.
+///
+/// **Folded from the middle, not from the end.** The first lines of a command's output are how it
+/// started and the last lines are what it decided, and it is almost always the second one you were
+/// waiting for: `cargo test` opens with `Compiling` and closes with `test result: ok`, and a card
+/// that keeps three lines from the top keeps `Compiling`, `Finished`, and a blank. So the head
+/// gets one row, the tail gets the rest, and the count of what fell out sits between them.
+///
+/// ```text
+///   │    Compiling neosh v0.1.0
+///   │ … +4 lines (^S ⇥ to expand)
+///   │ test result: ok. 12 passed
+/// ```
+///
+/// One row of head rather than half: what the head is *for* is telling you which command's output
+/// this is when the tail alone would be ambiguous, and one line does that. Everything else the
+/// budget can buy is spent at the end.
 ///
 /// Tabs become spaces on the way in. A terminal advances to the next tab stop and a buffer line
 /// does not, so a `Read` whose output is `     1\thello` arrives on screen as `1hello` — the one
@@ -743,7 +1010,8 @@ fn result_rows(
         return vec![Row::plain(format!("{margin}{word}"), hl)];
     }
 
-    let total = body.lines().count();
+    let all: Vec<&str> = body.lines().collect();
+    let total = all.len();
     let limit = if expanded {
         total
     } else if result.is_error {
@@ -757,14 +1025,38 @@ fn result_rows(
     }
 
     let room = width.saturating_sub(margin.chars().count()).max(8);
-    let mut out = Vec::new();
-    for line in body.lines().take(limit) {
-        out.push(Row::plain(format!("{margin}{}", clip(&tabs(line), room)), hl));
+    let row = |line: &str| Row::plain(format!("{margin}{}", clip(&tabs(line), room)), hl);
+    if total <= limit {
+        return all.iter().map(|l| row(l)).collect();
     }
-    let rest = total.saturating_sub(limit);
-    if rest > 0 {
-        out.push(trailer(g, &margin, rest, "lines"));
+
+    // One line of head — enough to say which output this is — and the rest of the budget at the
+    // end, where the answer is. A limit of one buys the tail alone: the last line of a command is
+    // the single most useful line of it.
+    //
+    // Blank rows are skipped at either end. A blank line is structure in a terminal and nothing at
+    // all in a budget of three: `cargo test` puts one right before `test result:`, and spending a
+    // third of the card on it is how the answer ends up one row further out of reach than the
+    // budget said. They are still *counted* as elided, because they were there.
+    fn says_something(l: &str) -> bool {
+        !l.trim().is_empty()
     }
+    let head = usize::from(limit > 1);
+    let mut out: Vec<Row> =
+        all.iter().filter(|l| says_something(l)).take(head).map(|l| row(l)).collect();
+    // Walk back from the end until `limit - head` lines that say something are behind us.
+    let mut from = total;
+    let mut want = limit - head;
+    while from > 0 && want > 0 {
+        from -= 1;
+        if says_something(all[from]) {
+            want -= 1;
+        }
+    }
+    let kept: Vec<&str> =
+        all[from..].iter().copied().filter(|l| says_something(l)).collect();
+    out.push(trailer(g, &margin, total - out.len() - kept.len(), "lines"));
+    out.extend(kept.into_iter().map(|l| row(l)));
     out
 }
 
@@ -1130,7 +1422,7 @@ mod tests {
             output: None,
         };
         let text = header_text(&g(), &quick, &root(), 80);
-        assert_eq!(text, "\u{23fa} Read  a.rs", "{text:?}");
+        assert_eq!(text, "  Read  a.rs", "{text:?}");
         let slow = Head { took: Some(Duration::from_millis(100)), ..quick };
         let text = header_text(&g(), &slow, &root(), 80);
         assert!(text.ends_with("  100ms"), "{text:?}");
@@ -1242,12 +1534,12 @@ mod tests {
     fn the_header_carries_stats_only_once_the_edit_has_landed() {
         let input = json!({ "file_path": "/work/a.rs", "old_string": "a", "new_string": "b\nc" });
         let running = header_text(&g(), &head("Edit", &input, ToolState::Running), &root(), 80);
-        assert_eq!(running, "\u{23fa} Edit  a.rs");
+        assert_eq!(running, "\u{25b8} Edited  a.rs", "a call still out wears the mark that moves");
         let failed = header_text(&g(), &head("Edit", &input, ToolState::Failed), &root(), 80);
-        assert_eq!(failed, "\u{23fa} Edit  a.rs", "a failed edit changed nothing");
+        assert_eq!(failed, "\u{2717} Edited  a.rs", "a failed edit changed nothing");
         let row = header(&g(), &head("Edit", &input, ToolState::Done), &root(), 80);
         let (done, spans) = (row.text.clone(), row.spans.clone());
-        assert_eq!(done, "\u{23fa} Edit  a.rs  +2 -1");
+        assert_eq!(done, "  Edited  a.rs  +2 -1", "and one that worked wears nothing at all");
         let groups: Vec<&str> = spans.iter().map(|s| s.2).collect();
         assert!(groups.contains(&"Diff.Add") && groups.contains(&"Diff.Delete"), "{spans:?}");
         // The spans land on the numbers, not around them.
@@ -1258,10 +1550,155 @@ mod tests {
     }
 
     #[test]
+    fn a_run_of_reads_is_one_row_naming_what_it_looked_at() {
+        let a = json!({ "file_path": "/work/crates/neosh/src/host.rs" });
+        let b = json!({ "file_path": "/work/crates/neosh/src/cards.rs" });
+        let c = json!({ "pattern": "fn header", "path": "/work/crates" });
+        let heads =
+            [head("Read", &a, ToolState::Done), head("Read", &b, ToolState::Done),
+             head("Grep", &c, ToolState::Done)];
+        let row = group_header(&g(), &heads, &root(), 80);
+        // `Explored`, because they do not all share a name — and the *basenames*, because a list
+        // of full paths is three directory listings with the facts buried at the ends of them.
+        assert_eq!(row.text, "  Explored  host.rs, cards.rs, fn header", "{row:?}");
+
+        // All one name, and the name is the tool's own. There is no friendlier word for `Read`.
+        let same = [head("Read", &a, ToolState::Done), head("Read", &b, ToolState::Done)];
+        assert_eq!(group_header(&g(), &same, &root(), 80).text, "  Read  host.rs, cards.rs");
+    }
+
+    #[test]
+    fn a_run_that_is_still_going_says_so_and_moves() {
+        let a = json!({ "file_path": "/work/a.rs" });
+        let b = json!({ "command": "ls" });
+        let heads = [head("Read", &a, ToolState::Running), head("Bash", &b, ToolState::Done)];
+        let row = group_header(&g(), &heads, &root(), 80);
+        assert_eq!(row.text, "\u{25b8} Exploring  a.rs, ls", "{row:?}");
+        // Only the call still out sweeps; the one that came back is quiet. A live run is meant to
+        // read as progress, and a whole list in motion says only "something is happening".
+        let hl = |needle: &str| {
+            let at = row.text.find(needle).expect(needle);
+            row.spans
+                .iter()
+                .find(|(a, b, _)| *a <= at && at < *b)
+                .map(|(_, _, hl)| *hl)
+                .unwrap_or("")
+        };
+        assert_eq!(hl("a.rs"), "Agent.ToolLive", "{:?}", row.spans);
+        assert_eq!(hl("ls"), "Agent.Usage", "{:?}", row.spans);
+        // And a run holding a failure says that instead, once nothing is still out.
+        let heads = [head("Read", &a, ToolState::Done), head("Read", &b, ToolState::Failed)];
+        assert!(group_header(&g(), &heads, &root(), 80).text.starts_with("\u{2717} "));
+    }
+
+    #[test]
+    fn a_run_too_long_for_the_row_counts_what_it_dropped() {
+        let inputs: Vec<serde_json::Value> = (0..9)
+            .map(|i| json!({ "file_path": format!("/work/some/where/file{i}.rs") }))
+            .collect();
+        let heads: Vec<Head> =
+            inputs.iter().map(|i| head("Read", i, ToolState::Done)).collect();
+        let row = group_header(&g(), &heads, &root(), 46);
+        assert!(row.text.chars().count() <= 46, "{row:?}");
+        // The names that fit, whole, and a count of the rest — never half a name, which is a file
+        // that does not exist.
+        assert!(row.text.ends_with(" more"), "{row:?}");
+        let shown = row.text.matches(".rs").count();
+        assert!(row.text.contains(&format!("+{} more", 9 - shown)), "{row:?}");
+    }
+
+    #[test]
+    fn a_run_is_a_row_until_it_is_opened_and_then_a_row_per_call() {
+        let a = json!({ "file_path": "/work/deep/down/a.rs" });
+        let b = json!({ "pattern": "fn main" });
+        let heads = [
+            Head { output: Some(120), ..head("Read", &a, ToolState::Done) },
+            Head { output: Some(3), ..head("Grep", &b, ToolState::Done) },
+        ];
+        assert!(group_body(&g(), &heads, &root(), false, 80).is_empty(), "folded, it is one row");
+        let rows = group_body(&g(), &heads, &root(), true, 80);
+        // Opened, every call gets its own row with the *whole* subject: the short names on the
+        // folded row are the loose answer, and this is where it is exact.
+        assert_eq!(texts(&rows), vec![
+            "  \u{2502} Read  deep/down/a.rs  120 lines",
+            "  \u{2502} Searched  fn main  3 lines",
+        ]);
+    }
+
+    #[test]
+    fn a_card_says_what_happened_and_falls_back_to_the_tools_own_name() {
+        // Read off the arguments, exactly as the colour is. `Bash` is the mechanism; `Ran` is what
+        // happened, and the card is an account of what happened.
+        for (name, input, want) in [
+            ("Bash", json!({"command": "ls"}), "Ran"),
+            ("shell", json!({"command": "ls"}), "Ran"),
+            ("Read", json!({"file_path": "/work/a.rs"}), "Read"),
+            ("Grep", json!({"pattern": "fn main"}), "Searched"),
+            ("Edit", json!({"file_path": "a", "old_string": "x", "new_string": "y"}), "Edited"),
+            ("Write", json!({"file_path": "a", "content": "x"}), "Wrote"),
+            ("WebFetch", json!({"url": "https://example.com"}), "Fetched"),
+        ] {
+            assert_eq!(did(&input), Some(want), "{name}");
+            let text = header_text(&g(), &head(name, &input, ToolState::Done), &root(), 80);
+            assert!(text.starts_with(&format!("  {want}")), "{name}: {text}");
+        }
+        // And a call nothing here understands keeps the name its author gave it, for ever. That is
+        // the half of ADR 0033 that was load-bearing: neosh never invents a word for a tool.
+        let opaque = json!({ "description": "look around", "thing": 3 });
+        assert_eq!(did(&opaque), None);
+        let text = header_text(&g(), &head("frobnicate", &opaque, ToolState::Done), &root(), 80);
+        assert!(text.starts_with("  frobnicate"), "{text}");
+    }
+
+    #[test]
+    fn a_command_is_folded_from_the_middle_so_its_answer_survives() {
+        // The head of a command's output is how it started and the tail is what it decided. Three
+        // lines from the top of `cargo test` is `Compiling`, `Finished`, and a blank.
+        let out = "   Compiling neosh v0.1.0\n    Finished dev in 8.6s\n\nrunning 12 tests\n\
+                   test cards::header ... ok\n\ntest result: ok. 12 passed";
+        let result = neosh_proto::ToolResult::ok(out);
+        let input = json!({ "command": "cargo test" });
+        let rows = body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 3 }, false, 90);
+        let t = texts(&rows);
+        assert!(t[0].ends_with("Compiling neosh v0.1.0"), "one line of head: {t:?}");
+        assert!(t[1].contains("\u{2026} +"), "then what was dropped: {t:?}");
+        assert!(t.last().unwrap().ends_with("test result: ok. 12 passed"), "the answer: {t:?}");
+        // And no row is spent on a blank line, of which that output has two.
+        assert!(t.iter().all(|r| !r.trim_end().ends_with('\u{2502}')), "{t:?}");
+    }
+
+    #[test]
+    fn a_call_is_about_what_it_looked_for_before_where_it_looked() {
+        // A grep names both, and the answer to "what was that call" is the pattern. A column of
+        // cards reading `src`, `src`, `src` says nothing about a turn that grepped three things.
+        let grep = json!({ "pattern": "fn header", "path": "/work/crates" });
+        assert_eq!(subject_of(&grep, &root(), 40), "fn header");
+        // A read names no pattern, so a path is still what it gets.
+        let read = json!({ "file_path": "/work/a.rs" });
+        assert_eq!(subject_of(&read, &root(), 40), "a.rs");
+        // And a glob's short form is the glob: `**/*.rs` shortened to `*.rs` is a different one.
+        let glob = json!({ "pattern": "**/*.rs" });
+        assert_eq!(short_subject_of(&glob, &root()), "**/*.rs");
+        assert_eq!(short_subject_of(&json!({ "path": "/work/a/b/c.rs" }), &root()), "c.rs");
+    }
+
+    #[test]
+    fn only_calls_that_looked_at_something_share_a_card() {
+        let read = json!({ "file_path": "/work/a.rs" });
+        let grep = json!({ "pattern": "x" });
+        let run = json!({ "command": "ls" });
+        let edit = json!({ "file_path": "/work/a.rs", "old_string": "a", "new_string": "b" });
+        assert!(groups_with(&read, &grep));
+        assert!(!groups_with(&read, &run), "a command's output is the answer, not a name");
+        assert!(!groups_with(&read, &edit), "an edit's diff is the answer");
+        assert!(!groups_with(&run, &run));
+    }
+
+    #[test]
     fn a_read_has_no_stats_however_it_went() {
         let input = json!({ "file_path": "/work/a.rs" });
         let done = header_text(&g(), &head("Read", &input, ToolState::Done), &root(), 80);
-        assert_eq!(done, "\u{23fa} Read  a.rs");
+        assert_eq!(done, "  Read  a.rs");
     }
 
     #[test]
@@ -1298,7 +1735,7 @@ mod tests {
         let rows = body(&g(), &input, &result, Limits { diff_lines: 3, output_lines: 3 }, false, 80);
         let t = texts(&rows);
         assert_eq!(t.len(), 4, "{t:?}");
-        assert!(t[3].contains("+3 more lines"), "{t:?}");
+        assert!(t[3].contains("+3 lines"), "{t:?}");
         assert!(t[3].contains("(^S \u{21e5} to expand)"), "{t:?}");
     }
 
@@ -1314,7 +1751,7 @@ mod tests {
         // Folded at the first change: the gap and everything after it are what is left.
         let rows = body(&g(), &input, &result, Limits { diff_lines: 5, output_lines: 3 }, false, 80);
         let t = texts(&rows);
-        assert!(t.last().unwrap().contains("+22 more lines"), "{t:?}");
+        assert!(t.last().unwrap().contains("+22 lines"), "{t:?}");
     }
 
     #[test]
@@ -1325,7 +1762,7 @@ mod tests {
         let result = neosh_proto::ToolResult::ok("ok");
         let rows = body(&g(), &input, &result, Limits { diff_lines: 2, output_lines: 3 }, true, 80);
         assert_eq!(rows.len(), 21, "{:?}", texts(&rows));
-        assert!(!texts(&rows).iter().any(|r| r.contains("more lines")));
+        assert!(!texts(&rows).iter().any(|r| r.contains("lines")));
     }
 
     #[test]
@@ -1351,8 +1788,13 @@ mod tests {
         let input = json!({ "command": "seq" });
         let folded = body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 2 }, false, 80);
         let t = texts(&folded);
-        assert_eq!(t.len(), 3);
-        assert!(t[2].contains("+2 more lines"), "{t:?}");
+        // One line of head, then what was dropped, then the end — which for a command is the
+        // answer. Folding from the end would keep `one` and `two` and throw away the result.
+        assert_eq!(t, vec![
+            "  \u{2502} one",
+            "  \u{2502} \u{2026} +2 lines (^S \u{21e5} to expand)",
+            "  \u{2502} four",
+        ]);
         let open = body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 2 }, true, 80);
         assert_eq!(texts(&open).len(), 4);
     }
@@ -1560,6 +2002,6 @@ mod tests {
         let g = Glyphs::new(true);
         let result = neosh_proto::ToolResult::ok("one\ntwo");
         let rows = body(&g, &json!({}), &result, Limits { diff_lines: 12, output_lines: 1 }, false, 80);
-        assert!(rows[1].text.contains("(^S Tab to expand)"), "{:?}", texts(&rows));
+        assert_eq!(texts(&rows), vec!["  | ... +1 line (^S Tab to expand)", "  | two"]);
     }
 }

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -199,6 +199,10 @@ pub struct Host {
     /// `session.messages` when its stream closes, so a transcript rebuilt from messages alone would
     /// show a conversation that is visibly working and has said nothing.
     rounds: std::collections::HashMap<neosh_proto::SessionId, Round>,
+    /// What the mode was before `^S`, to be put back on the way out. Stored rather than assumed to
+    /// be `Chat`: the door into reading is bound in every mode, so it is reachable from any of
+    /// them, and a mode restored to a guess is a keyboard that quietly changed under you.
+    mode_before_reading: Mode,
     /// What was in the composer when a change was last announced.
     ///
     /// Kept so [`neosh_proto::PluginEvent::ComposerChanged`] is about the draft rather than about
@@ -216,7 +220,11 @@ pub struct Host {
     /// Learned at the driver's handshake, not configured: which commands exist depends on the
     /// install — project commands, plugin commands and MCP prompts all count — so any list written
     /// down here would be wrong on the first machine that had one of its own. Outlives the turn
-    /// that learned it, because the menu is opened between turns.
+    /// that learned it, because the menu is opened between turns — and outlives the *workspace*
+    /// through [`Host::remembered_commands`], because it is also opened before them. A driver only
+    /// says this once its process is up, which is on the first turn; a conversation you have just
+    /// opened has not had one, and every command the agent accepts would be missing from the menu
+    /// at exactly the moment somebody typed `/` looking for it.
     driver_commands:
         std::collections::HashMap<neosh_proto::SessionId, Vec<neosh_proto::DriverCommand>>,
     /// Every tool card in the transcript on screen, in row order.
@@ -409,12 +417,8 @@ impl Task {
     }
 }
 
-/// A tool card on screen: where it is, and what it shows.
-///
-/// What it shows is kept so it can be drawn again — folded or opened from the transcript, or
-/// finished when the call comes back — without going looking for the call in the conversation,
-/// which for a running agent turn does not hold it yet.
-struct Card {
+/// One call a card is holding: what was asked, and what came back.
+struct Leg {
     id: neosh_proto::ToolCallId,
     name: String,
     input: serde_json::Value,
@@ -429,12 +433,54 @@ struct Card {
     took: Option<std::time::Duration>,
     /// What a failed call exited with, when its output said.
     exit: Option<i64>,
+}
+
+/// A tool card on screen: where it is, and what it shows.
+///
+/// What it shows is kept so it can be drawn again — folded or opened from the transcript, or
+/// finished when the call comes back — without going looking for the call in the conversation,
+/// which for a running agent turn does not hold it yet.
+///
+/// Usually one call. A *run* of calls that only looked at things — reads, greps, listings, one
+/// after another with nothing drawn between them — shares a card, and the card is one row saying
+/// what they all looked at. See [`cards::group_header`]. Nothing else ever shares: a command's
+/// output and an edit's diff are the answer, and there is no summarising them into a list of
+/// names.
+struct Card {
+    /// One, or a run of read-only calls, in the order they were made.
+    legs: Vec<Leg>,
     /// The header's row.
     row: u32,
     /// How many rows the body takes under it.
     body: u32,
     /// Whether the body is the whole of it or the first few rows.
     expanded: bool,
+}
+
+impl Card {
+    fn new(leg: Leg, row: u32) -> Self {
+        Self { legs: vec![leg], row, body: 0, expanded: false }
+    }
+
+    /// Whether this card holds a call answering to `id`, and which one.
+    fn leg_of(&self, id: &neosh_proto::ToolCallId) -> Option<usize> {
+        self.legs.iter().rposition(|l| l.id == *id)
+    }
+
+    /// Whether every call on this card has come back.
+    fn settled(&self) -> bool {
+        self.legs.iter().all(|l| l.result.is_some())
+    }
+
+    /// Whether a call `input` could join this card.
+    ///
+    /// Both sides have to be calls that only looked at something, and the card has to have room
+    /// for the idea — a card whose body is already on screen is a card the reader has opened, and
+    /// growing it under them would move what they were reading.
+    fn takes(&self, input: &serde_json::Value) -> bool {
+        !self.expanded
+            && self.legs.last().is_some_and(|l| cards::groups_with(&l.input, input))
+    }
 }
 
 /// One thing a running turn has produced, in the order it produced it.
@@ -569,6 +615,7 @@ impl Host {
             agent_drivers: Vec::new(),
             turns: std::collections::HashMap::new(),
             rounds: std::collections::HashMap::new(),
+            mode_before_reading: Mode::Chat,
             draft: String::new(),
             plan_rows: 0,
             driver_commands: std::collections::HashMap::new(),
@@ -763,8 +810,16 @@ impl Host {
                 Ok(ApiOk::Unit)
             }
             ApiCall::AgentDriverCommands => {
-                let commands =
-                    self.driver_commands.get(&self.active_session()).cloned().unwrap_or_default();
+                let here = self.active_session();
+                let commands = match self.driver_commands.get(&here) {
+                    Some(c) => c.clone(),
+                    // Not this conversation's own answer, but the last one given for the same
+                    // driver in the same project — which is what its handshake is about to say
+                    // again. Being one install-change out of date is the cost; the alternative is a
+                    // menu that knows none of the agent's commands until you have already sent
+                    // something, which is the state the menu is least useful in.
+                    None => self.remembered_commands(),
+                };
                 Ok(ApiOk::DriverCommands { commands })
             }
             ApiCall::ChatSetDraft { text } => {
@@ -1158,6 +1213,9 @@ impl Host {
             self.scroll_chat(0);
             self.chat_question(&text);
             self.begin_working();
+            // `\u{23ce}` steers from here until the turn is over, and the empty field is where that
+            // has to be said — it is the one thing on screen you are looking at when you press it.
+            self.refresh_composer();
         }
 
         let agent = self.agent.clone();
@@ -1572,10 +1630,15 @@ impl Host {
             ];
             let one = text.lines().next().unwrap_or("").trim();
             let tail = if i + 1 == take && more > 0 { format!("  (+{more} more)") } else { String::new() };
-            let key = if ascii { "S-Up" } else { "\u{21e7}\u{2191}" };
-            // The label, the gap either side of it, and the word after it, so a long message is
+            let key = "^Y";
+            // *What happens*, not what you do. `edit` is the operation and "I want that sentence
+            // back" is the thought, and the two only look the same to somebody who already knew
+            // the key was there.
+            let undo = " take back";
+            // The label, the gap either side of it, and the words after it, so a long message is
             // clipped rather than pushing the key that undoes it off the edge.
-            let room = width.saturating_sub(9 + tail.chars().count() + display_width(key) + 7);
+            let room = width
+                .saturating_sub(9 + tail.chars().count() + display_width(key) + 2 + undo.len());
             let body: String = one.chars().take(room).collect();
             v.push(chunk(format!("{body}{tail}"), "Composer.Hint"));
             // On the last row, so it is next to the message it would take back rather than
@@ -1583,7 +1646,7 @@ impl Host {
             if i + 1 == take {
                 v.push(chunk("  ", "Composer.Hint"));
                 v.push(chunk(key, "Composer.HintKey"));
-                v.push(chunk(" edit", "Composer.Hint"));
+                v.push(chunk(undo, "Composer.Hint"));
             }
             self.composer_mark(0, VirtTextPos::Above, v);
         }
@@ -1606,10 +1669,20 @@ impl Host {
         self.composer_mark(0, VirtTextPos::Inline, vec![chunk(caret, "Composer.Prompt")]);
 
         if text.is_empty() {
+            // While a turn is running, `\u{23ce}` does something else, and an empty field is the one
+            // place you are looking when you are about to press it. "Ask anything" there invites
+            // you to do the thing you cannot do and says nothing about the thing you can — which
+            // is how somebody presses it, watches the sentence vanish into a queue they did not
+            // know existed, and has no idea what just happened to it.
+            let words = if self.turns.contains_key(&self.active_session()) {
+                "Steer it \u{2014} taken in at the next gap"
+            } else {
+                "Ask anything, or run a command"
+            };
             self.composer_mark(
                 0,
                 VirtTextPos::Eol,
-                vec![chunk("Ask anything, or run a command", "Composer.Placeholder")],
+                vec![chunk(words, "Composer.Placeholder")],
             );
         }
 
@@ -1649,7 +1722,7 @@ impl Host {
         let card = self
             .card_at(self.chat_cursor().0)
             .map(|i| &self.cards[i])
-            .filter(|c| c.result.is_some())
+            .filter(|c| c.settled())
             .map(|c| c.expanded);
         let tab = self.glyphs().tab;
         let mut pairs: Vec<(&str, &str)> = match self.reading_pending {
@@ -2410,6 +2483,20 @@ impl Host {
         }
         self.reading = true;
         self.reading_pending = None;
+        // And the keymap has to be told, or the sentence above is only true of the keys nobody
+        // else wanted. Reading's keys arrive through [`Self::handle_unbound_key`], which is the
+        // *last* thing consulted — so `^D` scrolled half a screen only until the git plugin bound
+        // it in `chat` mode, after which it opened a diff, and `^B` toggled the sidebar instead of
+        // going back a page, and `^E` opened the effort picker instead of moving a line. Half of a
+        // documented vim vocabulary, quietly taken by whatever loaded first.
+        //
+        // `Normal` rather than a `Reading` mode of its own: the keys `chat` carries are the ones
+        // that compose a message, and none of them means anything here. What stays bound is the
+        // set the host puts in *every* mode — `^C`, `^Q`, `^R`, `^S` — which is exactly the set you
+        // want to keep working somewhere you did not intend to be. A plugin that wants a key while
+        // reading binds it in `normal`, which needs nothing new.
+        self.mode_before_reading = self.editor.mode();
+        self.editor.set_mode(Mode::Normal);
         let plugin = PluginId::from(BUILTIN);
         let _ = self.editor.apply(&plugin, ApiCall::FocusPush { win: self.chat_win });
         let _ = self.editor.apply(&plugin, ApiCall::WinSelect { win: self.chat_win, on: false });
@@ -2427,6 +2514,7 @@ impl Host {
         }
         self.reading = false;
         self.reading_pending = None;
+        self.editor.set_mode(self.mode_before_reading);
         self.clear_matches();
         let plugin = PluginId::from(BUILTIN);
         let _ = self.editor.apply(&plugin, ApiCall::WinSelect { win: self.chat_win, on: false });
@@ -2448,6 +2536,35 @@ impl Host {
             KeyCode::Char { c } => c.as_str(),
             _ => "",
         };
+        let select = self.chat_anchored() || key.mods.shift;
+
+        // Chords first — before the pending pair and before the plain motions, because a chord is
+        // a different key and not a modified one. Read after them, `^B` was matched by the `b` arm
+        // of the motion table and moved a word left, `^Y` opened a pending yank, and `^E` moved a
+        // word right: three of the six scroll keys taken by the unmodified letters they happen to
+        // share. `<C-d>`/`<C-u>` are half a screen because that is what they are everywhere; a full
+        // screen with no overlap loses the line you were reading.
+        let page = self.chat_height().max(2);
+        if key.mods.ctrl {
+            match ch {
+                "d" => return self.reading_by(page as i64 / 2, select),
+                "u" => return self.reading_by(-(page as i64 / 2), select),
+                "f" => return self.reading_by(page as i64, select),
+                "b" => return self.reading_by(-(page as i64), select),
+                "e" => return self.reading_by(1, select),
+                "y" => return self.reading_by(-1, select),
+                _ => {}
+            }
+        }
+        // A chord this mode does not define does *nothing*. Falling through, `^A` was read as `a`
+        // and put you back in the composer, `^W` as `w` and moved a word — a key that means
+        // something else here quietly meaning the letter it is made of. Alt as well as ctrl, and
+        // deliberately not shift: shift *is* a modifier on a motion here, and holding it is how a
+        // selection is extended.
+        if key.mods.ctrl || key.mods.alt {
+            return;
+        }
+
         // A pending first key consumes exactly one more press, whatever it is. Anything else and a
         // mistyped `y` would sit there waiting to eat an unrelated keystroke later.
         if let Some(first) = self.reading_pending.take() {
@@ -2461,7 +2578,6 @@ impl Host {
             return;
         }
 
-        let select = self.chat_anchored() || key.mods.shift;
         let motion = match (&key.code, ch) {
             (KeyCode::Left, _) | (_, "h") => Some(CursorMotion::Left),
             (KeyCode::Right, _) | (_, "l") => Some(CursorMotion::Right),
@@ -2486,20 +2602,6 @@ impl Host {
             return;
         }
 
-        // Whole-screen movement. `<C-d>`/`<C-u>` are half a screen because that is what they are
-        // everywhere; a full screen with no overlap loses the line you were reading.
-        let page = self.chat_height().max(2);
-        if key.mods.ctrl {
-            match ch {
-                "d" => return self.reading_by(page as i64 / 2, select),
-                "u" => return self.reading_by(-(page as i64 / 2), select),
-                "f" => return self.reading_by(page as i64, select),
-                "b" => return self.reading_by(-(page as i64), select),
-                "e" => return self.reading_by(1, select),
-                "y" => return self.reading_by(-1, select),
-                _ => {}
-            }
-        }
         match (&key.code, ch) {
             (KeyCode::PageDown, _) => self.reading_by(page as i64, select),
             (KeyCode::PageUp, _) => self.reading_by(-(page as i64), select),
@@ -3175,25 +3277,11 @@ impl Host {
     /// One function for the live path and the replay, because the two have to agree. They used to
     /// be two pieces of near-identical code, and near-identical is how a card acquires a blank line
     /// in one of them and not the other.
-    fn draw_tool_card(&mut self, call: &neosh_proto::ToolCall, state: ToolState) -> Option<u32> {
+    fn draw_tool_card(&mut self, call: &neosh_proto::ToolCall, _state: ToolState) -> Option<u32> {
         if !self.option_bool("chat.show_tools") {
             return None;
         }
-        let g = self.glyphs();
-        let root = self.root();
-        let width = self.chat_width();
-        let head = cards::Head {
-            name: &call.name,
-            input: &call.input,
-            state,
-            took: None,
-            exit: None,
-            output: None,
-        };
-        let card = cards::header(&g, &head, &root, width);
-        let row = self.chat_push(vec![card.text.clone()]);
-        self.chat_row(row, &card);
-        self.cards.push(Card {
+        let leg = Leg {
             id: call.id.clone(),
             name: call.name.clone(),
             input: call.input.clone(),
@@ -3201,11 +3289,70 @@ impl Host {
             started: Some(std::time::Instant::now()),
             took: None,
             exit: None,
-            row,
-            body: 0,
-            expanded: false,
-        });
+        };
+        // Onto the card above, when there is one and it is still the last thing in the transcript.
+        // *Still the last thing* is the whole condition: a run is calls with nothing between them,
+        // and anything at all having been drawn since — a sentence, a body, another kind of call —
+        // means the reader has been told something else and the run is over.
+        if let Some(i) = self.open_run()
+            && self.cards[i].takes(&call.input)
+        {
+            self.cards[i].legs.push(leg);
+            let row = self.cards[i].row;
+            let header = self.card_header(i);
+            self.replace_row(row, &header);
+            return Some(row);
+        }
+        let g = self.glyphs();
+        let root = self.root();
+        let width = self.chat_width();
+        let head = cards::Head {
+            name: &leg.name,
+            input: &leg.input,
+            state: ToolState::Running,
+            took: None,
+            exit: None,
+            output: None,
+        };
+        let card = cards::header(&g, &head, &root, width);
+        // A blank row between one action and the next. Butted together, a header, four rows of
+        // output and the next header are one block of text with no edges in it, and finding where
+        // an action starts means reading for it. A row of air is what turns the transcript into a
+        // list of things that happened — it is the cheapest structure there is, and every program
+        // that reads well spends it.
+        self.chat_gap();
+        let row = self.chat_push(vec![card.text.clone()]);
+        self.chat_row(row, &card);
+        self.cards.push(Card::new(leg, row));
         Some(row)
+    }
+
+    /// The card a new call could join: the last one drawn, if nothing has been drawn since.
+    fn open_run(&self) -> Option<usize> {
+        let i = self.cards.len().checked_sub(1)?;
+        let c = &self.cards[i];
+        (i64::from(c.row + c.body + 1) == self.chat_end()).then_some(i)
+    }
+
+    /// Put one row back where it was, marks and all. Nothing below moves.
+    fn replace_row(&mut self, row: u32, r: &cards::Row) {
+        let plugin = PluginId::from(BUILTIN);
+        // Cleared first: a mark clamps rather than dies when the line under it is replaced, and at
+        // equal priority the narrower one wins — so a row rewritten every tick ends up painted by
+        // the shortest label it ever had.
+        let _ = self.editor.apply(&plugin, ApiCall::MarkClear {
+            ns: self.chat_ns,
+            buf: self.chat,
+            start: Some(row),
+            end: Some(row + 1),
+        });
+        let _ = self.editor.apply(&plugin, ApiCall::BufSetLines {
+            buf: self.chat,
+            start: row as i64,
+            end: row as i64 + 1,
+            lines: vec![r.text.clone()],
+        });
+        self.chat_row(row, r);
     }
 
     /// The call came back: settle the dot, put the stats on the header and the body under it.
@@ -3218,7 +3365,13 @@ impl Host {
     /// to put them under: a tool that failed silently is a debugging session, and the setting is
     /// about noise, not about hiding failures.
     fn finish_card(&mut self, id: &neosh_proto::ToolCallId, result: &neosh_proto::ToolResult) {
-        let Some(i) = self.cards.iter().rposition(|c| c.id == *id) else {
+        let found = self
+            .cards
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(i, c)| c.leg_of(id).map(|k| (i, k)));
+        let Some((i, k)) = found else {
             if result.is_error || self.option_bool("chat.show_tools") {
                 let g = self.glyphs();
                 let limits = self.limits();
@@ -3233,43 +3386,55 @@ impl Host {
         };
         // Already answered. A replay can meet the same result twice — once in the messages and
         // once in the round's own record — and a second body would say it happened twice.
-        if self.cards[i].result.is_some() {
+        if self.cards[i].legs[k].result.is_some() {
             return;
         }
-        self.cards[i].took = self.cards[i].started.map(|s| s.elapsed());
-        self.cards[i].exit = result.is_error.then(|| cards::exit_code(&result.content)).flatten();
-        self.cards[i].result = Some(result.clone());
+        let leg = &mut self.cards[i].legs[k];
+        leg.took = leg.started.map(|s| s.elapsed());
+        leg.exit = result.is_error.then(|| cards::exit_code(&result.content)).flatten();
+        leg.result = Some(result.clone());
         self.redraw_card(i);
     }
 
-    /// How a card's call is going, which is what its dot says. Derived rather than stored: a call
+    /// How one call is going, which is what a card's mark says. Derived rather than stored: a call
     /// with a result is finished and one without is running, and there is no third source of truth
     /// to fall out of step with.
-    fn card_state(card: &Card) -> ToolState {
-        match &card.result {
+    fn leg_state(leg: &Leg) -> ToolState {
+        match &leg.result {
             Some(r) if r.is_error => ToolState::Failed,
             Some(_) => ToolState::Done,
             None => ToolState::Running,
         }
     }
 
+    /// Every call on card `i`, as the renderer wants them.
+    fn card_heads(card: &Card) -> Vec<cards::Head<'_>> {
+        card.legs
+            .iter()
+            .map(|leg| cards::Head {
+                name: &leg.name,
+                input: &leg.input,
+                state: Self::leg_state(leg),
+                // A finished call keeps whatever it took; a running one is timed from its start,
+                // so the number on screen is the one a clock on the wall would give. Whether
+                // either is worth printing is the renderer's decision, in one place, for both.
+                took: leg.took.or_else(|| leg.started.map(|s| s.elapsed())),
+                exit: leg.exit,
+                output: leg.result.as_ref().map(|r| lines_in(&r.content)),
+            })
+            .collect()
+    }
+
     /// Card `i`'s header line, as it should read now.
     fn card_header(&self, i: usize) -> cards::Row {
-        let card = &self.cards[i];
-        let head = cards::Head {
-            name: &card.name,
-            input: &card.input,
-            state: Self::card_state(card),
-            // A running call is timed from its start, so the number on screen is the one you would
-            // get by looking at a clock — which is the whole question being asked of it.
-            // A finished call keeps whatever it took; a running one is timed from its start, so
-            // the number on screen is the one a clock on the wall would give. Whether either is
-            // worth printing is the renderer's decision, in one place, for both.
-            took: card.took.or_else(|| card.started.map(|s| s.elapsed())),
-            exit: card.exit,
-            output: card.result.as_ref().map(|r| lines_in(&r.content)),
-        };
-        cards::header(&self.glyphs(), &head, &self.root(), self.chat_width())
+        let g = self.glyphs();
+        let root = self.root();
+        let width = self.chat_width();
+        let heads = Self::card_heads(&self.cards[i]);
+        match heads.as_slice() {
+            [one] => cards::header(&g, one, &root, width),
+            many => cards::group_header(&g, many, &root, width),
+        }
     }
 
     /// Advance the clock on every call that has not come back.
@@ -3283,26 +3448,15 @@ impl Host {
             .cards
             .iter()
             .enumerate()
-            .filter(|(_, c)| c.result.is_none() && c.started.is_some())
+            .filter(|(_, c)| {
+                c.legs.iter().any(|l| l.result.is_none() && l.started.is_some())
+            })
             .map(|(i, _)| i)
             .collect();
-        let plugin = PluginId::from(BUILTIN);
         for i in live {
             let card = self.card_header(i);
             let row = self.cards[i].row;
-            let _ = self.editor.apply(&plugin, ApiCall::MarkClear {
-                ns: self.chat_ns,
-                buf: self.chat,
-                start: Some(row),
-                end: Some(row + 1),
-            });
-            let _ = self.editor.apply(&plugin, ApiCall::BufSetLines {
-                buf: self.chat,
-                start: row as i64,
-                end: row as i64 + 1,
-                lines: vec![card.text.clone()],
-            });
-            self.chat_row(row, &card);
+            self.replace_row(row, &card);
         }
     }
 
@@ -3314,10 +3468,18 @@ impl Host {
         let limits = self.limits();
         let (row, old_body) = (self.cards[i].row, self.cards[i].body);
         let header = self.card_header(i);
+        let root = self.root();
         let card = &self.cards[i];
-        let body = match &card.result {
-            Some(r) => cards::body(&g, &card.input, r, limits, card.expanded, width),
-            None => Vec::new(),
+        let body = match card.legs.as_slice() {
+            // One call: whatever it came back with, folded or opened.
+            [leg] => match &leg.result {
+                Some(r) => cards::body(&g, &leg.input, r, limits, card.expanded, width),
+                None => Vec::new(),
+            },
+            // A run: nothing until it is opened, and then a row per call. What the fold exists to
+            // keep out of the transcript is the *contents* of the six files, so opening a run
+            // gives back the six names in full and stops there.
+            _ => cards::group_body(&g, &Self::card_heads(card), &root, card.expanded, width),
         };
         // Anything else writing into the transcript ends the answer: its rows are addressed by
         // range, and rows moving underneath it would make "the end of the answer" ambiguous. An
@@ -3370,7 +3532,7 @@ impl Host {
             self.editor_message(MessageLevel::Info, "the cursor is not on a tool call");
             return;
         };
-        if self.cards[i].result.is_none() {
+        if !self.cards[i].settled() {
             self.editor_message(MessageLevel::Info, "still running \u{2014} nothing to show yet");
             return;
         }
@@ -3466,7 +3628,7 @@ impl Host {
                     // it in `cards`. Drawing a second card would say it happened twice — and for a
                     // model driver it always does, because the call lands in the messages the
                     // moment the stream closes and the tool starts running after that.
-                    if !self.cards.iter().any(|c| c.id == call.id) {
+                    if !self.cards.iter().any(|c| c.leg_of(&call.id).is_some()) {
                         self.draw_tool_card(call, ToolState::Running);
                     }
                     // Whether the card came from the messages or was just drawn, a result the
@@ -3506,6 +3668,20 @@ impl Host {
         });
         self.streaming = None;
         at.max(0) as u32
+    }
+
+    /// A blank row at the end of the transcript, unless there already is one.
+    fn chat_gap(&mut self) {
+        let at = self.chat_end();
+        let blank = at <= 0
+            || self
+                .editor
+                .buffer(self.chat)
+                .map(|b| b.get_lines((at - 1) as u32, at as u32).iter().all(|l| l.trim().is_empty()))
+                .unwrap_or(true);
+        if !blank {
+            self.chat_push(vec![String::new()]);
+        }
     }
 
     /// Where new content goes: the end, or the line above the working line when there is one.
@@ -4098,6 +4274,8 @@ impl Host {
                 if !leftover.is_empty() {
                     self.start_turn_in(session, leftover.join("\n"));
                 }
+                // The field says what `\u{23ce}` does, and what it does just changed back.
+                self.refresh_composer();
             }
             // What the turn produced is in the conversation now, so the round's copy of it would
             // only go stale — and drawing both on a switch would say everything twice.
@@ -4235,7 +4413,23 @@ impl Host {
                 }
             }
             Activity::Commands { commands } => {
+                self.remember_commands(&session, &commands);
                 self.driver_commands.insert(session, commands);
+            }
+            // What the driver calls this conversation, written down where it will still be after
+            // the process that said it has gone. Persisted rather than held: the value is only
+            // worth anything on a run that is not this one.
+            Activity::Resume { token } => {
+                let changed = match self.agent.sessions().get_mut(&session) {
+                    Some(s) if s.resume.as_deref() != Some(token.as_str()) => {
+                        s.resume = Some(token);
+                        true
+                    }
+                    _ => false,
+                };
+                if changed {
+                    self.persist_sessions();
+                }
             }
             // The driver's own answer to "how full is it", which beats anything derived. A prompt
             // size counts one request; this counts the conversation the agent is holding, and it
@@ -4613,6 +4807,50 @@ impl Host {
     }
 
     /// Persist every conversation. Cheap enough to call after each turn; a no-op under `--clean`.
+    /// Where the last-known command list for a conversation's driver and project is filed.
+    ///
+    /// By instance and directory rather than by conversation, because that is what the answer
+    /// actually depends on: `claude` in one repository accepts that repository's project commands
+    /// and its MCP prompts, and every conversation in it gets the same list. Keyed by conversation
+    /// it would be learned again from scratch for each new one, which is precisely the case this
+    /// exists for.
+    fn commands_key(&self, session: &neosh_proto::SessionId) -> Option<String> {
+        let store = self.agent.sessions();
+        let s = store.get(session)?;
+        let instance = s
+            .selection
+            .as_ref()
+            .map(|sel| sel.instance.clone())
+            .or_else(|| self.agent.selection().map(|sel| sel.instance))?;
+        Some(format!("commands:{instance}:{}", s.cwd.display()))
+    }
+
+    /// Keep what a driver said it accepts, for the conversations that have not asked it yet.
+    fn remember_commands(
+        &mut self,
+        session: &neosh_proto::SessionId,
+        commands: &[neosh_proto::DriverCommand],
+    ) {
+        // An empty list is a driver that answered nothing, not a driver that accepts nothing.
+        // Writing it down would replace a good list with a blank one.
+        if commands.is_empty() {
+            return;
+        }
+        let Some(key) = self.commands_key(session) else { return };
+        let Ok(value) = serde_json::to_value(commands) else { return };
+        if self.pstate.get(BUILTIN, &key) == value {
+            return;
+        }
+        self.pstate.set(BUILTIN, key, value);
+    }
+
+    /// What this driver accepted last time it ran here, for a conversation that has not run yet.
+    fn remembered_commands(&mut self) -> Vec<neosh_proto::DriverCommand> {
+        let here = self.active_session();
+        let Some(key) = self.commands_key(&here) else { return Vec::new() };
+        serde_json::from_value(self.pstate.get(BUILTIN, &key)).unwrap_or_default()
+    }
+
     fn persist_sessions(&self) {
         let Some(dir) = &self.state_dir else { return };
         if let Err(e) = crate::sessions::save_all(dir, &self.agent.sessions()) {
@@ -4777,30 +5015,27 @@ impl Host {
                 desc: Some(desc.to_string()),
             });
         }
-        // In every mode: a config that fails to load can leave you somewhere unexpected, and that
-        // is precisely when you need to be able to reload.
-        for mode in [Mode::Normal, Mode::Insert, Mode::Visual, Mode::Chat] {
-            for (lhs, command, desc) in [
-                ("<C-r>", "config.reload", "Reload configuration"),
-                ("<C-q>", "quit", "Close neosh"),
-                // Bound because it is the first thing anyone tries. In raw mode the terminal does
-                // not turn this into SIGINT, so without a binding it does nothing at all — and a
-                // program you cannot get out of is not one people give a second chance.
-                ("<C-c>", "interrupt", "Cancel, clear, or quit"),
-                ("<PageUp>", "chat.scroll_up", "Scroll up"),
-                ("<PageDown>", "chat.scroll_down", "Scroll down"),
-                ("<C-End>", "chat.scroll_end", "Back to the newest message"),
-                // Reading the transcript is a separate place, and this is the door to it. Bound in
-                // every mode for the same reason reload is: you want it most when you are somewhere
-                // you did not intend to be.
-                ("<C-s>", "chat.read", "Read, select and copy the transcript"),
-                ("<C-x>", "edit.cut", "Cut the selection"),
-                ("<C-a>", "edit.select_all", "Select everything"),
-                // `⌥↑` is the model ladder and `⌥↓` its other half, so the queue takes the shift
-                // pair. Both are "up, to the thing before this one", which is what makes them
-                // rememberable — and neither is a chord anybody's `init.ts` has taken.
-                ("<S-Up>", "chat.queue.edit", "Edit the last queued message"),
-            ] {
+        // Two lists, and the split is the point. **A mode's keys are the mode's keys**: while you
+        // are reading the transcript, `^X` cutting a composer you cannot see and `^Y` pulling a
+        // queued message into it are not things you asked for — they are the previous mode still
+        // holding the keyboard. Everything that acts on the composer or scrolls the transcript
+        // *without* the cursor is therefore bound in `Chat` alone, and reading answers those keys
+        // itself, in the way this mode means them.
+        //
+        // What is left is the escape hatches, and only those. A config that fails to load can put
+        // you somewhere unexpected, which is exactly when you need to reload, quit, interrupt, or
+        // get into the transcript — so those four are bound everywhere and nothing else is.
+        for (lhs, command, desc) in [
+            ("<C-r>", "config.reload", "Reload configuration"),
+            ("<C-q>", "quit", "Close neosh"),
+            // Bound because it is the first thing anyone tries. In raw mode the terminal does
+            // not turn this into SIGINT, so without a binding it does nothing at all — and a
+            // program you cannot get out of is not one people give a second chance.
+            ("<C-c>", "interrupt", "Cancel, clear, or quit"),
+            // Reading the transcript is a separate place, and this is the door to it.
+            ("<C-s>", "chat.read", "Read, select and copy the transcript"),
+        ] {
+            for mode in [Mode::Normal, Mode::Insert, Mode::Visual, Mode::Chat] {
                 let _ = self.editor.apply(&plugin, ApiCall::KeymapSet {
                     mode,
                     lhs: lhs.to_string(),
@@ -4809,6 +5044,33 @@ impl Host {
                     desc: Some(desc.to_string()),
                 });
             }
+        }
+        for (lhs, command, desc) in [
+            // Scrolling that leaves the cursor behind, which is what you want when the composer
+            // has it. Reading binds the same two keys to a screen of *motion*, because there the
+            // cursor is the thing you are moving.
+            ("<PageUp>", "chat.scroll_up", "Scroll up"),
+            ("<PageDown>", "chat.scroll_down", "Scroll down"),
+            ("<C-End>", "chat.scroll_end", "Back to the newest message"),
+            ("<C-x>", "edit.cut", "Cut the selection"),
+            ("<C-a>", "edit.select_all", "Select everything"),
+            // `^Y`, because it is readline's: `^U` and `^W` kill, `^Y` brings back what was
+            // killed, and those two are already the composer's. Sending while a turn runs is a
+            // kill of the same kind — the sentence leaves the field — so the key that undoes it is
+            // the one a terminal's fingers already know.
+            //
+            // It used to be `⇧↑`, which needs an arrow, and a keyboard without arrows could not
+            // reach it at all. It also took `⇧↑` away from the composer, where it is how you select
+            // upward through a pasted snippet — the field handles it and never saw it.
+            ("<C-y>", "chat.queue.edit", "Take the last queued message back"),
+        ] {
+            let _ = self.editor.apply(&plugin, ApiCall::KeymapSet {
+                mode: Mode::Chat,
+                lhs: lhs.to_string(),
+                command: command.to_string(),
+                scope: None,
+                desc: Some(desc.to_string()),
+            });
         }
     }
 
@@ -5840,6 +6102,42 @@ fn transcript(
             lines.insert(row as usize, r.text);
         }
     }
+    // A card's header, from what the conversation says about every call on it.
+    //
+    // The results are read out of `answered` rather than off the legs: a result block always comes
+    // *after* the call it answers, and a header that only settled on the second pass would show
+    // every finished call as running for one frame of every switch.
+    fn header_of(
+        g: &Glyphs,
+        card: &Card,
+        answered: &std::collections::HashMap<&neosh_proto::ToolCallId, (bool, Option<i64>, usize)>,
+        root: &std::path::Path,
+        width: usize,
+    ) -> cards::Row {
+        let heads: Vec<cards::Head> = card
+            .legs
+            .iter()
+            .map(|leg| {
+                let (state, exit, output) = match answered.get(&leg.id) {
+                    Some((true, exit, n)) => (ToolState::Failed, *exit, Some(*n)),
+                    Some((false, _, n)) => (ToolState::Done, None, Some(*n)),
+                    None => (ToolState::Running, None, None),
+                };
+                cards::Head {
+                    name: &leg.name,
+                    input: &leg.input,
+                    state,
+                    took: None,
+                    exit,
+                    output,
+                }
+            })
+            .collect();
+        match heads.as_slice() {
+            [one] => cards::header(g, one, root, width),
+            many => cards::group_header(g, many, root, width),
+        }
+    }
     // A gap, unless there already is one: what came before was often a tool card, which has no
     // trailing blank of its own, and the next thing butted against it reads as part of it.
     fn gap(lines: &mut Vec<String>) {
@@ -5876,7 +6174,11 @@ fn transcript(
                 }
                 ContentBlock::Text { text } => {
                     // Through the same renderer the live stream uses, so switching away and back
-                    // does not change what an answer looks like.
+                    // does not change what an answer looks like — and behind the same blank row,
+                    // which `open_answer_row` puts there live and this used to leave out. Nothing
+                    // showed while a card had no air of its own; the moment one did, a sentence
+                    // after a card was the only thing on the screen still butted against it.
+                    gap(&mut lines);
                     let at = lines.len() as u32;
                     let (rendered, styled) = crate::markdown::render(text);
                     marks.extend(
@@ -5888,33 +6190,51 @@ fn transcript(
                 // Gated on the same setting the live path uses. Drawn unconditionally, switching
                 // conversations with tool cards off made them all appear.
                 ContentBlock::ToolUse { id, name, input } if show_tools => {
-                    // The dot says how it went, which the conversation already records: a call
+                    // The mark says how it went, which the conversation already records: a call
                     // with a result somewhere after it is finished, and one without is still
                     // running. Nothing here has to remember anything.
-                    let (state, exit, output) = match answered.get(id) {
-                        Some((true, exit, n)) => (ToolState::Failed, *exit, Some(*n)),
-                        Some((false, _, n)) => (ToolState::Done, None, Some(*n)),
-                        None => (ToolState::Running, None, None),
+                    let exit = match answered.get(id) {
+                        Some((true, exit, _)) => *exit,
+                        _ => None,
                     };
-                    let head = cards::Head { name, input, state, took: None, exit, output };
-                    let card = cards::header(&g, &head, root, width);
-                    let at = lines.len() as u32;
-                    cards.push(Card {
+                    let leg = Leg {
                         id: id.clone(),
                         name: name.clone(),
                         input: input.clone(),
+                        // The result is filled in when its block is reached, which is what puts a
+                        // body under the right header. The *header* cannot wait for that — it is
+                        // written now, from `answered`, or a restored transcript would show every
+                        // call as running until the second pass.
                         result: None,
                         // Nothing here watched the call happen, so nothing here can say how long it
                         // took. A restored transcript is a record, not a replay.
                         started: None,
                         took: None,
                         exit,
-                        row: at,
-                        body: 0,
-                        expanded: false,
-                    });
-                    marks.extend(Mark::of(at, &card));
-                    lines.push(card.text.clone());
+                    };
+                    // Onto the run above when there is one and nothing has been drawn since — the
+                    // same rule the live path uses, because the two have to produce the same rows.
+                    let open = cards
+                        .last()
+                        .filter(|c| c.row + c.body + 1 == lines.len() as u32)
+                        .is_some_and(|c| c.takes(input));
+                    let at = if open {
+                        let i = cards.len() - 1;
+                        cards[i].legs.push(leg);
+                        cards[i].row
+                    } else {
+                        // The row of air the live path puts between one action and the next.
+                        gap(&mut lines);
+                        let at = lines.len() as u32;
+                        cards.push(Card::new(leg, at));
+                        lines.push(String::new());
+                        at
+                    };
+                    let i = cards.len() - 1;
+                    let row = header_of(&g, &cards[i], &answered, root, width);
+                    marks.retain(|m| m.row != at);
+                    marks.extend(Mark::of(at, &row));
+                    lines[at as usize] = row.text;
                 }
                 ContentBlock::ToolUse { .. } => {}
                 // Errors show even with tool cards off, exactly as they do live: the setting is
@@ -5926,18 +6246,28 @@ fn transcript(
                         content: content.clone(),
                         is_error: *is_error,
                     };
-                    match cards.iter().rposition(|c| c.id == *tool_use_id) {
+                    let found = cards
+                        .iter()
+                        .enumerate()
+                        .rev()
+                        .find_map(|(i, c)| c.leg_of(tool_use_id).map(|k| (i, k)));
+                    match found {
                         // Under its own header, however many other calls came between.
-                        Some(i) => {
+                        Some((i, k)) => {
                             if !*is_error {
-                                cards::tally(&mut changes, &cards::edits_of(&cards[i].input));
+                                cards::tally(&mut changes, &cards::edits_of(&cards[i].legs[k].input));
                             }
-                            let rows =
-                                cards::body(&g, &cards[i].input, &result, limits, false, width);
+                            // A run holds its calls' answers and shows none of them: it is one row
+                            // until somebody opens it, exactly as it is live.
+                            let rows = if cards[i].legs.len() > 1 {
+                                Vec::new()
+                            } else {
+                                cards::body(&g, &cards[i].legs[k].input, &result, limits, false, width)
+                            };
                             let n = rows.len() as u32;
                             let at = cards[i].row + 1;
                             insert(&mut lines, &mut marks, &mut cards, at, rows);
-                            cards[i].result = Some(result);
+                            cards[i].legs[k].result = Some(result);
                             cards[i].body = n;
                         }
                         // No card to go under — cards are off and this is an error — so at the

--- a/crates/neosh/src/sessions.rs
+++ b/crates/neosh/src/sessions.rs
@@ -58,6 +58,14 @@ struct Stored {
     /// still reaches every conversation that never overrode it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     permission_mode: Option<neosh_proto::PermissionMode>,
+    /// What the driver calls this conversation on its own side.
+    ///
+    /// The one field here that is *only* useful once this process is gone. A vendor CLI keeps the
+    /// history and hands back a handle; without this, reopening a conversation after a restart
+    /// starts an agent that has never heard of it, and the transcript on screen is the only place
+    /// any of it still exists. See [`neosh_proto::TurnRequest::resume`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    resume: Option<String>,
     /// The system prompt is *not* stored. It comes from configuration, and a stale copy pinned into
     /// a saved session would silently outrank the one the user edited.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -108,6 +116,7 @@ impl From<&Session> for Stored {
             archived: s.archived,
             archived_at: s.archived_at,
             permission_mode: s.permission_mode,
+            resume: s.resume.clone(),
             _reserved: None,
         }
     }
@@ -128,6 +137,7 @@ impl Stored {
         s.archived = self.archived;
         s.archived_at = self.archived_at;
         s.permission_mode = self.permission_mode;
+        s.resume = self.resume;
         s
     }
 }
@@ -270,6 +280,33 @@ mod tests {
         assert_eq!(loaded[0].messages.len(), 1);
         assert_eq!(loaded[0].usage.input_tokens, 7);
         assert_eq!(loaded[0].cwd, original.cwd);
+    }
+
+    /// The one value here whose whole purpose is to outlive the process that learned it.
+    ///
+    /// A vendor CLI keeps the conversation on its side and hands back a handle. Lose the handle and
+    /// reopening a conversation starts an agent that has never heard of it: the transcript is full,
+    /// the model knows nothing, and the first thing that visibly breaks is `/compact` finishing at
+    /// once with nothing to compact.
+    #[test]
+    fn what_the_driver_calls_a_conversation_survives_the_workspace() {
+        let t = tmp("resume");
+        let mut known = session("carry on");
+        known.resume = Some("4db87a5d-8bc3-41ec-a044-ea6d2d683503".into());
+        let fresh = session("never run");
+        save(&t.0, &known).expect("save");
+        save(&t.0, &fresh).expect("save");
+
+        let (loaded, _) = load(&t.0);
+        let of = |id: &neosh_proto::SessionId| {
+            loaded.iter().find(|s| &s.id == id).expect("saved").resume.clone()
+        };
+        assert_eq!(of(&known.id).as_deref(), Some("4db87a5d-8bc3-41ec-a044-ea6d2d683503"));
+        assert_eq!(
+            of(&fresh.id),
+            None,
+            "a conversation no driver has run yet has nothing to pick up, and starting fresh is right"
+        );
     }
 
     /// A mode you chose for one conversation is a decision, not a mood.

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -2864,6 +2864,65 @@ export async function activate({ neosh }: PluginContext) {
 }
 "#;
 
+const LOOKER: &str = r#"
+import type { PluginContext } from "@neosh/api";
+
+export async function activate({ neosh }: PluginContext) {
+  const lines = (n: number) => Array.from({ length: n }, (_, i) => `line ${i + 1}`).join("\n");
+  await neosh.tool.register(
+    { name: "look", description: "Read", inputSchema: { type: "object" } },
+    async () => ({ content: lines(9) }),
+  );
+  await neosh.tool.register(
+    { name: "hunt", description: "Grep", inputSchema: { type: "object" } },
+    async () => ({ content: lines(4) }),
+  );
+  await neosh.tool.register(
+    { name: "edit", description: "Edit", inputSchema: { type: "object" } },
+    async () => ({ content: "edited" }),
+  );
+  let turn = 0;
+  await neosh.provider.register("looker", [{
+    id: "looker", driver: "looker", display_name: "Looker",
+    models: [{ id: "looker", display_name: "Looker" }],
+  }], async (_req, emit) => {
+    emit({ type: "message_start", model: "looker", usage: {} });
+    const call = (i: number, name: string, input: unknown) => {
+      emit({ type: "block_start", index: i, block: { kind: "tool_use", id: `t${turn}_${i}`, name } });
+      emit({ type: "tool_input_delta", index: i, partial_json: JSON.stringify(input) });
+      emit({ type: "block_stop", index: i });
+    };
+    turn += 1;
+    if (turn === 1) {
+      call(0, "look", { file_path: "/work/src/one.rs" });
+      call(1, "look", { file_path: "/work/src/two.rs" });
+      call(2, "hunt", { pattern: "fn main", path: "/work/src" });
+      call(3, "edit", { file_path: "/work/src/one.rs", old_string: "a", new_string: "b" });
+      emit({ type: "message_delta", stop_reason: { kind: "tool_use" }, usage: {} });
+      emit({ type: "message_stop" });
+      return;
+    }
+    emit({ type: "block_start", index: 0, block: { kind: "text" } });
+    emit({ type: "text_delta", index: 0, text: "Looked." });
+    emit({ type: "block_stop", index: 0 });
+    emit({ type: "message_delta", stop_reason: { kind: "end_turn" }, usage: {} });
+    emit({ type: "message_stop" });
+  });
+  neosh.notify("looker ready");
+}
+"#;
+
+fn install_looker(sb: &Sandbox) {
+    let dir = sb.root.join("config/plugins/looker");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    std::fs::write(
+        dir.join("plugin.toml"),
+        "name = \"looker\"\nversion = \"0.1.0\"\nentry = \"main.ts\"\npermissions = [\"providers\", \"tools\"]\n",
+    )
+    .expect("manifest");
+    std::fs::write(dir.join("main.ts"), LOOKER).expect("plugin");
+}
+
 fn install_editor(sb: &Sandbox) {
     let dir = sb.root.join("config/plugins/editor");
     std::fs::create_dir_all(&dir).expect("mkdir");
@@ -2929,16 +2988,16 @@ fn a_question_is_framed_so_you_can_find_where_a_turn_began() {
 
 #[test]
 fn a_tool_call_says_what_it_is_about_not_only_its_name() {
-    // `read_file` tells you nothing you did not already know. `read_file  .env` is the line you
-    // actually wanted, and it costs one lookup in the input the tool was given.
+    // The tool's name tells you nothing you did not already know. `Read  .env` is the line you
+    // actually wanted, and both halves of it cost one lookup in the input the tool was given.
     let sb = Sandbox::new("toolrow");
     let mut s = sb.start();
     s.wait_for("PROJECTS");
     s.key("h");
     s.enter();
     assert!(
-        s.pump(|s| s.chat_now().iter().any(|l| l.contains("read_file") && l.contains(".env"))),
-        "the subject is beside the name\n{:?}",
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("Read") && l.contains(".env"))),
+        "the subject is beside what was done\n{:?}",
         s.chat_now()
     );
 }
@@ -3935,8 +3994,16 @@ fn what_is_queued_sits_above_the_composer_and_says_how_to_take_it_back() {
         s.composer_chrome()
     );
     assert!(
-        s.composer_chrome().iter().any(|t| t.contains("edit")),
-        "with the key that undoes it\n{:?}",
+        s.composer_chrome().iter().any(|t| t.contains("take back")),
+        "with the key that undoes it, saying what it does rather than naming the operation\n{:?}",
+        s.composer_chrome()
+    );
+    // And the field itself says what `\u{23ce}` does now. "Ask anything" while a turn is running
+    // invites the one thing you cannot do and says nothing about the thing you can, which is how a
+    // sentence disappears into a queue nobody knew was there.
+    assert!(
+        s.composer_chrome().iter().any(|t| t.contains("Steer it")),
+        "and the empty field says what sending does now\n{:?}",
         s.composer_chrome()
     );
     assert!(
@@ -4088,7 +4155,7 @@ fn a_question_gets_a_gap_above_it_and_keeps_its_bar() {
     s.type_text("go");
     s.enter();
     assert!(
-        s.pump(|s| s.chat_now().iter().any(|l| l.contains("read_file"))),
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("Read  .env"))),
         "the turn ran\n{:?}",
         s.chat_now()
     );
@@ -4131,7 +4198,7 @@ fn a_tool_calls_dot_says_whether_it_is_still_going() {
     assert!(
         s.pump(|s| {
             let rows = s.chat_now();
-            let Some(at) = rows.iter().position(|l| l.contains("read_file  .env")) else {
+            let Some(at) = rows.iter().position(|l| l.contains("Read  .env")) else {
                 return false;
             };
             // Failed, because `.env` is not there — which is the point: the dot reports how it
@@ -4195,14 +4262,16 @@ fn how_much_of_a_tool_result_to_show_is_a_setting() {
         s.chat_now()
     );
     let rows = s.chat_now();
-    assert!(rows.iter().any(|l| l.contains("one")), "the first line is there\n{rows:?}");
-    assert!(rows.iter().any(|l| l.contains("two")), "and the second\n{rows:?}");
+    assert!(rows.iter().any(|l| l.contains("one")), "one line of head is there\n{rows:?}");
+    // Folded from the *middle*: what a command decided is at the end of what it printed, and a
+    // card that keeps the first two lines of `cargo test` keeps `Compiling` and `Finished`.
+    assert!(rows.iter().any(|l| l.contains("five")), "and the line it ended on\n{rows:?}");
     assert!(
         !rows.iter().any(|l| l.contains("three")),
         "and the setting stopped it there\n{rows:?}"
     );
     assert!(
-        rows.iter().any(|l| l.contains("+3 more lines")),
+        rows.iter().any(|l| l.contains("+3 lines")),
         "saying how much was left out, because a result that is silently cut is a result you \
          would believe\n{rows:?}"
     );
@@ -4218,7 +4287,7 @@ fn a_tool_call_says_what_came_back_not_only_that_it_ran() {
     s.type_text("go");
     s.enter();
     assert!(
-        s.pump(|s| s.chat_now().iter().any(|l| l.contains("read_file  .env"))),
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("Read  .env"))),
         "the call is shown with its subject\n{:?}",
         s.chat_now()
     );
@@ -4232,7 +4301,7 @@ fn a_tool_call_says_what_came_back_not_only_that_it_ran() {
 
 #[test]
 fn an_edit_card_shows_the_change_and_how_much_of_it() {
-    // `⏺ edit(main.rs)` and "edited" underneath says that something happened. The diff says what,
+    // `edit(main.rs)` and "edited" underneath says that something happened. The diff says what,
     // the `+2 -1` says how much, and the row at the end of the turn adds it up — which is the
     // difference between a transcript you can review and one you have to take on trust.
     let sb = Sandbox::new("editcard");
@@ -4250,7 +4319,7 @@ fn an_edit_card_shows_the_change_and_how_much_of_it() {
     let rows = s.chat_now();
     let header = rows
         .iter()
-        .position(|l| l.starts_with('\u{23fa}') && l.contains("edit  ") && l.contains("main.rs"))
+        .position(|l| l.starts_with("  Edited  ") && l.contains("main.rs"))
         .expect("the card's header");
     assert!(
         rows[header].ends_with("+2 -1"),
@@ -4275,6 +4344,90 @@ fn an_edit_card_shows_the_change_and_how_much_of_it() {
 }
 
 #[test]
+fn calls_that_only_looked_at_things_share_one_row_and_open_into_several() {
+    // A turn that reads three files used to be three cards, each with a mark down the left and a
+    // slice of the file under it. What you wanted was the *list of what it looked at*, which is
+    // exactly what those bodies were holding apart. So the run is one row — and the edit that
+    // follows is not part of it, because a diff is an answer and not a name.
+    let sb = Sandbox::new("looks");
+    install_looker(&sb);
+    sb.write_config("[options]\n\"agent.model\" = \"looker/looker\"\n");
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("looker ready");
+    s.type_text("go");
+    s.enter();
+    assert!(
+        s.pump(|s| {
+            let rows = s.chat_now();
+            rows.iter().any(|l| l.contains("Looked."))
+                && !rows.iter().any(|l| l.contains("esc to interrupt"))
+        }),
+        "the turn finished\n{:?}",
+        s.chat_now()
+    );
+    let rows = s.chat_now();
+    let run = rows
+        .iter()
+        .position(|l| l.starts_with("  Explored  "))
+        .unwrap_or_else(|| panic!("the run is one row\n{rows:?}"));
+    assert_eq!(
+        rows[run], "  Explored  one.rs, two.rs, fn main",
+        "named, shortest first-glance form\n{rows:?}"
+    );
+    assert!(
+        !rows.iter().any(|l| l.contains("line 1")),
+        "and nothing any of them came back with\n{rows:?}"
+    );
+    assert!(
+        !rows.iter().any(|l| l.starts_with('\u{23fa}')),
+        "no card carries the old dot\n{rows:?}"
+    );
+    // The edit is its own card, right under the run, with its diff.
+    assert!(rows[run + 2].starts_with("  Edited  "), "with a row of air between\n{rows:?}");
+    assert!(rows.iter().any(|l| l.ends_with("- a")), "the edit kept its diff\n{rows:?}");
+
+    // Opened, one row per call, with the whole subject and how much came back.
+    s.ctrl("s");
+    s.key("g");
+    s.key("g");
+    for _ in 0..run {
+        s.key("j");
+    }
+    s.special("tab");
+    assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("Read  /work/src/one.rs"))),
+        "open, every call is named in full\n{:?}",
+        s.chat_now()
+    );
+    let open = s.chat_now();
+    assert!(open.iter().any(|l| l.contains("Read  /work/src/two.rs  9 lines")), "{open:?}");
+    assert!(open.iter().any(|l| l.contains("Searched  fn main  4 lines")), "{open:?}");
+    assert_eq!(open[run], rows[run], "the header did not move or change\n{open:?}");
+
+    // And the same rows come back after switching away and back, which is the whole reason the
+    // live path and the replay go through one renderer.
+    s.special("esc");
+    let live: Vec<String> = s.chat_now().into_iter().filter(|l| !l.trim().is_empty()).collect();
+    s.send(&command("session.new"));
+    assert!(s.pump(|s| !s.chat_now().iter().any(|l| l.contains("Looked."))), "somewhere else");
+    s.send(&command("session.close"));
+    assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("Looked."))),
+        "and back\n{:?}",
+        s.chat_now()
+    );
+    let back = s.chat_now();
+    assert!(
+        back.iter().any(|l| l == "  Explored  one.rs, two.rs, fn main"),
+        "the replay folds the run exactly as the live stream did\nlive: {live:?}\nback: {back:?}"
+    );
+    assert!(
+        !back.iter().any(|l| l.contains("line 1")),
+        "and does not unfold it\n{back:?}"
+    );
+}
+
+#[test]
 fn a_folded_card_opens_with_tab_while_reading_and_folds_again() {
     // A card shows enough to know what happened. The whole of it is one key away, in the place
     // you go to read — and the trailer says which key.
@@ -4291,11 +4444,11 @@ fn a_folded_card_opens_with_tab_while_reading_and_folds_again() {
         s.chat_now()
     );
     let rows = s.chat_now();
-    let trailer = rows.iter().find(|l| l.contains("more lines")).expect("a trailer");
-    assert!(trailer.contains("+6 more lines"), "{trailer}");
+    let trailer = rows.iter().find(|l| l.contains(" lines (")).expect("a trailer");
+    assert!(trailer.contains("+6 lines"), "{trailer}");
     assert!(trailer.contains("^S \u{21e5} to expand"), "it says how: {trailer}");
     assert!(!rows.iter().any(|l| l.ends_with("+ i")), "the end of the diff is folded away\n{rows:?}");
-    let header = rows.iter().position(|l| l.starts_with('\u{23fa}')).expect("the header");
+    let header = rows.iter().position(|l| l.starts_with("  Edited  ")).expect("the header");
 
     // Into the transcript, to the top, and down onto the card.
     s.ctrl("s");
@@ -4311,7 +4464,7 @@ fn a_folded_card_opens_with_tab_while_reading_and_folds_again() {
         s.chat_now()
     );
     let rows = s.chat_now();
-    assert!(!rows.iter().any(|l| l.contains("more lines")), "and nothing is held back\n{rows:?}");
+    assert!(!rows.iter().any(|l| l.contains(" lines (")), "and nothing is held back\n{rows:?}");
     assert!(
         rows.iter().position(|l| l.contains("changed 1 file")).unwrap() > header,
         "what was below the card is still below it\n{rows:?}"
@@ -4319,7 +4472,7 @@ fn a_folded_card_opens_with_tab_while_reading_and_folds_again() {
 
     s.special("tab");
     assert!(
-        s.pump(|s| s.chat_now().iter().any(|l| l.contains("+6 more lines"))),
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("+6 lines"))),
         "and it folds again\n{:?}",
         s.chat_now()
     );

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -3830,6 +3830,9 @@ fn an_answer_is_rendered_as_markdown_while_it_streams() {
 fn a_rendered_answer_looks_the_same_after_switching_away_and_back() {
     // Two renderers is how a reopened conversation stops looking like the one you were just in.
     let sb = Sandbox::new("mdreplay");
+    // Not asked before closing: these use `session.close` as a way to *leave* a conversation and
+    // come back, and the confirmation is a different test's subject.
+    sb.write_config("[options]\n\"ui.confirm_destructive\" = false\n");
     let mut s = sb.spawn(&markdown_fixture(), Some("mock/mock"));
     s.wait_for("PROJECTS");
     s.type_text("tell me");
@@ -4351,7 +4354,11 @@ fn calls_that_only_looked_at_things_share_one_row_and_open_into_several() {
     // follows is not part of it, because a diff is an answer and not a name.
     let sb = Sandbox::new("looks");
     install_looker(&sb);
-    sb.write_config("[options]\n\"agent.model\" = \"looker/looker\"\n");
+    // Not asked before closing: these use `session.close` as a way to *leave* a conversation and
+    // come back, and the confirmation is a different test's subject.
+    sb.write_config(
+        "[options]\n\"agent.model\" = \"looker/looker\"\n\"ui.confirm_destructive\" = false\n",
+    );
     let mut s = sb.start_letting_config_choose();
     s.wait_for("looker ready");
     s.type_text("go");
@@ -4525,7 +4532,10 @@ fn the_footer_says_what_the_agent_may_do_and_which_key_changes_it() {
 #[test]
 fn a_permission_mode_belongs_to_the_conversation_it_was_chosen_in() {
     let sb = Sandbox::new("permsession");
-    let mut s = sb.start();
+    // Not asked before closing: these use `session.close` as a way to *leave* a conversation and
+    // come back, and the confirmation is a different test's subject.
+    sb.write_config("[options]\n\"ui.confirm_destructive\" = false\n");
+    let mut s = sb.start_letting_config_choose();
     assert!(
         s.pump(|s| s.status_now().iter().any(|l| l.contains("full access"))),
         "the configured default to start from\n{:?}",

--- a/crates/neosh/tests/reading.rs
+++ b/crates/neosh/tests/reading.rs
@@ -524,6 +524,77 @@ fn a_capital_in_the_query_makes_the_search_case_sensitive() {
 /// under the composer says what they are — whatever `ui.hints` is set to, since that setting is
 /// about the *typing* shortcuts and this is not typing.
 #[test]
+fn a_chord_while_reading_is_not_the_letter_it_is_made_of() {
+    // Two ways a reading key was quietly taken. `^D` is bound to `git.diff` in `chat` mode, and
+    // reading's keys arrive only through the *unbound* path — so it opened a diff instead of
+    // moving half a screen. And `^B` did reach `reading_key`, but was matched by the `b` arm of
+    // the motion table on the way past, so it moved a word left. Half of a documented vim
+    // vocabulary, taken by a plugin and by a letter.
+    let sb = Sandbox::new("chords");
+    let mut s = sb.start();
+    s.answered_and_reading();
+    s.to_top();
+
+    // Down half a screen. The transcript is longer than the window, so the row has to change.
+    s.press(json!({"kind": "char", "c": "d"}), &["ctrl"]);
+    assert!(
+        s.pump(|s| s.chat_cursor().is_some_and(|r| r > 0)),
+        "^D moved rather than opening a diff\n{:?}",
+        s.messages()
+    );
+    let down = s.chat_cursor().unwrap_or(0);
+
+    // Back a screen — not a word left, which would leave the cursor on the same row.
+    s.press(json!({"kind": "char", "c": "b"}), &["ctrl"]);
+    assert!(
+        s.pump(|s| s.chat_cursor().is_some_and(|r| r < down)),
+        "^B went back a screen rather than a word\n{down} -> {:?}",
+        s.chat_cursor()
+    );
+
+    // And `^Y`, whose letter is the yank prefix, is a line up rather than a pending operator.
+    s.press(json!({"kind": "char", "c": "d"}), &["ctrl"]);
+    assert!(s.pump(|s| s.chat_cursor().is_some_and(|r| r > 0)), "somewhere with room above");
+    let at = s.chat_cursor().unwrap_or(0);
+    s.press(json!({"kind": "char", "c": "y"}), &["ctrl"]);
+    assert!(
+        s.pump(|s| s.chat_cursor() == Some(at - 1)),
+        "^Y moved one line up\n{at} -> {:?}",
+        s.chat_cursor()
+    );
+}
+
+#[test]
+fn a_mode_gets_its_own_keys_and_nobody_elses() {
+    // The rule, said plainly: while you are here, `^X` cutting a composer you cannot see and `^A`
+    // selecting it are not things you asked for — they are the mode you left still holding the
+    // keyboard. Only the escape hatches are bound everywhere.
+    let sb = Sandbox::new("modekeys");
+    let mut s = sb.start();
+    s.answered_and_reading();
+    s.to_top();
+    let before = s.chat();
+
+    // `^A`, `^X` and `^W` are the composer's, and `Chat`'s alone. `^Y` is *both* — the queue's
+    // there and a line up here — which is the whole point of a mode: the same key, asked of a
+    // different place, and only one answer arrives.
+    for c in ["a", "x", "w"] {
+        s.press(json!({"kind": "char", "c": c}), &["ctrl"]);
+    }
+    assert!(
+        s.pump(|s| s.chat_cursor() == Some(0)),
+        "none of them moved the cursor\n{:?}",
+        s.chat_cursor()
+    );
+    assert!(
+        s.buffer("[status]").iter().any(|l| l.contains("reading")),
+        "and none of them took the keyboard back\n{:?}",
+        s.buffer("[status]")
+    );
+    assert_eq!(s.chat(), before, "and none of them changed the transcript");
+}
+
+#[test]
 fn reading_says_what_its_keys_do() {
     let sb = Sandbox::new("readhints");
     let mut s = sb.start();

--- a/crates/neosh/tests/sessions.rs
+++ b/crates/neosh/tests/sessions.rs
@@ -601,7 +601,7 @@ fn a_restored_conversation_still_has_its_tool_cards() {
     s.drain_for(Duration::from_millis(300));
     let now = s.chat_now();
     assert_eq!(
-        now.iter().filter(|l| l.contains("list_dir")).count(),
+        now.iter().filter(|l| l.contains("Read  src")).count(),
         1,
         "the tool it called came back with it\n{now:?}"
     );
@@ -824,7 +824,7 @@ fn coming_back_to_a_running_agent_turn_shows_what_it_has_done() {
     // of that header is read off the result — so a card saying `1 line` is a card whose answer came
     // back with the replay, which is the whole point of this test.
     assert!(
-        now.iter().any(|l| l.contains("list_dir") && l.contains("1 line")),
+        now.iter().any(|l| l.contains("Read  src") && l.contains("1 line")),
         "and the tool it called, with what it came back with\n{now:?}"
     );
     assert!(
@@ -876,7 +876,7 @@ fn a_finished_agent_turn_is_drawn_from_the_conversation_and_not_twice() {
         );
     }
     assert_eq!(
-        now.iter().filter(|l| l.contains("list_dir")).count(),
+        now.iter().filter(|l| l.contains("Read  src")).count(),
         1,
         "and so does the tool it called\n{now:?}"
     );
@@ -1124,9 +1124,10 @@ fn a_call_that_has_not_come_back_says_how_long_it_has_been() {
     // Two ticks of the one-second clock, so the number has moved at least once.
     s.drain_for(Duration::from_millis(2400));
     let rows = s.chat_now();
-    // The card, not the working line under it, which names the tool too.
+    // The card, not the working line under it, which names the tool too. A call still out wears
+    // the one mark a card ever has, so this is also what proves the mark is there while it runs.
     let cards: Vec<&String> =
-        rows.iter().filter(|l| l.starts_with('\u{23fa}') && l.contains("wait_forever")).collect();
+        rows.iter().filter(|l| l.starts_with('\u{25b8}') && l.contains("wait_forever")).collect();
     assert_eq!(cards.len(), 1, "still one card, not one per tick\n{rows:?}");
     let clock = cards[0].rsplit("  ").next().unwrap_or_default();
     assert!(
@@ -1176,7 +1177,7 @@ fn a_round_the_conversation_already_holds_is_not_replayed_on_top_of_itself() {
     );
     assert_eq!(
         // The card, not the working line, which says the same words for as long as the tool runs.
-        now.iter().filter(|l| l.starts_with('\u{23fa}')).count(),
+        now.iter().filter(|l| l.starts_with('\u{25b8}')).count(),
         1,
         "and so is the call it ended on\n{now:?}"
     );

--- a/docs/adr/0039-a-conversation-outlives-the-agent-holding-it.md
+++ b/docs/adr/0039-a-conversation-outlives-the-agent-holding-it.md
@@ -1,0 +1,62 @@
+# 0039 — A conversation outlives the agent holding it
+
+**Status:** accepted
+
+## Context
+
+An agent driver does not send the conversation. `claude` in stream-json mode takes one prompt at a
+time and keeps the history on its own side; `codex app-server` and ACP do the same. What comes back
+is a handle — a session id — and the deal is that handing it over next time is what makes the second
+turn a continuation of the first rather than a fresh start.
+
+neosh honoured half of that deal. `ClaudeCliProvider` kept the handle in `Live::session`, in memory,
+inside the conversation's slot, and used it when it had to replace the process mid-run: a change of
+directory or of permission mode relaunches the CLI, and the replacement carried `--resume` so the
+turn continued where it left off. Within one workspace this was invisible and correct.
+
+Across two, it was neither. Nothing wrote the handle down. Stop the workspace, start it again, open
+a conversation with a hundred messages in it, and the driver had no handle to offer — so it spawned
+a CLI that had never heard of any of it and told it only the newest thing you said. The transcript
+on screen was complete. The agent's memory was one line long. **Neither side reports this**, because
+from the driver's point of view a new conversation is a perfectly ordinary thing to start.
+
+What made it visible was `/compact` finishing in three seconds. Compaction is a summarisation call:
+measured against a real CLI it takes fourteen seconds on a twenty-thousand-token conversation and
+longer on a large one. Three seconds is the CLI answering `Error: No messages to compact` — the only
+externally visible symptom of an agent that had forgotten everything, and it reads as a feature that
+does not work rather than as a conversation that is gone.
+
+## Decision
+
+**The handle belongs to the conversation.** `Session::resume` holds what the driver called this
+conversation, it is persisted in the session file beside the messages, and it is handed back on
+every turn as `TurnRequest::resume`. A driver that keeps state on its own side reads that field
+instead of hoping a process from earlier is still around.
+
+**The driver says the handle out loud.** `Activity::Resume { token }` is how it travels — the same
+family as everything else a driver's loop reports about itself, and for the same reason: it is not
+content, `TurnAssembler` never reads it, and the host is what keeps it. Said whenever it changes
+rather than once, because resuming does not always keep the id it was given, and a conversation
+filed under an id the CLI has stopped using resumes into a history missing everything since.
+
+**A handle that no longer resolves is thrown away, not reported.** The CLI says
+`No conversation found with session ID` on an ordinary `result` line with `is_error`. The driver
+recognises that one sentence, forwards nothing, and the turn is run again from the top without the
+handle. The history is already lost at that point — the user's own `~/.claude` was cleared, or the
+project moved — and failing the turn as well would add a second loss to the first. Retried exactly
+once, so a driver that says it about every attempt cannot loop.
+
+## Consequences
+
+A conversation reopened next week is the conversation, not a transcript of one. `/compact` compacts.
+The context meter, which reads the CLI's own accounting, is about the conversation you are looking
+at rather than about a session that has just started.
+
+`Activity::Resume` is deliberately not claude-specific: `codex`'s conversation id and ACP's session
+are the same shape of value with the same lifetime problem, and they can be moved onto it without a
+second mechanism. They have not been yet — ACP is the case that needs thinking about, because its
+session lives on the agent's side and an agent that is not running has no session to resume.
+
+What is stored is an opaque handle to history the vendor CLI already keeps on disk. It is not a
+secret and it is not content, but it does point at a transcript: `sessions.rs` was already the file
+holding everything you said, and this does not widen what is on disk.

--- a/docs/adr/0040-a-turn-that-read-six-files-is-one-row.md
+++ b/docs/adr/0040-a-turn-that-read-six-files-is-one-row.md
@@ -1,0 +1,161 @@
+# 0040 — A turn that read six files is one row
+
+**Status:** accepted
+
+## Context
+
+ADR 0033 gave a tool call a card: a state dot, the tool's name, its subject, and — for a call that
+only *looked* at something — nothing under it, because the answer to "did the read work" is almost
+always "yes, and it was what you would expect". That fixed the bodies. It left the headers.
+
+A real turn opens by reading three files, grepping twice and listing a directory. That is six
+cards, which is six rows, which on a forty-row terminal is a sixth of the screen — and every one of
+those rows opens with the same filled circle in the same colour saying the same thing. The
+information in the block is six names. The block is six rows tall.
+
+Two specific complaints, and they turn out to be the same one:
+
+1. **The dot.** `⏺` is `U+23FA`, a record button. It is wide, it is the leftmost thing on the row,
+   and it appears on every card whatever happened. A mark that is on every row of a column is a
+   mark the eye stops reading by the third one — so it costs two columns and a lot of ink to say
+   "this happened", which is what a card being there already says.
+2. **The height.** Six rows for six names.
+
+Put beside the references: `codex` groups a run of reads under one `Explored` header with `└`
+continuation rows and merges consecutive reads onto one of them; `claude-code` collapses the whole
+run to a single dim line — `Read 3 files, searched for 1 pattern` — with a spinner and a live hint
+of the current file while it is going; `pi` draws no marker at all, just `read src/main.rs` in the
+tool's colour, and hides the result entirely unless you expand it. Three different programs, one
+agreement: **the per-call row is not the unit a reader wants for calls that only looked at
+something.**
+
+## Decision
+
+**A mark appears only when the state is news.** A call still out gets `▸`, pulsing, and it is then
+the one moving thing in the transcript. A call that failed gets `✗` in red. A call that finished
+gets two blanks of the same width. Nothing is lost: the kind is still the colour of the name, the
+failure still shows, and the column of names still lines up — the body's rule now sits directly
+under the name it belongs to, which it always should have. `Agent.ToolDone` is gone from the
+palette, because there is no longer anything for it to paint.
+
+**A run of calls that only looked at things shares one card.**
+
+```text
+  Explored  host.rs, cards.rs, diff.rs, fn header, **/*.rs
+```
+
+The names rather than a count. `Read 3 files` is one row and `codex`'s `└ Read a, b, c` is two, and
+the thing you actually wanted from those six rows was the six names — so the row carries as many as
+fit, whole, and `+N more` for the rest. Never half a name: `cards.r…` is a file that does not
+exist, and `+2 more` is a fact.
+
+It is called what the tools call themselves when they agree — three `Read`s are still reads, and
+inventing a friendlier word for a tool is the thing ADR 0033 already refused to do. `Explored` only
+for a mixture, where no one name would be true, and `Exploring` while any of it is still out.
+
+**A run is calls with nothing drawn between them.** Not "calls in the same message", not "calls of
+the same kind": if a sentence, a diff, a command's output or another card has been drawn since,
+the reader has been told something else and the run is over. Both the live path and the replay ask
+the same question the same way — *is this card still the last row of the transcript* — which is why
+switching away and back cannot re-fold a conversation differently from how you left it.
+
+**Only calls that looked at something ever share.** A command's output is the answer and an edit's
+diff is the answer; there is no summarising either into a list of names. The rule is the one from
+ADR 0033, unchanged: [`cards::looks_at_something`], read off the arguments rather than a list of
+tool names, so a plugin's tool joins a run tomorrow without anybody adding it to anything.
+
+**`⇥` opens the run into a row per call**, with the whole subject and how much came back:
+
+```text
+  Explored  one.rs, two.rs, fn main
+  │ Read  crates/neosh/src/one.rs  120 lines
+  │ Read  crates/neosh/src/two.rs  86 lines
+  │ Grep  fn main  4 lines
+```
+
+The short names on the folded row are the loose answer and this is where it is exact. It stops
+there — the *contents* of the six files is what the fold existed to keep out of the transcript, and
+a single read that was never part of a run is still an ordinary card whose `⇥` gives you the file.
+
+**A call is about what it looked for before where it looked.** A grep is `{pattern, path}` and the
+subject used to be the path, so a turn that grepped three different things showed `src`, `src`,
+`src`. The pattern is the answer to "what was that call"; the path is a directory the model picked,
+usually the one you are already in. Reading and writing name no pattern, so they still get a path.
+
+## Consequences
+
+- `Card` holds `legs: Vec<Leg>` rather than one call. One leg is the ordinary case and renders
+  exactly as before; several is a run. `finish_card` resolves `(card, leg)` by id, and a result
+  arriving for a leg of a folded run draws nothing, which is the point.
+- **A run costs no rows while it happens.** The header is rewritten in place as each call starts,
+  so a turn that reads six files never pushes six rows and takes them back. It used to.
+- Nothing says on the row that a run can be opened. The `^S` hint strip already says `⇥ expand`
+  when the cursor is on a card that has something to show, and a permanent `(⇥ to expand)` on every
+  run would be noise on the row this ADR exists to shorten.
+- `Glyphs::dot` is gone, replaced by `live` and `fail`. `compaction` draws with a finished call's
+  blank, which is what it is.
+- The mark and the subject animate differently and deliberately: `Agent.ToolRunning` pulses a
+  single glyph, `Agent.ToolLive` sweeps a run of text. A band travelling along the list of things
+  being read is legible from across the room; a glyph brightening is not, and a glyph is all the
+  mark is.
+- Two calls to the *same* file in one run are named twice. `codex` de-duplicates. Left alone: two
+  reads of one file is a fact about the turn, and a list that quietly drops one is a list you
+  cannot count.
+
+## What was added afterwards: a card says what happened
+
+The rows got shorter and still did not read. `Bash`, `Agent`, `Grep`, `Broken`, `Edit` down the
+left of a turn is a list of *mechanisms*, and it asks the reader to know what each of those is
+before the transcript says anything. Beside `codex` — `Explored`, `Ran`, `Read`, `Search` — the
+difference is not density, it is that one of them is written in English and the other is a call
+log.
+
+Three changes, and none of them shows more:
+
+**A card leads with what the call did, when its arguments say.** `Ran cargo test`, `Searched fn
+header`, `Edited src/cards.rs`, `Wrote src/glyph.rs`, `Fetched https://…`. Read off the arguments
+in the same pass and by the same rule [`Kind::of`] reads the colour — so nothing is looked up in a
+table of tool names, and a tool registered tomorrow gets a verb for the same reason it gets a
+diff.
+
+This reverses half of ADR 0033, and the other half stands: [`did`] returns `None` for a call
+nothing here understands, and then the tool's own name is what shows. A plugin's `frobnicate` is
+`frobnicate` for ever. What that ADR was protecting against was neosh *inventing* a friendlier word
+for a tool and then disagreeing with it; stating what a call did, from what it was handed, invents
+nothing.
+
+**A command's output is folded from the middle.** One line of head, the count of what fell out,
+and the rest of the budget spent on the end:
+
+```text
+  Ran  cargo test -p neosh-core -- --test-threads 2      9.0s
+  │    Compiling neosh v0.1.0
+  │ … +5 lines (^S ⇥ to expand)
+  │ test cards::body ... ok
+  │ test result: ok. 12 passed
+```
+
+The head of a command's output is how it started and the tail is what it decided. Folding from the
+end kept `Compiling`, `Finished` and a blank line, and put `test result: ok` behind `⇥` — three
+rows spent proving the command had begun. Blank rows are skipped at either edge for the same
+reason: in a budget of three, a blank line is a third of the card spent on nothing. They are still
+counted as elided, because they were there.
+
+**A row of air between one action and the next.** The cheapest structure there is, and the thing
+that makes `codex` scannable. Butted together, a header, four rows of output and the next header
+are one block with no edges in it. This is the one change here that makes the transcript *taller*,
+and it is worth more than the rows it costs — the fold above pays for most of them anyway.
+
+### Consequences
+
+- `… +N more lines` became `… +N lines`. The row now appears in the middle of an output as often as
+  at the end of one, and "more" is only true at the end.
+- The elision mark is a glyph now (`Glyphs::elision`), because `…` was hardcoded and is not ASCII —
+  in `ui.ascii_only` the one row whose job is to say "there is more" was drawn with a character the
+  terminal had been told it could not draw. `clip` still has the same leak for a clipped subject,
+  which is smaller and not fixed here.
+- `Read` and `Searched` are told apart by which argument the call is *about*, the same question
+  [`subject`] answers — a grep is not a read of its directory.
+- Two tools of the same kind now read identically: a call to `Bash` and a call to `Shell` are both
+  `Ran`. Accepted. Which of two shells ran a command is not a question a transcript is asked, and
+  the exact name is in the conversation.

--- a/plugins/api/src/generated/Activity.ts
+++ b/plugins/api/src/generated/Activity.ts
@@ -61,4 +61,5 @@ export type Activity =
   | { "kind": "compacting" }
   | { "kind": "compacted"; before?: number | null; after?: number | null }
   | { "kind": "commands"; commands: Array<DriverCommand> }
+  | { "kind": "resume"; token: string }
   | { "kind": "context"; used: number; total: number };

--- a/plugins/api/src/generated/TurnRequest.ts
+++ b/plugins/api/src/generated/TurnRequest.ts
@@ -32,6 +32,23 @@ export type TurnRequest = {
    * before this field existed.
    */
   cwd: string;
+  /**
+   * What the driver called this conversation last time, if it named it.
+   *
+   * A vendor CLI keeps the history on its side and hands back a handle — `claude`'s session id,
+   * ACP's session, `codex`'s conversation. A driver that only remembers that handle in its own
+   * process remembers it exactly as long as the workspace lives: restart, reopen a conversation
+   * with a hundred messages in it, and the agent is started fresh and told only the newest one.
+   * The transcript looks full and the model has never heard of any of it, which is not a thing
+   * either side reports as an error — it is simply an agent that has forgotten, and the first
+   * visible sign of it is `/compact` finishing instantly with nothing to compact.
+   *
+   * So the handle belongs to the conversation, which is the thing that outlives the process.
+   * The driver hands it over with [`Activity::Resume`] and is given it back here. `None` means
+   * this conversation has never been run by this driver, which is the only case where starting
+   * fresh is right.
+   */
+  resume?: string | null;
   system?: string | null;
   messages: Array<Message>;
   tools?: Array<ToolDef>;

--- a/plugins/api/src/ui.ts
+++ b/plugins/api/src/ui.ts
@@ -336,8 +336,17 @@ export interface PickerOptions<T> {
    * cannot make the list flicker backwards.
    */
   source?(query: string): Promise<PickerItem<T>[]>;
-  /** What the filter starts with. */
-  query?: string;
+  /**
+   * What the filter starts with.
+   *
+   * A function is asked at the last possible moment — once the picker is on screen and holds the
+   * keyboard — rather than when it was called. That matters for anything completing a field that
+   * is still being typed into: opening this takes several round-trips, every keystroke in that
+   * window goes to the field, and a picker seeded with what was there *before* them shows an
+   * unfiltered list with the wrong row under the accept key. Typing `/compact` quickly and
+   * pressing `↵` ran the first command in the list, which was not `compact`.
+   */
+  query?: string | (() => string);
   /**
    * Whether there is a filter line at all. On by default.
    *
@@ -479,7 +488,7 @@ export async function picker<T>(
     z: 200,
   });
 
-  let query = opts.query ?? "";
+  let query = typeof opts.query === "string" ? opts.query : "";
   let cursor = Math.min(Math.max(0, opts.selected ?? 0), Math.max(0, items.length - 1));
   let visible = items.map((item, index) => ({ item, index, positions: [] as number[] }));
   let top = 0;
@@ -777,6 +786,10 @@ export async function picker<T>(
   // is on screen — the one moment the user obviously meant "close this". A window-scoped binding
   // outranks the global one and is dropped with the window.
   await bindWidgetKeys(neosh, win, command, keys, opts.ownKeys ?? []);
+  // Now, and not before: everything typed while this was being built went somewhere, and if it
+  // went into the field this is completing then it is part of the query. Asked after the keyboard
+  // is ours, so there is no further keystroke to miss.
+  if (typeof opts.query === "function") query = opts.query();
   await refetch();
   await render();
   if (opts.onHighlight) {

--- a/plugins/builtin/slash/main.ts
+++ b/plugins/builtin/slash/main.ts
@@ -68,14 +68,18 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
   // command name is already half-typed. Marked open for the same reason the draft path is: the menu
   // writes the composer back, and a second one opening on its own echo would take the keyboard from
   // the first.
-  const start = async (query: string) => {
+  // The query is asked for rather than passed: this takes several round-trips to open, and
+  // everything typed in that window lands in the composer. Read at the start, the menu comes up
+  // unfiltered with a row nobody aimed at under `↵` — which is how typing `/compact` at speed ran
+  // the first command in the list instead. Read at the end, what you typed is the filter.
+  const start = async () => {
     if (open) return;
     open = true;
-    await show(neosh, query, () => (open = false));
+    await show(neosh, () => TOKEN.exec(draft)?.[1] ?? "", () => (open = false));
   };
 
   subscriptions.push(
-    await neosh.cmd.register("slash.open", () => start(TOKEN.exec(draft)?.[1] ?? ""), {
+    await neosh.cmd.register("slash.open", () => start(), {
       desc: "Run a command by name, neosh's or the agent's",
     }),
   );
@@ -90,12 +94,12 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
   subscriptions.push(
     neosh.agent.onComposerChange(({ text }) => {
       draft = text;
-      if (text === "/") void start("");
+      if (text === "/") void start();
     }),
   );
 }
 
-async function show(neosh: Neosh, query: string, done: () => void): Promise<void> {
+async function show(neosh: Neosh, query: () => string, done: () => void): Promise<void> {
   const [commands, keymaps, driver] = await Promise.all([
     neosh.cmd.list(),
     neosh.keymap.list("chat"),

--- a/scripts/shot.py
+++ b/scripts/shot.py
@@ -3,7 +3,7 @@
 
 Usage: shot.py [--cols N] [--rows N] [--wait MS] [--after MS] [--color] key [key ...]
 
-Keys are literal text, or a name in angle brackets: <cr> <esc> <tab> <c-p> <up> ...
+Keys are literal text, or a name in angle brackets: <cr> <esc> <tab> <c-p> <up> <pageup> ...
 A key of the form <wait:400> sleeps that many milliseconds.
 
 --color prints what colour every run of every row is, instead of the plain screen. A band behind a
@@ -21,6 +21,11 @@ NAMED = {
     "s-up": "\x1b[1;2A", "s-down": "\x1b[1;2B",
     "s-right": "\x1b[1;2C", "s-left": "\x1b[1;2D",
     "f1": "\x1bOP", "f2": "\x1bOQ", "f3": "\x1bOR", "f4": "\x1bOS",
+    # Bound keys, so a screenshot has to be able to press them. Paging is what a long transcript is
+    # read with, and `home`/`end` are what a composer's line ends are reached with.
+    "pageup": "\x1b[5~", "pagedown": "\x1b[6~",
+    "home": "\x1b[H", "end": "\x1b[F",
+    "delete": "\x1b[3~", "insert": "\x1b[2~",
 }
 
 def encode(tok: str) -> str:


### PR DESCRIPTION
A turn that read six files used to be six rows, each opening with the same
filled circle, and a `cargo test` card showed `Compiling` and hid
`test result: ok`. Put beside `codex` it read as a call log rather than as an
account of what happened. And `^D` while reading the transcript opened a git
diff, because reading never told the keymap it was a different place.

## A card says what happened — ADR 0040

**No mark on a finished call.** `⏺` was on every card whatever had happened, so
a turn that read three files, grepped twice and listed a directory was six
identical circles down the left. A mark on every row answers a question nobody
asks twice: the card being there is already the claim that the call happened.
The column holds a mark only while a call is out — `▸`, pulsing — or when it
failed, `✗`.

**A run of read-only calls is one row.**

```
  Explored  host.rs, cards.rs, diff.rs, fn header, **/*.rs
```

The names, as many as fit, `+N more` for the rest — never half a name. A run is
calls with *nothing drawn between them*, asked the same way by the live path and
by `transcript()`, so switching away and back cannot re-fold a conversation
differently from how you left it. `⇥` opens it into a row per call. Each name is
coloured by its own call, so a live run reads as progress rather than as one
block in motion, and the header is rewritten in place — a turn that reads six
files no longer pushes six rows and takes them back.

**A card leads with what the call did.** `Ran cargo test`, `Searched fn header`,
`Edited src/cards.rs`, `Wrote`, `Fetched` — read off the arguments in the same
pass `Kind::of` reads the colour. This reverses half of ADR 0033 and keeps the
half that was load-bearing: `did` returns `None` for a call nothing here
understands, and then the tool's own name stands. A plugin's `frobnicate` is
`frobnicate` for ever.

**A command's output folds from the middle.**

```
  Ran  cargo test -p neosh-core -- --test-threads 2      9.0s
  │    Compiling neosh v0.1.0
  │ … +5 lines (^S ⇥ to expand)
  │ test cards::body ... ok
  │ test result: ok. 12 passed
```

The head is how it started and the tail is what it decided. Folding from the end
spent three rows proving the command had begun. Blank rows are skipped at either
edge — in a budget of three, a blank line is a third of the card spent on
nothing — and still counted as elided.

**A row of air between actions**, which is the cheapest structure there is.

## A mode's keys are the mode's keys

`^S` now puts the editor in `Normal`, so `chat`'s bindings stop firing and
reading gets its vocabulary back. Only four things are bound in every mode, and
they are the escape hatches: `^C`, `^Q`, `^R`, `^S`. Three bugs fell out of that:

- **A key another mode claimed never arrived.** Reading's keys come through the
  *unbound* path, the last thing consulted — so `^D` was `git.diff`, `^B` was
  `sidebar.toggle`, `^E` was the effort picker. Half the scroll vocabulary.
- **A chord was read as the letter it is made of.** `^B` moved a word left and
  `^A` put you back in the composer. Chords are matched first now, and one this
  mode does not define does nothing at all. Shift is excluded: it *is* a modifier
  on a motion here.
- **The composer held the keyboard.** `^X`, `^A` and the paging keys were bound
  in all four modes rather than in `Chat`. PageUp/PageDown in reading now move a
  screen of cursor, which is what they mean here.

`chat.queue.edit` moves from `⇧↑` to `^Y` — readline's yank, beside the `^U` and
`^W` the composer already has, and reachable without arrow keys. That also gives
`⇧↑` back to the composer, where it selects upward through a pasted snippet.

## Steering, which was invisible

`Composer.HintKey` was `fg(muted)` and `Composer.Hint` is `Comment` — the same
hex, differing only by the dim attribute. So `⇧↑ edit` at the end of a queued
message read as the end of the sentence, and the whole `^S` hint row had no
visible keys at all. It links to `Key` now, the group the welcome row uses.

The empty composer says what `⏎` does while a turn runs — `Steer it — taken in
at the next gap` rather than `Ask anything`, which invited the one thing you
could not do. And `edit` became `take back`.

## Carried along

**ADR 0039 — a conversation outlives the agent holding it.** Uncommitted work
already in the tree, in the same files, so it could not be split out: what a
driver calls a conversation travels as `Activity::Resume`, is kept in
`Session::resume`, and comes back as `TurnRequest::resume`.

**Two tests that were already failing on `main`.**
`a_rendered_answer_looks_the_same_after_switching_away_and_back` and
`a_permission_mode_belongs_to_the_conversation_it_was_chosen_in` use
`session.close` to leave a conversation and come back, which since
`confirmDestructive` landed puts a dialog on screen and waits. They now set
`ui.confirm_destructive = false`.

**`scripts/shot.py` learned the paging keys.** It exits silently on an unknown
key name, so `<pageup>` printed nothing at all rather than saying why.

## Verification

Per crate, on the rebase: `builtin_plugins` 116, `reading` 15, `sessions` 27,
`editing` 19, `workspace` 8, `approvals` 7, `user_config` 37, `hello_plugin` 2,
`neosh` unit 162, `neosh-core` 103, `neosh-provider` 138, `neosh-proto` 138,
`neosh-agent` 61. Bindings regenerate clean, `tsc --noEmit` passes, and every
visual claim above was checked by driving the real binary under `shot.py`.

Six new tests, four of them regressions for the keymap bugs.
