### PR TITLE
feat(model,chat): every knob on one panel, and a turn you have not seen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,13 @@ jobs:
       #
       # Registered *after* `rust-cache` on purpose. Post steps run in reverse
       # order, so this one saves the archive before `rust-cache` prunes it.
+      # Restore and save are separate because `actions/cache` does not save on a
+      # failed job — which is precisely the run that just paid to download it,
+      # and precisely the run somebody is iterating on. A red build should still
+      # leave the 150MB behind for the next attempt.
       - name: Cache the V8 prebuilt
-        uses: actions/cache@v4
+        id: v8
+        uses: actions/cache/restore@v4
         with:
           path: target/debug/gn_out
           key: v8-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -91,7 +96,18 @@ jobs:
           git config --global init.defaultBranch main
 
       - name: Tests
-        run: cargo test --workspace --locked
+        run: cargo test --workspace --exclude neosh --locked
+
+      # The binary's own suites drive a real `neosh` under a pty, and each one
+      # is a whole workspace with a V8 runtime in it. Run at the runner's
+      # default parallelism they spend their budget waiting for each other's
+      # CPU rather than for the thing they are asserting on — sixteen of them
+      # timed out at once on a four-core runner, most in code this branch never
+      # touched. `--test-threads 2` is what AGENTS.md already prescribes for
+      # them locally, and a runner with fewer cores than a laptop needs it more
+      # rather than less.
+      - name: The binary's integration tests
+        run: cargo test -p neosh --locked -- --test-threads 2
 
       # The plugin API's wire types are generated from Rust and committed. A
       # Rust type that changed without its binding being regenerated means the
@@ -126,6 +142,15 @@ jobs:
           scaffold="$(mktemp -d)"
           cargo run --quiet --locked -p neosh -- --config-dir "$scaffold" init
           ./plugins/api/node_modules/.bin/tsc --noEmit --project "$scaffold/tsconfig.json"
+
+      # Last, because the archive only exists once something has built V8, and
+      # `if: always()` because a run that failed its tests still downloaded it.
+      - name: Save the V8 prebuilt
+        if: always() && steps.v8.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: target/debug/gn_out
+          key: v8-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,13 @@
 #
 # The steps are deliberately not folded into one `check.sh` call: a red X should
 # say *which* thing broke without anyone opening the log.
+#
+# Linting is a job of its own rather than a step, because `cargo clippy` and
+# `cargo test` cannot share a single artefact between them — one produces
+# clippy's metadata and the other produces real object code, so a job that does
+# both compiles the whole dependency graph twice in series. Split, they compile
+# it twice in parallel, and the run is as long as the slower half instead of the
+# sum. Clippy also never links, which is why it is the half that needs no V8.
 name: ci
 
 on:
@@ -18,6 +25,12 @@ env:
   CARGO_TERM_COLOR: always
   # A failing build should print the error, not a backtrace of rustc.
   RUST_BACKTRACE: 1
+  # Nothing here is compiled twice in the same job, so incremental state is
+  # weight in the cache and nothing else.
+  CARGO_INCREMENTAL: 0
+  # Debug info is most of a debug build's link time and most of what the cache
+  # then has to carry, and nothing in this suite reads a symbolised frame.
+  CARGO_PROFILE_DEV_DEBUG: 0
 
 jobs:
   rust:
@@ -26,19 +39,48 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
 
       # V8 dominates a clean build, so caching is the difference between a
       # two-minute run and a twenty-minute one.
+      #
+      # `cache-on-failure` because the run that is failing is exactly the run
+      # somebody is iterating on, and making them pay for a cold graph on every
+      # attempt is how a ten-minute CI becomes a thirty-minute one.
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
 
-      - name: Formatting
-        run: cargo fmt --all --check
-        continue-on-error: true
+      # `rusty_v8` downloads a 150MB prebuilt static library into
+      # `target/debug/gn_out` — which is not one of the paths `rust-cache`
+      # recognises, so it prunes the archive while keeping the build script's
+      # "already ran" fingerprint. Cargo then has no reason to fetch it again,
+      # and the first thing that actually *links* V8 dies with "could not find
+      # native static library `rusty_v8`". Clippy survives because a check never
+      # links, which is why this only ever broke the test job.
+      #
+      # Keyed on the lockfile rather than on the asset's name: which archive the
+      # build script wants depends on the version *and* on the features it was
+      # compiled with, so a workflow that spells the filename out is a workflow
+      # that is silently wrong the first time either of them changes.
+      #
+      # Registered *after* `rust-cache` on purpose. Post steps run in reverse
+      # order, so this one saves the archive before `rust-cache` prunes it.
+      - name: Cache the V8 prebuilt
+        uses: actions/cache@v4
+        with:
+          path: target/debug/gn_out
+          key: v8-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
 
-      - name: Clippy
-        run: cargo clippy --workspace --all-targets
+      # The self-heal, for a cold cache or a lockfile that just moved. Dropping
+      # the fingerprint is what gives the build script permission to run again;
+      # it then finds its own checksum file next to the archive and re-downloads
+      # only if the URL it wants has actually changed.
+      - name: Let cargo fetch V8 again if the archive is missing
+        run: |
+          if [ ! -f target/debug/gn_out/obj/librusty_v8.a ]; then
+            echo "no prebuilt V8 in the cache — clearing the build fingerprint so cargo fetches it"
+            rm -rf target/debug/build/v8-*
+          fi
 
       # Git is a dependency of the version-control tests, and its default
       # branch name and identity are not configured on a fresh runner.
@@ -49,7 +91,7 @@ jobs:
           git config --global init.defaultBranch main
 
       - name: Tests
-        run: cargo test --workspace
+        run: cargo test --workspace --locked
 
       # The plugin API's wire types are generated from Rust and committed. A
       # Rust type that changed without its binding being regenerated means the
@@ -61,6 +103,50 @@ jobs:
             echo "::error::generated TypeScript is out of date — run 'cargo test -p neosh-proto' and commit plugins/api/src/generated"
             exit 1
           fi
+
+      # Folded in here rather than kept as a job of its own: it needs the same
+      # dependency graph and the same linked binary the tests already built, and
+      # as a separate job it was compiling all of it a second time from a second
+      # cache to run one command.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: plugins/api/package-lock.json
+
+      - name: Install
+        working-directory: plugins/api
+        run: npm ci
+
+      # `neosh init` writes a starter config *and* the types it is checked
+      # against, both emitted from the binary. If the template drifts from the
+      # API, every new user's first experience is a type error.
+      - name: The scaffolded config type-checks against its own emitted types
+        run: |
+          scaffold="$(mktemp -d)"
+          cargo run --quiet --locked -p neosh -- --config-dir "$scaffold" init
+          ./plugins/api/node_modules/.bin/tsc --noEmit --project "$scaffold/tsconfig.json"
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Formatting
+        run: cargo fmt --all --check
+        continue-on-error: true
+
+      # Never links, so it needs no prebuilt V8 — see the note on the job above.
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets --locked
 
   typescript:
     runs-on: ubuntu-latest
@@ -93,28 +179,3 @@ jobs:
       - name: The bundled plugins type-check against the published API
         working-directory: plugins/builtin
         run: ../api/node_modules/.bin/tsc --noEmit
-
-  scaffold:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: plugins/api/package-lock.json
-
-      - name: Install
-        working-directory: plugins/api
-        run: npm ci
-
-      # `neosh init` writes a starter config *and* the types it is checked
-      # against, both emitted from the binary. If the template drifts from the
-      # API, every new user's first experience is a type error.
-      - name: The scaffolded config type-checks against its own emitted types
-        run: |
-          scaffold="$(mktemp -d)"
-          cargo run --quiet -p neosh -- --config-dir "$scaffold" init
-          ./plugins/api/node_modules/.bin/tsc --noEmit --project "$scaffold/tsconfig.json"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,7 +319,7 @@ registry — this table is what ships.
 | `^T` | Projects and conversations. Switching is never refused — turns keep running where they are |
 | `^J` | The computers in this workspace. Add one by its address, allow one that is asking, or open what it is running |
 | `^F` | What you have archived. Filter it, put one back, or finally throw it away |
-| `^N` | New conversation. In a repository it asks where: here, a new worktree, an existing one, elsewhere |
+| `^N` | New conversation. In a repository it asks where: here, a worktree you need not name, one you do, an existing one, another machine, elsewhere |
 | `^O` | Add a project |
 | `^B` | Toggle the sidebar |
 | `^K` | Command palette |
@@ -412,7 +412,7 @@ says how many are asking, `^T` is where you go, and it opens when you get there.
 |---|---|
 | `↵` | Open a conversation, fold a project, or add one from the `+` row |
 | `j` `k` | Move |
-| `n` | New conversation here |
+| `n` | New conversation — the same question `^N` asks, about the project the cursor is on |
 | `o` | Add a project |
 | `f` | Pin a project to the top |
 | `J` `K` | Reorder within a group |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,14 @@ per decision, and records the *reasoning*, not the choice.
   things you are finished with is the only part of that column that is never the answer, and it
   grows forever. One row with a count, `a` in the panel or `^F` anywhere, and it opens as a picker
   you can filter — because a flat list of dim rows is not a way to find anything. See ADR 0039.
+- **A turn that finished while you were elsewhere is news until you go and look.** The panel says
+  what is *happening* and stops the moment it stops, so an answer that arrived while you were in
+  another conversation looks exactly like an answer you read yesterday. `SessionInfo::unread` is set
+  when a turn ends off screen and cleared by *arriving* — no dismissal key, because a mark you clear
+  by hand is a second chore attached to the first. It lives on the conversation and is persisted, so
+  every list agrees and a restart does not lose it; it wears `Status.Unread`, the amber the palette
+  already uses for *act now*, and it never moves — motion means "something is happening you cannot
+  see", and this is the opposite. A folded project carries a dot for what it is hiding. See ADR 0042.
 - **A card is a row until you ask for more.** A call that only *looked* at something folds to its
   header with the size of what came back on the end of it; a command keeps its output, an edit keeps
   its diff, and a failure always shows. See ADR 0033.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,17 @@ per decision, and records the *reasoning*, not the choice.
 - **Every view gets every event.** `Agent` fans its stream out to one queue per view. Never a
   `broadcast` channel: lagging consumers drop the oldest, silently, under load — and a view that
   missed one `ToolFinished` has a card that spins forever with nothing to put it right.
+- **A setting you cannot send is still a setting, and every model has some.** A knob is a
+  `ProviderOptionDescriptor` the *driver* advertises — discovered where an endpoint says what it
+  takes (OpenRouter's `supported_parameters`, `codex`'s `model/list`), written down where it will
+  not — and a provider with no knobs listed is a bug in a catalogue, not a model without options.
+  Some of them are words rather than parameters: `ultrathink` and `ultracode` are read by a
+  *harness*, so they live on `claude-cli` and never on `anthropic`, they travel as
+  `prompt_injected_values` / `prompt_injected_word`, and the injection happens once, above every
+  driver, on the copy of the message this turn sends — never on the transcript, never on a tool
+  round, and always with a sendable value put back in the selection's place. `^E` shows *all* of
+  them at once and applies as you move, because a knob you cannot see is a knob you do not have. See
+  ADR 0043.
 - **Take the transport that can do the most.** `claude` in stream-json mode with the control
   protocol; `codex app-server`, not `codex exec`. The cheaper one is not simpler for long — it is
   the one where streaming, approvals and interrupts turn out to be impossible rather than missing.
@@ -294,7 +305,7 @@ registry — this table is what ships.
 | `^V` | Attach the image on the clipboard. A key rather than a paste, because a terminal's paste can only ever hand over text |
 | `⌥V` | Take the last attached image back off |
 | `^P` | Pick a model. Mid-turn too — the running agent is told, and thinks the rest with it |
-| `^E` | Reasoning effort and the other per-model options |
+| `^E` | Everything this model can be told, on one panel: effort, thinking, fast mode, context, and whatever a driver invented. `←→` along a row, `↑↓` between them, and it applies as you move |
 | `⌥↑` `⌥↓` | One rung up or down the capability ladder, same provider |
 | `⇧⇥` | Permission mode — full access to start with, then ask, allow-listed, deny. Belongs to this conversation, saved with it, and takes effect on the turn that is running |
 | `^T` | Projects and conversations. Switching is never refused — turns keep running where they are |

--- a/crates/neosh-agent/src/agent.rs
+++ b/crates/neosh-agent/src/agent.rs
@@ -403,6 +403,16 @@ impl Agent {
             format!("no driver for instance {} — is the plugin that provides it loaded?", selection.instance)
         })?;
 
+        // A knob spelled into the prompt applies here too. A branch name generated at `ultrathink`
+        // is silly, but a *level the endpoint would reject* is not silly, it is a failed request —
+        // and this path shares the conversation's selection, so it inherits whatever was chosen
+        // there.
+        let mut selection = selection;
+        let words = neosh_provider::prompt_injections(&instance.models, &mut selection);
+        let mut messages =
+            vec![Message { role: Role::User, content: vec![ContentBlock::Text { text: prompt }] }];
+        neosh_provider::inject(&mut messages, &words);
+
         let request = TurnRequest {
             selection,
             // A one-shot generation is nobody's conversation: it borrows the model and the
@@ -413,10 +423,7 @@ impl Agent {
             // Nobody's conversation, so there is nothing to pick up and nothing to leave behind.
             resume: None,
             system,
-            messages: vec![Message {
-                role: Role::User,
-                content: vec![ContentBlock::Text { text: prompt }],
-            }],
+            messages,
             tools: Vec::new(),
             max_output_tokens: None,
         };
@@ -610,7 +617,7 @@ impl Agent {
 
             // One guard, not two: temporaries in a struct literal live to the end of the
             // statement, so taking the session lock twice here would deadlock against itself.
-            let Some((cwd, system, messages, resume)) = self.with(&session, |s| {
+            let Some((cwd, system, mut messages, resume)) = self.with(&session, |s| {
                 (s.cwd.clone(), s.system.clone(), s.messages.clone(), s.resume.clone())
             }) else {
                 // Closed while its own turn was running. There is nowhere to put the answer, so
@@ -619,8 +626,24 @@ impl Agent {
                 stop = StopReason::Cancelled;
                 break;
             };
+            // Options that are said rather than sent. A vendor gating depth on a word in the
+            // message — `ultrathink`, and everything that has copied it — is still a setting: you
+            // choose it in the same picker, it shows in the same strip, and it applies to the same
+            // turn. It just cannot travel as a parameter, so it travels in the message this turn is
+            // about to send, and *only* that copy: the transcript keeps what you actually typed, and
+            // the round trips after a tool call do not each say it again. See
+            // `neosh_provider::injection`.
+            let mut selection = selection.clone();
+            let words = neosh_provider::prompt_injections(&instance.models, &mut selection);
+            // The first round only. A tool result travels as a user message, so every round after
+            // this one has a "last user message" that nobody typed — putting the word on that would
+            // say it again after every tool call, each time as a fresh instruction.
+            if round == 0 {
+                neosh_provider::inject(&mut messages, &words);
+            }
+
             let request = TurnRequest {
-                selection: selection.clone(),
+                selection,
                 conversation: session.clone(),
                 cwd: cwd.clone(),
                 // What this driver called the conversation last time it ran one, which is the only

--- a/crates/neosh-agent/src/session.rs
+++ b/crates/neosh-agent/src/session.rs
@@ -88,6 +88,13 @@ pub struct Session {
     /// clock in here, so this type stays deterministic and testable.
     pub created_at: i64,
     pub updated_at: i64,
+    /// A turn ended here while you were somewhere else, and you have not been back since.
+    ///
+    /// See [`neosh_proto::SessionInfo::unread`]. Held on the conversation rather than worked out
+    /// by whoever draws a list, because "have you seen this" is a fact about the conversation and
+    /// there is more than one list: the panel, a status segment and a picker all have to agree,
+    /// and a second panel deriving it from timestamps would disagree with the first.
+    pub unread: bool,
     /// Put away, not thrown away: still on disk, still openable, just not in the everyday list.
     pub archived: bool,
     /// When it was put away, in seconds since the epoch. Set by whoever archives it, for the same
@@ -123,6 +130,7 @@ impl Session {
             title: None,
             created_at: 0,
             updated_at: 0,
+            unread: false,
             archived: false,
             archived_at: None,
             permission_mode: None,
@@ -254,6 +262,7 @@ impl Session {
             context_window: self.context_window,
             // Filled in by the store, which is the only thing that knows.
             is_active: false,
+            unread: self.unread,
             archived: self.archived,
             archived_at: self.archived_at,
             permission_mode: self.permission_mode,

--- a/crates/neosh-agent/src/store.rs
+++ b/crates/neosh-agent/src/store.rs
@@ -82,9 +82,14 @@ impl SessionStore {
     /// Make `id` the active session, parking the current one.
     pub fn switch(&mut self, id: &SessionId) -> Result<(), StoreError> {
         if &self.active.id == id {
+            self.active.unread = false;
             return Ok(());
         }
-        let next = self.idle.remove(id).ok_or_else(|| StoreError::NoSuchSession(id.clone()))?;
+        let mut next = self.idle.remove(id).ok_or_else(|| StoreError::NoSuchSession(id.clone()))?;
+        // Arriving is what reading is. Cleared here rather than by whoever draws the list, so that
+        // every list agrees the moment you switch — a panel that cleared its own copy would keep
+        // saying "new" in the status line you did not happen to be looking at.
+        next.unread = false;
         let previous = std::mem::replace(&mut self.active, next);
         self.idle.insert(previous.id.clone(), previous);
         // Move to the front rather than re-sorting: "most recently active" is a history, and a
@@ -141,6 +146,20 @@ impl SessionStore {
 
     fn contains(&self, id: &SessionId) -> bool {
         &self.active.id == id || self.idle.contains_key(id)
+    }
+
+    /// You are looking at it, so whatever finished while you were away has been seen.
+    ///
+    /// Answers whether anything changed, because the caller's next move is a write to disk and
+    /// re-persisting every conversation on every arrival is a cost for nothing.
+    pub fn mark_read(&mut self, id: &SessionId) -> bool {
+        match self.get_mut(id) {
+            Some(s) if s.unread => {
+                s.unread = false;
+                true
+            }
+            _ => false,
+        }
     }
 
     /// Public because a turn reaches its own conversation by id: it may not be the active one, and
@@ -328,6 +347,28 @@ mod tests {
 
         s.switch(&a).expect("switch back");
         assert_eq!(s.active().messages.len(), 1, "the parked conversation survived");
+    }
+
+    #[test]
+    fn arriving_at_a_conversation_is_what_reads_it() {
+        // The mark is news, and news stops being news when you have been to look. Cleared here
+        // rather than by whoever draws a list, so the panel, the status line and a picker cannot
+        // disagree about whether you have seen something.
+        let (mut s, a, b, _c) = store();
+        s.get_mut(&b).expect("there").unread = true;
+        assert!(s.list().iter().find(|i| i.id == b).expect("listed").unread);
+
+        s.switch(&b).expect("switch");
+        assert!(!s.get(&b).expect("there").unread);
+        assert!(s.list().iter().all(|i| !i.unread));
+
+        // And it is only the one you arrived at. A "mark everything read" gesture nobody asked for
+        // is how you lose the answer you switched away to wait for.
+        s.get_mut(&a).expect("there").unread = true;
+        s.switch(&b).expect("already here");
+        assert!(s.get(&a).expect("there").unread);
+        assert!(s.mark_read(&a), "and it reports the change, so the caller knows to write it down");
+        assert!(!s.mark_read(&a), "twice is not a change");
     }
 
     #[test]

--- a/crates/neosh-core/src/palette.rs
+++ b/crates/neosh-core/src/palette.rs
@@ -228,6 +228,11 @@ fn underline(mut s: HighlightSpec) -> HighlightSpec {
     s
 }
 
+fn reverse(mut s: HighlightSpec) -> HighlightSpec {
+    s.attrs.reverse = true;
+    s
+}
+
 fn struck(mut s: HighlightSpec) -> HighlightSpec {
     s.attrs.strikethrough = true;
     s
@@ -253,6 +258,11 @@ fn flash(mut s: HighlightSpec, ms: u32) -> HighlightSpec {
     s
 }
 
+fn spectrum(mut s: HighlightSpec, period_ms: u32) -> HighlightSpec {
+    s.animate = Some(neosh_proto::Animation::Spectrum { period_ms });
+    s
+}
+
 /// Every group a plugin may link to, with a concrete spec.
 ///
 /// Kept as one list rather than scattered across the crates that use each group, because the whole
@@ -265,6 +275,9 @@ pub fn groups(variant: Variant) -> Vec<(&'static str, HighlightDef)> {
     };
 
     let spec = |s: HighlightSpec| HighlightDef::Spec { spec: s };
+    // A value that is in effect: the colour that says how far up its ladder it is, on the band that
+    // says it is the one selected.
+    let lit = |c: Color| HighlightSpec { fg: Some(c), bg: Some(r.cursor_bg), ..HighlightSpec::default() };
     let link = |to: &str| HighlightDef::Link { to: to.to_string() };
 
     vec![
@@ -510,6 +523,35 @@ pub fn groups(variant: Variant) -> Vec<(&'static str, HighlightDef)> {
         ("Account.Key", spec(fg(r.accent))),
         ("Account.Local", spec(dim(fg(r.muted)))),
         ("Account.Missing", link("Diagnostic.Warn")),
+        // ---- model options -------------------------------------------------
+        // A knob's value, drawn on the ladder it sits on. **Weight, not hue**: the rule at the top
+        // of this file says three colours do the work and a fourth would need a legend, and a
+        // reasoning level is not a state — it is a *position on a scale*, which prominence carries
+        // natively. Read down a row of them and the ramp is obvious without anything being learnt.
+        //
+        // Which step a value gets is the plugin's business, because only it knows how long the
+        // ladder is: five levels on Claude, three on most endpoints, two on Gemini.
+        // Every step carries the band as well as the colour, because a ranged highlight does not
+        // patch another ranged highlight — the renderer takes the highest-priority one covering a
+        // character and stops. Two marks, a background and a foreground, would therefore have drawn
+        // one of them and silently dropped the other; the group that means "this is the value in
+        // effect" has to say both things at once.
+        ("Option.Unset", spec(dim(fg(r.faint)))),
+        ("Option.Step1", spec(dim(lit(r.muted)))),
+        ("Option.Step2", spec(lit(r.muted))),
+        ("Option.Step3", spec(lit(r.fg))),
+        ("Option.Step4", spec(lit(r.accent))),
+        ("Option.Step5", spec(bold(lit(r.accent)))),
+        // The step that is not on the ladder: a level bought by putting a word in the prompt rather
+        // than by sending a parameter. It gets the one animation that abandons the palette, because
+        // what it has to say is "this is not one of the normal settings" — and that is a thing no
+        // amount of amber can say. See `Animation::Spectrum`.
+        ("Option.Beyond", spec(spectrum(bold(lit(r.accent)), 3200))),
+        // The value you just settled on, for the moment before the panel closes. Reverse, which
+        // the rules at the top of this file reserve for selection and for the one-shot "it moved
+        // there" flash — this is the second of those, and it is the only acknowledgement a control
+        // that takes effect as you pass over it can give you that it heard the decision.
+        ("Option.Chosen", spec(reverse(bold(fg(r.accent))))),
     ]
 }
 

--- a/crates/neosh-core/src/palette.rs
+++ b/crates/neosh-core/src/palette.rs
@@ -381,6 +381,11 @@ pub fn groups(variant: Variant) -> Vec<(&'static str, HighlightDef)> {
         ("Status.Failed", spec(bold(fg(r.danger)))),
         ("Status.Done", spec(fg(r.success))),
         ("Status.Idle", spec(dim(fg(r.muted)))),
+        // Finished, and you have not seen it. The attention hue rather than the success one, and
+        // bold rather than dim: `Status.Done` is a fact about a turn and this is a request that you
+        // go and look, which is the same thing `Status.Approval` is asking and the reason they
+        // share a colour. It is also the one group here that goes away by being read.
+        ("Status.Unread", spec(bold(fg(r.attention)))),
         // The two groups that move. Motion is reserved for "something is happening and you cannot
         // see it yet" — the one state where a still screen and a wedged program look identical.
         //

--- a/crates/neosh-proto/src/agent.rs
+++ b/crates/neosh-proto/src/agent.rs
@@ -194,6 +194,19 @@ pub struct SessionInfo {
     pub context_window: Option<u64>,
     #[serde(default)]
     pub is_active: bool,
+    /// A turn finished here while you were looking at something else.
+    ///
+    /// The one thing a list of conversations cannot say without being told. A turn takes minutes,
+    /// you switch away, and the row it left behind is indistinguishable from the twelve above it —
+    /// so the answer you were waiting for is found by opening conversations until one of them has
+    /// it. This is the mark that makes it findable, and it is *news* rather than state: it is set
+    /// when a turn ends somewhere you were not, and cleared the moment you arrive.
+    ///
+    /// Off screen is the whole test. A turn that ended in the conversation on screen has already
+    /// been seen — including when nothing was attached, because reattaching lands you in that
+    /// conversation with the answer in it.
+    #[serde(default)]
+    pub unread: bool,
     /// Put away rather than thrown away.
     ///
     /// An archived conversation keeps every message and can be brought back; it is simply not in

--- a/crates/neosh-proto/src/provider.rs
+++ b/crates/neosh-proto/src/provider.rs
@@ -113,6 +113,15 @@ pub enum ProviderOptionDescriptor {
         description: Option<String>,
         #[serde(default)]
         current_value: bool,
+        /// A word to put in the message while this is on, for a switch a vendor reads out of the
+        /// prompt rather than off a parameter.
+        ///
+        /// The switch is then *nothing but* that word: with it on, the word is written into the
+        /// turn and no option value is sent at all. The same idea as
+        /// [`Self::Select::prompt_injected_values`], for the knobs that are a yes/no rather than a
+        /// rung — orchestration modes, personas, anything a harness gates on what you said.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        prompt_injected_word: Option<String>,
     },
 }
 

--- a/crates/neosh-proto/src/ui.rs
+++ b/crates/neosh-proto/src/ui.rs
@@ -316,6 +316,21 @@ pub enum Animation {
         #[ts(type = "number")]
         ms: u32,
     },
+    /// Hue travelling along the run: every cell a different colour, the whole band drifting.
+    ///
+    /// The one animation that abandons the group's own colour, and it is reserved for the one thing
+    /// that deserves it — a setting that is *not on the ladder*, like an effort level bought by
+    /// putting a word in the prompt. Everything else here is a state, and states are three hues and
+    /// an attribute (see `neosh_core::palette`); this is the exception that proves it, because what
+    /// it says is "this is not one of the normal settings" and no amount of amber says that.
+    ///
+    /// Keeps the base colour's *lightness* and replaces only the hue, so a light theme gets a
+    /// rainbow it can read. Without truecolor it rotates the six ANSI hues instead, which is
+    /// coarser and still unmistakably the same idea.
+    Spectrum {
+        #[ts(type = "number")]
+        period_ms: u32,
+    },
 }
 
 /// The glyphs a [`Animation::Frames`] cycles through.
@@ -342,9 +357,10 @@ pub enum FrameSet {
 impl Animation {
     pub fn period_ms(self) -> u32 {
         match self {
-            Self::Shimmer { period_ms } | Self::Pulse { period_ms } | Self::Frames { period_ms, .. } => {
-                period_ms.max(50)
-            }
+            Self::Shimmer { period_ms }
+            | Self::Pulse { period_ms }
+            | Self::Spectrum { period_ms }
+            | Self::Frames { period_ms, .. } => period_ms.max(50),
             Self::Flash { ms } => ms.max(50),
         }
     }

--- a/crates/neosh-provider/src/catalog.rs
+++ b/crates/neosh-provider/src/catalog.rs
@@ -17,18 +17,80 @@ use neosh_proto::{
 };
 
 /// Reasoning-effort levels available on a given model generation.
+///
+/// `pub` under a longer name because a driver that *discovered* a ladder needs to build the same
+/// descriptor: the picker keys off `"effort"` being the same knob everywhere, and a second spelling
+/// of it invented in a driver is a knob that does not carry over when you switch models.
+pub fn effort_levels(levels: &[&str], default: &str) -> ProviderOptionDescriptor {
+    effort_with(levels, default, &[])
+}
+
 fn effort(levels: &[&str], default: &str) -> ProviderOptionDescriptor {
+    effort_levels(levels, default)
+}
+
+/// A level bought with a word in the prompt rather than with a request parameter.
+///
+/// The id **is** the word. That is what makes injection generic: nothing between here and the
+/// driver has to hold a table of magic strings — the value the picker stored is the thing that gets
+/// written into the message, and a provider plugin that invents its own gets the same treatment
+/// with no host change. See [`crate::prompt_injections`].
+struct Magic {
+    /// Also the word. `"ultrathink"`.
+    id: &'static str,
+    label: &'static str,
+    description: &'static str,
+}
+
+/// A ladder, plus any levels that are spelled rather than sent.
+///
+/// The spelled ones sort last because they are past the top of the scale: `max` is the most a
+/// parameter can ask for, and these are what you say when that was not enough.
+fn effort_with(levels: &[&str], default: &str, magic: &[Magic]) -> ProviderOptionDescriptor {
+    let mut options: Vec<OptionChoice> = levels
+        .iter()
+        .map(|l| OptionChoice {
+            id: (*l).into(),
+            label: level_label(l),
+            description: None,
+            is_default: *l == default,
+        })
+        .collect();
+    options.extend(magic.iter().map(|m| OptionChoice {
+        id: m.id.into(),
+        label: m.label.into(),
+        description: Some(m.description.into()),
+        is_default: false,
+    }));
     ProviderOptionDescriptor::Select {
         id: "effort".into(),
         label: "Effort".into(),
         description: Some("How much reasoning the model spends before answering.".into()),
-        options: levels
+        options,
+        current_value: Some(default.into()),
+        prompt_injected_values: magic.iter().map(|m| m.id.to_string()).collect(),
+    }
+}
+
+/// A select over anything, for the knobs that are not the reasoning ladder.
+fn select(
+    id: &str,
+    label: &str,
+    description: &str,
+    choices: &[(&str, &str, Option<&str>)],
+    default: &str,
+) -> ProviderOptionDescriptor {
+    ProviderOptionDescriptor::Select {
+        id: id.into(),
+        label: label.into(),
+        description: Some(description.into()),
+        options: choices
             .iter()
-            .map(|l| OptionChoice {
-                id: (*l).into(),
-                label: title_case(l),
-                description: None,
-                is_default: *l == default,
+            .map(|(id, label, desc)| OptionChoice {
+                id: (*id).into(),
+                label: (*label).into(),
+                description: desc.map(str::to_string),
+                is_default: *id == default,
             })
             .collect(),
         current_value: Some(default.into()),
@@ -42,10 +104,35 @@ fn boolean(id: &str, label: &str, desc: &str) -> ProviderOptionDescriptor {
         label: label.into(),
         description: Some(desc.into()),
         current_value: false,
+        prompt_injected_word: None,
     }
 }
-/// `low` -> `Low`. Shared so a discovered effort level reads like a written-down one.
 
+/// A switch that is a word in the message rather than a parameter. The id is the word.
+fn spoken(id: &str, label: &str, desc: &str) -> ProviderOptionDescriptor {
+    ProviderOptionDescriptor::Boolean {
+        id: id.into(),
+        label: label.into(),
+        description: Some(desc.into()),
+        current_value: false,
+        prompt_injected_word: Some(id.into()),
+    }
+}
+/// How a reasoning level reads in a list.
+///
+/// Title case for almost all of them, and a lookup for the ones where it is wrong: `xhigh` is a
+/// contraction, and "Xhigh" reads as a typo in a column of English words. Shared with the drivers
+/// that *discover* their ladders, so a level `codex` reported and one written down here are spelled
+/// the same way on screen.
+pub fn level_label(id: &str) -> String {
+    match id {
+        "xhigh" => "X-high".into(),
+        "ultra" => "Ultra".into(),
+        other => title_case(other),
+    }
+}
+
+/// `low` -> `Low`. Shared so a discovered effort level reads like a written-down one.
 pub fn title_case(s: &str) -> String {
     let mut c = s.chars();
     match c.next() {
@@ -74,6 +161,22 @@ pub fn default_options(caps: &ModelCapabilities) -> Vec<OptionSelection> {
 
 const EFFORT_5: &[&str] = &["low", "medium", "high", "xhigh", "max"];
 const EFFORT_46: &[&str] = &["low", "medium", "high", "max"];
+
+/// What `claude` reads out of a message rather than off its command line.
+///
+/// **The harness's words, not the model's**, which is why they are on the CLI's catalogue and not
+/// on Anthropic's. `api.anthropic.com` serves a model: it has `output_config.effort` and no opinion
+/// about English, so a message beginning "ultrathink" is a message beginning with a word. The CLI
+/// is a program wrapped around that model, and these are two of the things it looks for.
+///
+/// Advertising them where they do not work would be worse than not having them: the picker would
+/// offer a level that silently does nothing, on the one provider where the same word does something
+/// real — and "it worked yesterday" would be a difference of instance nobody can see.
+const CLAUDE_WORDS: &[Magic] = &[Magic {
+    id: "ultrathink",
+    label: "Ultrathink",
+    description: "Past the top of the ladder — said in the message, not sent as a level.",
+}];
 
 /// One entry in the Anthropic catalogue.
 ///
@@ -236,7 +339,16 @@ pub fn claude_cli_models() -> Vec<ModelInfo> {
         .map(|(id, name, family, tier, tagline, ctx, efforts, fast, long, legacy)| {
             let mut descriptors = Vec::new();
             if let Some(levels) = efforts {
-                descriptors.push(effort(levels, "high"));
+                descriptors.push(effort_with(levels, "high", CLAUDE_WORDS));
+                // Orchestration rather than depth, so a switch of its own rather than a rung on the
+                // effort ladder: you can want a fleet of sub-agents on a shallow turn, and asking
+                // for one by moving a slider marked "how hard should it think" is a control that
+                // does two things and says one.
+                descriptors.push(spoken(
+                    "ultracode",
+                    "Ultracode",
+                    "Let it orchestrate sub-agents by default. Slower, and thorough.",
+                ));
             } else {
                 descriptors.push(boolean(
                     "thinking",
@@ -278,19 +390,24 @@ pub fn claude_cli_models() -> Vec<ModelInfo> {
 /// `(id, display name, family, tier, tagline, superseded)`.
 type Seed = (&'static str, &'static str, &'static str, ModelTier, &'static str, bool);
 
-/// Turn a seed list into models, with the option knobs every one of these endpoints understands.
-fn seeded(seeds: &[Seed]) -> Vec<ModelInfo> {
+/// Turn a seed list into models, asking `knobs` what each one accepts.
+///
+/// Per model rather than per provider, because that is how the ladders actually differ: one
+/// generation gained a level the one before it rejects, and a small model in the same lineup has no
+/// reasoning knob at all.
+fn seeded(seeds: &[Seed], knobs: fn(&str) -> Vec<ProviderOptionDescriptor>) -> Vec<ModelInfo> {
     seeds
         .iter()
         .map(|(id, name, family, tier, tagline, legacy)| {
+            let descriptors = knobs(id);
             let mut m = ModelInfo::undescribed(*id, *name);
             m.capabilities = ModelCapabilities {
                 tools: true,
                 vision: true,
                 streaming: true,
-                thinking: false,
+                thinking: descriptors.iter().any(|d| is_reasoning(d.id())),
                 prompt_caching: false,
-                option_descriptors: Vec::new(),
+                option_descriptors: descriptors,
             };
             m.family = Some((*family).to_string());
             m.tier = Some(*tier);
@@ -299,6 +416,76 @@ fn seeded(seeds: &[Seed]) -> Vec<ModelInfo> {
             m
         })
         .collect()
+}
+
+/// Whether a knob is about *reasoning* rather than about the shape of the answer.
+///
+/// One list, because three vendors spell the same idea three ways and `ModelCapabilities::thinking`
+/// is a single bit that a picker uses to decide whether a model reasons at all.
+fn is_reasoning(id: &str) -> bool {
+    matches!(id, "effort" | "thinking" | "thinking_level" | "thinking_budget")
+}
+
+/// A model with no seeded knobs. Most endpoints, most of the time — see [`seed_models`].
+fn no_knobs(_: &str) -> Vec<ProviderOptionDescriptor> {
+    Vec::new()
+}
+
+/// Answer length, which every GPT-5-shaped endpoint takes and nothing else does.
+pub fn verbosity_levels() -> ProviderOptionDescriptor {
+    select(
+        "verbosity",
+        "Verbosity",
+        "How much answer to write, independently of how hard it thought.",
+        &[("low", "Low", Some("Terse.")), ("medium", "Medium", None), ("high", "High", Some("Explains itself."))],
+        "medium",
+    )
+}
+
+/// What OpenAI's own endpoint accepts beside the messages.
+///
+/// The ladder is `reasoning_effort`, and it is *not* Anthropic's: it starts at `minimal`, which has
+/// no equivalent there, and the top rung differs by generation. Written down rather than guessed
+/// from the id, because the failure mode of guessing is a 400 on send rather than a knob that reads
+/// slightly wrong — the same reason the Anthropic catalogue is written down at all.
+fn openai_knobs(id: &str) -> Vec<ProviderOptionDescriptor> {
+    let levels: &[&str] = if id.starts_with("gpt-5.6") {
+        &["minimal", "low", "medium", "high", "xhigh"]
+    } else if id.starts_with("gpt-5") {
+        &["minimal", "low", "medium", "high"]
+    } else {
+        return Vec::new();
+    };
+    vec![effort(levels, "medium"), verbosity_levels()]
+}
+
+/// What Gemini accepts, which changed shape between generations.
+///
+/// The 3 line takes `thinkingLevel`, a named rung. The 2.5 line takes `thinkingBudget`, a token
+/// count — and the only value of it worth putting in a picker is "none", because every other number
+/// is a guess about a turn that has not happened yet. So the 2.5 models get a switch and the 3 line
+/// gets a ladder, which is what each of them actually has.
+///
+/// 2.5 Pro is deliberately blank: its budget cannot be set to zero, and offering a switch that the
+/// endpoint rejects is worse than offering nothing.
+pub fn gemini_knobs(id: &str) -> Vec<ProviderOptionDescriptor> {
+    if id.starts_with("gemini-3") {
+        return vec![select(
+            "thinking_level",
+            "Thinking",
+            "How much reasoning the model spends before answering.",
+            &[("low", "Low", None), ("high", "High", None)],
+            "high",
+        )];
+    }
+    if id.starts_with("gemini-2.5") && !id.contains("pro") {
+        let mut on = boolean("thinking", "Thinking", "Let it reason before answering.");
+        if let ProviderOptionDescriptor::Boolean { current_value, .. } = &mut on {
+            *current_value = true;
+        }
+        return vec![on];
+    }
+    Vec::new()
 }
 
 /// What a provider offers, written down, so its models are visible before you have a key.
@@ -319,6 +506,21 @@ fn seeded(seeds: &[Seed]) -> Vec<ModelInfo> {
 /// resolves to something is better than an id that resolves to a 404.
 fn seed_models(instance: &str) -> Vec<ModelInfo> {
     use ModelTier::{Balanced, Fast, Frontier};
+    // Which knobs a seeded model has is a fact about the *vendor*, so it is chosen here rather than
+    // written on every row: an endpoint either takes `reasoning_effort` or it does not, and the
+    // twelve rows below would otherwise repeat the same answer twelve times and disagree on the
+    // thirteenth.
+    let knobs: fn(&str) -> Vec<ProviderOptionDescriptor> = match instance {
+        "openai" => openai_knobs,
+        "google" => gemini_knobs,
+        // Nothing for xAI, DeepSeek or Mistral, and it is not an omission. None of the three
+        // documents a reasoning knob on the models seeded here — Grok's is on the `mini` line only,
+        // DeepSeek's reasoner has no dial at all, and Mistral's models do not reason. A knob
+        // invented for them would be a 400 on the first turn, which is the failure this whole file
+        // is written out longhand to avoid. Where an endpoint *does* say, the driver reads it back:
+        // see `openai_compat`'s discovery.
+        _ => no_knobs,
+    };
     seeded(match instance {
         "openai" => &[
             ("gpt-5.6-sol", "GPT-5.6 Sol", "sol", Frontier, "Frontier agentic coding", false),
@@ -356,7 +558,7 @@ fn seed_models(instance: &str) -> Vec<ModelInfo> {
         // would be wrong faster than it was useful. Discovery is the honest answer there, and the
         // picker says so rather than showing an empty pane with no explanation.
         _ => &[],
-    })
+    }, knobs)
 }
 
 /// Let a discovered list decide what exists, and a seed list decide how it reads.
@@ -383,6 +585,13 @@ pub fn merge(discovered: Vec<ModelInfo>, seeds: &[ModelInfo]) -> Vec<ModelInfo> 
                 out.context_window = m.context_window.or(seed.context_window);
                 out.max_output_tokens = m.max_output_tokens.or(seed.max_output_tokens);
                 out.pricing = m.pricing.clone().or_else(|| seed.pricing.clone());
+                // An endpoint that listed its own parameters has said something the catalogue can
+                // only have guessed, so it wins. One that said nothing leaves the seeds standing —
+                // silence is not a claim that the model has no knobs.
+                if !m.capabilities.option_descriptors.is_empty() {
+                    out.capabilities.option_descriptors = m.capabilities.option_descriptors.clone();
+                    out.capabilities.thinking = m.capabilities.thinking;
+                }
                 described.push(out);
             }
             None => rest.push(m),
@@ -775,6 +984,86 @@ mod tests {
         assert!(has_fast("claude-opus-4-8"));
         assert!(!has_fast("claude-sonnet-5"));
         assert!(!has_fast("claude-haiku-4-5"));
+    }
+
+    /// Every knob a model advertises, as `(id, values)`.
+    fn knobs(m: &ModelInfo) -> Vec<(String, Vec<String>)> {
+        m.capabilities
+            .option_descriptors
+            .iter()
+            .map(|d| match d {
+                ProviderOptionDescriptor::Select { id, options, .. } => {
+                    (id.clone(), options.iter().map(|o| o.id.clone()).collect())
+                }
+                ProviderOptionDescriptor::Boolean { id, .. } => (id.clone(), Vec::new()),
+            })
+            .collect()
+    }
+
+    fn find(models: &[ModelInfo], id: &str) -> ModelInfo {
+        models.iter().find(|m| m.id.0 == id).unwrap_or_else(|| panic!("no {id}")).clone()
+    }
+
+    #[test]
+    fn a_reasoning_ladder_is_not_an_anthropic_privilege() {
+        // The knob existed and only one vendor's models carried it, so `^E` on anything else said
+        // "no options to set" — about models that document a reasoning parameter in their first
+        // paragraph. Each of these is spelled the way its own endpoint spells it.
+        let openai = find(&seed_models("openai"), "gpt-5.6-sol");
+        let effort = knobs(&openai).into_iter().find(|(id, _)| id == "effort").expect("a ladder");
+        assert!(effort.1.contains(&"minimal".to_string()), "OpenAI's starts below low");
+        assert!(!effort.1.contains(&"max".to_string()), "and does not borrow Anthropic's top rung");
+        assert!(knobs(&openai).iter().any(|(id, _)| id == "verbosity"));
+        assert!(openai.capabilities.thinking, "a model with a ladder reasons, by definition");
+
+        // Gemini changed the shape of the question between generations, so the two are different
+        // knobs rather than one knob with a translation layer nobody can see.
+        let three = find(&seed_models("google"), "gemini-3.1-pro-preview");
+        assert_eq!(knobs(&three)[0].0, "thinking_level");
+        let flash = find(&seed_models("google"), "gemini-2.5-flash");
+        assert_eq!(knobs(&flash)[0].0, "thinking");
+    }
+
+    #[test]
+    fn a_word_is_offered_only_where_something_reads_it() {
+        // `ultrathink` is the harness's, not the model's. On the CLI it buys depth; sent to
+        // `api.anthropic.com` as `output_config.effort` it is a 400, and put in a message there it
+        // is a word. So the same lineup has it on one instance and not on the other.
+        let cli = find(&claude_cli_models(), "claude-opus-5");
+        let ProviderOptionDescriptor::Select { options, prompt_injected_values, .. } =
+            &cli.capabilities.option_descriptors[0]
+        else {
+            panic!("expected an effort select");
+        };
+        assert_eq!(prompt_injected_values, &["ultrathink".to_string()]);
+        assert_eq!(options.last().map(|o| o.id.as_str()), Some("ultrathink"), "past the top rung");
+        assert!(
+            cli.capabilities.option_descriptors.iter().any(|d| matches!(
+                d,
+                ProviderOptionDescriptor::Boolean { prompt_injected_word: Some(w), .. } if w == "ultracode"
+            )),
+            "orchestration is a switch of its own, not a rung on the depth ladder"
+        );
+
+        let api = find(&anthropic_models(), "claude-opus-5");
+        for d in &api.capabilities.option_descriptors {
+            if let ProviderOptionDescriptor::Select { prompt_injected_values, .. } = d {
+                assert!(prompt_injected_values.is_empty(), "the API reads no words");
+            }
+        }
+    }
+
+    #[test]
+    fn a_spelled_level_never_becomes_the_value_that_gets_sent() {
+        // `default_options` is what a freshly chosen model starts with. Starting on a level that
+        // has to be rewritten before it can be sent would mean every first turn went through the
+        // injection path, which is the path with the interesting bugs in it.
+        let cli = find(&claude_cli_models(), "claude-opus-5");
+        let opts = default_options(&cli.capabilities);
+        assert_eq!(
+            opts.iter().find(|o| o.id == "effort").map(|o| &o.value),
+            Some(&ProviderOptionValue::Text("high".into()))
+        );
     }
 
     #[test]

--- a/crates/neosh-provider/src/drivers/codex_cli.rs
+++ b/crates/neosh-provider/src/drivers/codex_cli.rs
@@ -714,7 +714,7 @@ pub fn codex_model(v: &serde_json::Value) -> Option<ModelInfo> {
                 .iter()
                 .map(|l| OptionChoice {
                     id: (*l).into(),
-                    label: catalog::title_case(l),
+                    label: catalog::level_label(l),
                     // The CLI writes a sentence for each level. It is better than anything we
                     // would invent, and it is per model rather than per ladder.
                     description: v

--- a/crates/neosh-provider/src/drivers/google.rs
+++ b/crates/neosh-provider/src/drivers/google.rs
@@ -95,7 +95,20 @@ impl GoogleProvider {
             gen_cfg["maxOutputTokens"] = json!(max);
         }
         // Ask for reasoning to be surfaced rather than silently discarded.
-        gen_cfg["thinkingConfig"] = json!({"includeThoughts": true});
+        let mut thinking = json!({"includeThoughts": true});
+        // Two spellings of one idea, because the API changed shape between generations: the 3 line
+        // takes a named rung, the 2.5 line takes a token budget where the only number worth a
+        // control is zero. Whichever knob the model advertised is the one that arrives here; a
+        // model that advertised neither sends neither, and gets the endpoint's own default.
+        if let Some(level) = request.selection.option_str("thinking_level") {
+            thinking["thinkingLevel"] = json!(level);
+        }
+        if let Some(on) = request.selection.option_flag("thinking") {
+            // `-1` is "decide for yourself", which is the default and the only honest value for
+            // "on": any fixed budget we chose here would be a guess about a turn we cannot see.
+            thinking["thinkingBudget"] = json!(if on { -1 } else { 0 });
+        }
+        gen_cfg["thinkingConfig"] = thinking;
         body["generationConfig"] = gen_cfg;
         body
     }
@@ -143,13 +156,19 @@ impl Provider for GoogleProvider {
                         );
                         info.context_window = m.get("inputTokenLimit").and_then(Value::as_u64);
                         info.max_output_tokens = m.get("outputTokenLimit").and_then(Value::as_u64);
+                        // Keyed off the id, which is the one thing `models.list` is certain to
+                        // return and the one thing Google's own knob follows from: the 3 line takes
+                        // a thinking *level*, the 2.5 line a *budget*. Done here as well as in the
+                        // catalogue so a model released this morning arrives with its ladder rather
+                        // than waiting for a seed entry to be written for it.
+                        let descriptors = crate::catalog::gemini_knobs(id);
                         info.capabilities = neosh_proto::ModelCapabilities {
                             tools: true,
                             vision: true,
                             streaming: true,
                             thinking: true,
                             prompt_caching: false,
-                            option_descriptors: vec![],
+                            option_descriptors: descriptors,
                         };
                         Some(info)
                     })

--- a/crates/neosh-provider/src/drivers/openai.rs
+++ b/crates/neosh-provider/src/drivers/openai.rs
@@ -14,6 +14,7 @@ use serde_json::{Value, json};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
+use crate::catalog;
 use crate::drivers::http;
 use crate::{Provider, ProviderError, ProviderStream, resolve_auth, sse};
 
@@ -148,6 +149,40 @@ impl OpenAiCompatProvider {
             .collect()
     }
 
+    /// The knobs an entry in `/models` says it takes.
+    ///
+    /// # Why an aggregator can answer this and a vendor cannot
+    ///
+    /// `GET /v1/models` is barely specified: OpenAI returns four fields and none of them is about
+    /// parameters. An aggregator has to do better, because it fronts hundreds of models from dozens
+    /// of vendors and nobody could otherwise tell which of them reason — so OpenRouter puts
+    /// `supported_parameters` on every row, and that list is the only place in this entire family of
+    /// endpoints where "does this model take a reasoning effort" is a question with a real answer.
+    ///
+    /// So this is discovery where discovery exists, and [`catalog::seed_models`] is the written-down
+    /// answer for the endpoints that will not say. Four hundred OpenRouter models arrive with the
+    /// right ladder each and no catalogue entry between them.
+    ///
+    /// Deliberately narrow: only parameters this driver actually sends are turned into knobs. A
+    /// picker offering a control that goes nowhere is worse than one that is short.
+    fn advertised_knobs(m: &Value) -> Vec<neosh_proto::ProviderOptionDescriptor> {
+        let Some(params) = m.get("supported_parameters").and_then(Value::as_array) else {
+            return Vec::new();
+        };
+        let takes = |name: &str| params.iter().any(|p| p.as_str() == Some(name));
+        let mut out = Vec::new();
+        if takes("reasoning") || takes("reasoning_effort") {
+            // Three rungs, because that is what the aggregator normalises every vendor's ladder
+            // onto before passing it on. A fourth invented here would be translated into one of
+            // these anyway, or rejected.
+            out.push(catalog::effort_levels(&["low", "medium", "high"], "medium"));
+        }
+        if takes("verbosity") {
+            out.push(catalog::verbosity_levels());
+        }
+        out
+    }
+
     pub fn body(request: &TurnRequest) -> Value {
         let mut body = json!({
             "model": request.selection.model.0,
@@ -165,6 +200,12 @@ impl OpenAiCompatProvider {
         }
         if let Some(effort) = request.selection.option_str("effort") {
             body["reasoning_effort"] = json!(effort);
+        }
+        // How long the answer is, which is a separate question from how hard it thought — and the
+        // one people actually reach for. Sent only when a model advertised it, so an endpoint that
+        // has never heard of the parameter never sees it.
+        if let Some(verbosity) = request.selection.option_str("verbosity") {
+            body["verbosity"] = json!(verbosity);
         }
         body
     }
@@ -206,13 +247,14 @@ impl Provider for OpenAiCompatProvider {
                             .get("context_length")
                             .or(m.get("context_window"))
                             .and_then(Value::as_u64);
+                        let descriptors = Self::advertised_knobs(m);
                         info.capabilities = neosh_proto::ModelCapabilities {
                             tools: true,
                             vision: false,
                             streaming: true,
-                            thinking: false,
+                            thinking: descriptors.iter().any(|d| d.id() == "effort"),
                             prompt_caching: false,
-                            option_descriptors: vec![],
+                            option_descriptors: descriptors,
                         };
                         Some(info)
                     })

--- a/crates/neosh-provider/src/injection.rs
+++ b/crates/neosh-provider/src/injection.rs
@@ -1,0 +1,232 @@
+//! Options that are spelled into the message rather than sent beside it.
+//!
+//! # Why any of this exists
+//!
+//! Not every knob a vendor offers is a request parameter. A harness that wraps a model — `claude`,
+//! and every agent CLI that has copied it — reads words out of the prompt and changes how it runs:
+//! `ultrathink` buys thinking depth past anything `--effort` will accept, `ultracode` turns on
+//! orchestration that has no flag at all. They are settings by every test that matters — you choose
+//! one, it changes the next turn, and it should be visible in the strip while it is on — and they
+//! are settings you cannot *send*.
+//!
+//! [`ProviderOptionDescriptor`] has carried `prompt_injected_values` since ADR 0011 and nothing has
+//! ever acted on it, which meant choosing one sent the word as a parameter: `--effort ultrathink`,
+//! which is not a level, and the turn fails. This is the half that was missing.
+//!
+//! # Where it happens, and why not in the driver
+//!
+//! Above every driver, in the agent, on the request rather than on the conversation. Three
+//! consequences, all of them the point:
+//!
+//! * **Every driver gets it.** A vendor plugin that advertises a magic word needs no code here.
+//! * **The transcript never sees it.** The word goes into the copy of the message that this turn
+//!   sends. What you typed is what stays on screen and what the next turn replays — otherwise every
+//!   turn after an ultrathink would carry the word again, and turning it off would not turn it off.
+//! * **Nothing invalid reaches the wire.** The injected value is replaced with the ladder's ordinary
+//!   default, so the parameter is always one the endpoint accepts.
+
+use neosh_proto::{
+    Message, ModelInfo, ModelSelection, ProviderOptionDescriptor, ProviderOptionValue, Role,
+};
+
+/// The words a selection asks for, with the injected values taken back out of it.
+///
+/// Mutates `selection` so what is left is safe to send: a spelled level becomes the ladder's
+/// default, and a spelled flag becomes nothing at all.
+///
+/// `models` is the catalogue for the instance being used. A model nothing here describes has no
+/// descriptors, so it has no magic words, so this does nothing — which is the right answer for
+/// every discovered endpoint that told us only an id.
+pub fn prompt_injections(models: &[ModelInfo], selection: &mut ModelSelection) -> Vec<String> {
+    let Some(model) = models.iter().find(|m| m.id == selection.model) else {
+        return Vec::new();
+    };
+
+    let mut words = Vec::new();
+    for descriptor in &model.capabilities.option_descriptors {
+        match descriptor {
+            ProviderOptionDescriptor::Select {
+                id, options, prompt_injected_values, ..
+            } if !prompt_injected_values.is_empty() => {
+                let Some(chosen) = selection.option_str(id).map(str::to_string) else { continue };
+                if !prompt_injected_values.contains(&chosen) {
+                    continue;
+                }
+                words.push(chosen);
+                // Back to the top of the ladder that can actually be sent. Dropping the option
+                // instead would hand the endpoint its own default, which on a driver whose default
+                // is "medium" would quietly *lower* the depth of the turn you asked to deepen.
+                let fallback = options
+                    .iter()
+                    .filter(|o| !prompt_injected_values.contains(&o.id))
+                    .find(|o| o.is_default)
+                    .or_else(|| {
+                        options.iter().rfind(|o| !prompt_injected_values.contains(&o.id))
+                    })
+                    .map(|o| o.id.clone());
+                match fallback {
+                    Some(v) => set(selection, id, ProviderOptionValue::Text(v)),
+                    None => selection.options.retain(|o| &o.id != id),
+                }
+            }
+            ProviderOptionDescriptor::Boolean { id, prompt_injected_word: Some(word), .. } => {
+                if selection.option_flag(id) == Some(true) {
+                    words.push(word.clone());
+                }
+                // Off *and* on: the switch is the word, so there is no parameter either way, and
+                // sending `{"ultracode": true}` to an endpoint that has never heard of it is how a
+                // knob that works becomes a 400.
+                selection.options.retain(|o| &o.id != id);
+            }
+            _ => {}
+        }
+    }
+    words
+}
+
+fn set(selection: &mut ModelSelection, id: &str, value: ProviderOptionValue) {
+    match selection.options.iter_mut().find(|o| o.id == id) {
+        Some(slot) => slot.value = value,
+        None => selection.options.push(neosh_proto::OptionSelection { id: id.into(), value }),
+    }
+}
+
+/// Put the words at the top of the message this turn is about to send.
+///
+/// The **last user message**, because that is the one being answered: a word attached to the
+/// question from four turns ago is a word the model reads as history. Each on its own line and in
+/// the order the descriptors declared them, which is the order they appear in the picker.
+///
+/// A turn with no user message in it — a tool result being handed back mid-loop — is left alone. The
+/// word was already said on the message that started the loop, and saying it again on every round
+/// trip would be a different instruction each time the model looked.
+pub fn inject(messages: &mut [Message], words: &[String]) {
+    if words.is_empty() {
+        return;
+    }
+    let Some(last) = messages.iter_mut().rfind(|m| m.role == Role::User) else { return };
+    let prefix = format!("{}\n\n", words.join("\n"));
+    // The first text block, not a new one: a message whose first block is an image and whose second
+    // is the question would otherwise get the word before the image, where a vendor scanning "the
+    // text of the prompt" may not look at all.
+    for block in last.content.iter_mut() {
+        if let neosh_proto::ContentBlock::Text { text } = block {
+            *text = format!("{prefix}{text}");
+            return;
+        }
+    }
+    last.content.insert(0, neosh_proto::ContentBlock::Text { text: words.join("\n") });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use neosh_proto::{
+        ContentBlock, ModelCapabilities, OptionChoice, OptionSelection, ProviderOptionDescriptor,
+    };
+
+    fn ladder() -> ProviderOptionDescriptor {
+        ProviderOptionDescriptor::Select {
+            id: "effort".into(),
+            label: "Effort".into(),
+            description: None,
+            options: vec![
+                OptionChoice { id: "low".into(), label: "Low".into(), description: None, is_default: false },
+                OptionChoice { id: "high".into(), label: "High".into(), description: None, is_default: true },
+                OptionChoice { id: "ultrathink".into(), label: "Ultrathink".into(), description: None, is_default: false },
+            ],
+            current_value: Some("high".into()),
+            prompt_injected_values: vec!["ultrathink".into()],
+        }
+    }
+
+    fn switch() -> ProviderOptionDescriptor {
+        ProviderOptionDescriptor::Boolean {
+            id: "ultracode".into(),
+            label: "Ultracode".into(),
+            description: None,
+            current_value: false,
+            prompt_injected_word: Some("ultracode".into()),
+        }
+    }
+
+    fn model() -> Vec<ModelInfo> {
+        let mut m = ModelInfo::undescribed("m", "M");
+        m.capabilities = ModelCapabilities {
+            option_descriptors: vec![ladder(), switch()],
+            ..ModelCapabilities::default()
+        };
+        vec![m]
+    }
+
+    fn selection(options: Vec<OptionSelection>) -> ModelSelection {
+        ModelSelection { instance: "i".into(), model: "m".into(), options }
+    }
+
+    fn text(id: &str, v: &str) -> OptionSelection {
+        OptionSelection { id: id.into(), value: ProviderOptionValue::Text(v.into()) }
+    }
+
+    #[test]
+    fn a_spelled_level_becomes_a_word_and_a_sendable_value() {
+        // `--effort ultrathink` is not a level. The whole reason this exists is that choosing one
+        // used to put it on the command line.
+        let mut sel = selection(vec![text("effort", "ultrathink")]);
+        assert_eq!(prompt_injections(&model(), &mut sel), vec!["ultrathink".to_string()]);
+        assert_eq!(sel.option_str("effort"), Some("high"), "the ladder's own default, not the endpoint's");
+    }
+
+    #[test]
+    fn an_ordinary_level_is_left_exactly_where_it_was() {
+        let mut sel = selection(vec![text("effort", "low")]);
+        assert!(prompt_injections(&model(), &mut sel).is_empty());
+        assert_eq!(sel.option_str("effort"), Some("low"));
+    }
+
+    #[test]
+    fn a_spelled_switch_sends_nothing_either_way() {
+        for on in [true, false] {
+            let mut sel = selection(vec![OptionSelection {
+                id: "ultracode".into(),
+                value: ProviderOptionValue::Flag(on),
+            }]);
+            let words = prompt_injections(&model(), &mut sel);
+            assert_eq!(words.is_empty(), !on);
+            assert!(sel.option_flag("ultracode").is_none(), "the switch is the word, not a parameter");
+        }
+    }
+
+    #[test]
+    fn a_model_nobody_described_has_no_magic_words() {
+        let mut sel = ModelSelection {
+            instance: "i".into(),
+            model: "something-discovered".into(),
+            options: vec![text("effort", "ultrathink")],
+        };
+        assert!(prompt_injections(&model(), &mut sel).is_empty());
+        assert_eq!(sel.option_str("effort"), Some("ultrathink"), "untouched, because unknown");
+    }
+
+    #[test]
+    fn the_word_goes_on_the_question_being_answered() {
+        let mut messages = vec![
+            Message { role: Role::User, content: vec![ContentBlock::Text { text: "first".into() }] },
+            Message { role: Role::Assistant, content: vec![ContentBlock::Text { text: "answer".into() }] },
+            Message { role: Role::User, content: vec![ContentBlock::Text { text: "second".into() }] },
+        ];
+        inject(&mut messages, &["ultrathink".into()]);
+        let ContentBlock::Text { text: first } = &messages[0].content[0] else { panic!() };
+        let ContentBlock::Text { text: last } = &messages[2].content[0] else { panic!() };
+        assert_eq!(first, "first", "history is what was actually said");
+        assert_eq!(last, "ultrathink\n\nsecond");
+    }
+
+    #[test]
+    fn nothing_chosen_rewrites_nothing() {
+        let mut messages =
+            vec![Message { role: Role::User, content: vec![ContentBlock::Text { text: "hi".into() }] }];
+        inject(&mut messages, &[]);
+        let ContentBlock::Text { text } = &messages[0].content[0] else { panic!() };
+        assert_eq!(text, "hi");
+    }
+}

--- a/crates/neosh-provider/src/lib.rs
+++ b/crates/neosh-provider/src/lib.rs
@@ -25,6 +25,7 @@ pub mod catalog;
 pub mod credentials;
 pub mod drivers;
 pub mod image;
+pub mod injection;
 pub mod quota;
 pub mod registry;
 pub mod sse;
@@ -35,6 +36,7 @@ use futures::Stream;
 use neosh_proto::{InstanceConfig, ModelInfo, ProviderEvent, TurnRequest};
 use tokio_util::sync::CancellationToken;
 
+pub use injection::{inject, prompt_injections};
 pub use registry::ProviderRegistry;
 
 /// A stream of normalized events. Errors are a [`ProviderEvent::Error`] variant rather than a

--- a/crates/neosh-script/src/loader.rs
+++ b/crates/neosh-script/src/loader.rs
@@ -43,9 +43,11 @@ pub static API_TREE: include_dir::Dir<'static> =
 /// picker are written against the surface a third-party author has, which is how we find out when
 /// that surface is not enough.
 ///
-/// Each is a **single entry module**. Relative imports are not resolvable from a `neosh:` URL, and
-/// keeping bundled plugins to one file each is a cheaper constraint than teaching the loader a
-/// second module system.
+/// Loaded from `neosh:/builtin/<name>/main.ts`, and the leading slash is load-bearing: a `neosh:`
+/// URL with an opaque path is *cannot-be-a-base*, so `./options.ts` next to it has nothing to
+/// resolve against and fails with a URL error nobody can act on. Bundled plugins used to be one
+/// file each because of it — which made them the only plugins in the system that could not be
+/// split up, and this crate's whole claim is that they are ordinary.
 pub static BUILTIN_TREE: include_dir::Dir<'static> =
     include_dir::include_dir!("$CARGO_MANIFEST_DIR/../../plugins/builtin");
 
@@ -78,23 +80,24 @@ pub fn builtin_plugins() -> Vec<BuiltinPlugin> {
             name: name.to_string(),
             manifest: manifest.to_string(),
             entry: source.to_string(),
-            url: format!("{BUILTIN_URL_PREFIX}{name}"),
+            url: format!("{BUILTIN_URL_PREFIX}{name}/main.ts"),
         });
     }
     out
 }
 
 /// URL scheme-and-path prefix bundled plugins load from.
-pub const BUILTIN_URL_PREFIX: &str = "neosh:builtin/";
+///
+/// `neosh:/`, not `neosh:` — see [`BUILTIN_TREE`] for why the slash matters.
+pub const BUILTIN_URL_PREFIX: &str = "neosh:/builtin/";
 
+/// The file behind a `neosh:/builtin/...` URL, whether it is a plugin's entry or something it
+/// imported alongside it.
 fn builtin_source(url: &str) -> Option<String> {
-    let name = url.strip_prefix(BUILTIN_URL_PREFIX)?;
+    let path = url.strip_prefix(BUILTIN_URL_PREFIX)?;
     // Strip the reload generation, which is appended as `?v=N` exactly as it is for file modules.
-    let name = name.split('?').next().unwrap_or(name);
-    BUILTIN_TREE
-        .get_file(format!("{name}/main.ts"))
-        .and_then(|f| f.contents_utf8())
-        .map(str::to_string)
+    let path = path.split('?').next().unwrap_or(path);
+    BUILTIN_TREE.get_file(path).and_then(|f| f.contents_utf8()).map(str::to_string)
 }
 
 /// Write the API source tree to `dest`, returning the number of files written.

--- a/crates/neosh-script/tests/runtime.rs
+++ b/crates/neosh-script/tests/runtime.rs
@@ -322,7 +322,7 @@ fn every_bundled_plugin_is_well_formed() {
             "{}: no activate export, so nothing would happen when it loads",
             p.name
         );
-        assert!(p.url.starts_with("neosh:builtin/"), "{}: unexpected url {}", p.name, p.url);
+        assert!(p.url.starts_with("neosh:/builtin/"), "{}: unexpected url {}", p.name, p.url);
     }
 }
 

--- a/crates/neosh-tui/src/shimmer.rs
+++ b/crates/neosh-tui/src/shimmer.rs
@@ -284,7 +284,82 @@ pub fn animate(
                 })
                 .collect()
         }
+        Animation::Spectrum { .. } => {
+            let clusters: Vec<&str> = text.graphemes(true).collect();
+            if clusters.is_empty() {
+                return Vec::new();
+            }
+            // Measured in clusters like the sweep, and for the same reason: a rainbow timed in
+            // bytes has a different pitch in CJK than in ASCII.
+            //
+            // Two-thirds of a turn across the run, so a short label carries a visible gradient
+            // rather than one flat colour, and a long one does not repeat itself twice over.
+            let spread = 0.66 / clusters.len().max(1) as f32;
+            let lightness = base_rgb(&base).map_or(0.62, luminance);
+            let start = phase(anim.period_ms());
+            clusters
+                .iter()
+                .enumerate()
+                .map(|(i, g)| {
+                    let hue = start + i as f32 * spread;
+                    let colour = if truecolor {
+                        hue_at(hue, lightness)
+                    } else {
+                        let at = ((hue.fract() + 1.0).fract() * 6.0) as usize;
+                        ANSI_HUES[at.min(5)]
+                    };
+                    // Bold as well as coloured: without truecolor the six hues are all there is,
+                    // and the whole point of this animation is that it is impossible to miss.
+                    Span::styled(
+                        (*g).to_string(),
+                        base.fg(colour).remove_modifier(Modifier::DIM).add_modifier(Modifier::BOLD),
+                    )
+                })
+                .collect()
+        }
     }
+}
+
+/// The six ANSI hues, in spectral order, for a terminal that cannot mix its own.
+///
+/// Six rather than the full sixteen: the dim halves of each pair differ by brightness rather than by
+/// hue, and a rainbow that keeps stepping back on itself reads as flicker.
+const ANSI_HUES: [Color; 6] = [
+    Color::LightRed,
+    Color::LightYellow,
+    Color::LightGreen,
+    Color::LightCyan,
+    Color::LightBlue,
+    Color::LightMagenta,
+];
+
+/// How light a colour reads, 0 to 1. Rec. 601 weights, which is what the eye does with green.
+fn luminance((r, g, b): (u8, u8, u8)) -> f32 {
+    (0.299 * r as f32 + 0.587 * g as f32 + 0.114 * b as f32) / 255.0
+}
+
+/// A hue at a given lightness, fully saturated. `hue` wraps, so callers need not normalise.
+///
+/// Lightness is taken from whatever the group was already going to be drawn in, so the same
+/// animation stays readable on a light theme and on a dark one without either being told about the
+/// other.
+fn hue_at(hue: f32, lightness: f32) -> Color {
+    let h = (hue.fract() + 1.0).fract() * 6.0;
+    let l = lightness.clamp(0.25, 0.85);
+    // HSL with S = 1, written out rather than pulled in: one call site, six lines, no dependency.
+    let c = (1.0 - (2.0 * l - 1.0).abs()) * 1.0;
+    let x = c * (1.0 - (h % 2.0 - 1.0).abs());
+    let m = l - c / 2.0;
+    let (r, g, b) = match h as u32 {
+        0 => (c, x, 0.0),
+        1 => (x, c, 0.0),
+        2 => (0.0, c, x),
+        3 => (0.0, x, c),
+        4 => (x, 0.0, c),
+        _ => (c, 0.0, x),
+    };
+    let to8 = |v: f32| ((v + m) * 255.0).round().clamp(0.0, 255.0) as u8;
+    Color::Rgb(to8(r), to8(g), to8(b))
 }
 
 /// Lift a style toward "lit", by `t` in `0.0..1.0`.
@@ -442,6 +517,35 @@ mod tests {
         let ns = NamespaceId(9);
         let lit = (1..=20).filter(|i| first_seen(ns, ExtmarkId(*i)).is_some()).count();
         assert_eq!(lit, BURST, "only the first few of a burst are treated as news");
+    }
+
+    #[test]
+    fn a_spectrum_gives_neighbouring_cells_different_hues() {
+        // The whole point: one colour along the run, not one colour for the run. A gradient that
+        // resolved to the same value everywhere would be an expensive way to draw plain text.
+        let spans = animate("ultrathink", styled(), Animation::Spectrum { period_ms: 4000 }, true, None);
+        assert_eq!(spans.len(), "ultrathink".graphemes(true).count());
+        assert!(spans[0].style.fg != spans[spans.len() - 1].style.fg);
+    }
+
+    #[test]
+    fn a_spectrum_keeps_the_lightness_it_was_given() {
+        // A rainbow at a fixed lightness is a rainbow that vanishes on a light theme. The hue is
+        // the animation's; how bright it is belongs to whoever chose the colour.
+        let dark = animate("abc", Style::default().fg(Color::Rgb(40, 40, 40)), Animation::Spectrum { period_ms: 4000 }, true, None);
+        let light = animate("abc", Style::default().fg(Color::Rgb(220, 220, 220)), Animation::Spectrum { period_ms: 4000 }, true, None);
+        let lum = |s: &Span| match s.style.fg {
+            Some(Color::Rgb(r, g, b)) => luminance((r, g, b)),
+            _ => panic!("truecolor spectrum must produce rgb"),
+        };
+        assert!(lum(&dark[0]) < lum(&light[0]));
+    }
+
+    #[test]
+    fn without_truecolor_a_spectrum_is_six_hues_rather_than_none() {
+        let spans = animate("abcdefgh", styled(), Animation::Spectrum { period_ms: 4000 }, false, None);
+        assert!(spans.iter().all(|s| ANSI_HUES.contains(&s.style.fg.expect("a hue"))));
+        assert!(spans.iter().all(|s| s.style.add_modifier.contains(Modifier::BOLD)));
     }
 
     #[test]

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -4140,6 +4140,18 @@ impl Host {
         // somebody else's. Left running, the mode survives into a conversation it was never opened
         // on, and the rows it names there are whatever happens to be at those numbers.
         self.leave_reading();
+        // Arriving is reading. Every way into a conversation comes through here — switching, a new
+        // one, the one you land on after closing or archiving, and the one a restored workspace
+        // opens on — so this is the one place that has to clear the mark, and a flag left set on
+        // the conversation you are sitting in would say "new" about the answer on screen.
+        let arrived = {
+            let mut store = self.agent.sessions();
+            let here = store.active_id().clone();
+            store.mark_read(&here)
+        };
+        if arrived {
+            self.persist_sessions();
+        }
         // Not closed: the buffer is about to be replaced wholesale, so settling an answer into rows
         // that are on their way out would write into the conversation being left behind.
         self.answer = None;
@@ -5292,6 +5304,12 @@ impl Host {
                 self.rounds.remove(&session);
                 if let Some(s) = self.agent.sessions().get_mut(&session) {
                     s.updated_at = now_secs();
+                    // News, and only where you were not looking. A turn that ended in the
+                    // conversation on screen has been seen by definition — including with nothing
+                    // attached, because reattaching lands you in that conversation with the answer
+                    // already in it. Anywhere else, the row is the only thing that will ever
+                    // mention it, so it has to say so until you go there. See ADR 0042.
+                    s.unread = !on_screen;
                 }
                 self.persist_sessions();
                 if self.watched(&session) {

--- a/crates/neosh/src/sessions.rs
+++ b/crates/neosh/src/sessions.rs
@@ -47,6 +47,13 @@ struct Stored {
     /// meter whose denominator changed on reload would move without anything having happened.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     context_window: Option<u64>,
+    /// A turn finished here and nobody has been back to look at it.
+    ///
+    /// Persisted because that is exactly the case it exists for: the workspace ran the turn while
+    /// you were elsewhere, and "elsewhere" includes having stopped and restarted the thing. A mark
+    /// that a restart cleared would go out precisely when the wait was longest.
+    #[serde(default)]
+    unread: bool,
     /// Put away rather than deleted. Defaulted, so a session written before archiving existed
     /// comes back in the open list, which is where it was.
     #[serde(default)]
@@ -113,6 +120,7 @@ impl From<&Session> for Stored {
             usage: s.usage,
             context_tokens: s.context_tokens,
             context_window: s.context_window,
+            unread: s.unread,
             archived: s.archived,
             archived_at: s.archived_at,
             permission_mode: s.permission_mode,
@@ -134,6 +142,7 @@ impl Stored {
         s.usage = self.usage;
         s.context_tokens = self.context_tokens;
         s.context_window = self.context_window;
+        s.unread = self.unread;
         s.archived = self.archived;
         s.archived_at = self.archived_at;
         s.permission_mode = self.permission_mode;
@@ -307,6 +316,28 @@ mod tests {
             None,
             "a conversation no driver has run yet has nothing to pick up, and starting fresh is right"
         );
+    }
+
+    /// The wait a restart makes longer is exactly the one the mark is for.
+    ///
+    /// A turn ran while you were elsewhere, and "elsewhere" includes having closed the terminal and
+    /// come back tomorrow. A flag that a restart cleared would go out precisely when it was doing
+    /// the most work.
+    #[test]
+    fn a_finished_turn_you_have_not_seen_survives_the_workspace() {
+        let t = tmp("unread");
+        let mut waiting = session("go and do it");
+        waiting.unread = true;
+        let seen = session("we spoke");
+        save(&t.0, &waiting).expect("save");
+        save(&t.0, &seen).expect("save");
+
+        let (loaded, _) = load(&t.0);
+        let of = |id: &neosh_proto::SessionId| {
+            loaded.iter().find(|s| &s.id == id).expect("saved").unread
+        };
+        assert!(of(&waiting.id));
+        assert!(!of(&seen.id), "and a conversation with no news does not acquire any by being saved");
     }
 
     /// A mode you chose for one conversation is a decision, not a mood.

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -253,6 +253,42 @@ impl Session {
         open
     }
 
+    /// Every buffer that has ever been opened under `name`, newest last.
+    ///
+    /// A panel that is opened, closed and opened again is two buffers with one name, so a helper
+    /// that took the first would be watching the one from last time forever.
+    fn buffers_named(&self, name: &str) -> Vec<u64> {
+        self.events
+            .iter()
+            .filter(|e| e["type"] == "buffer_opened" && e["name"] == name)
+            .filter_map(|e| e["buf"].as_u64())
+            .collect()
+    }
+
+    /// Wait until something on screen is showing a buffer called `name`.
+    ///
+    /// Not `wait_for` on its text: that scans everything the screen has *ever* said, so the second
+    /// time a panel is opened it returns immediately — before the panel is there — and the keys
+    /// meant for it go to the composer instead.
+    fn wait_open(&mut self, name: &str) {
+        let there = |s: &Session| s.buffers_named(name).iter().any(|b| !s.windows_for(*b).is_empty());
+        assert!(self.pump(there), "{name} never opened\n{}", self.transcript());
+    }
+
+    /// Wait until nothing on screen is showing the buffer called `name`.
+    ///
+    /// The panels are plugin-drawn, so closing one is a round trip: the key resolves against the
+    /// window that is still open, the plugin is told, and the window goes away a moment later. A
+    /// test that types the next key immediately is typing it *into the panel* — which no person is
+    /// fast enough to do, and every test is.
+    fn wait_closed(&mut self, name: &str) {
+        let gone = |s: &Session| {
+            let bufs = s.buffers_named(name);
+            !bufs.is_empty() && bufs.iter().all(|b| s.windows_for(*b).is_empty())
+        };
+        assert!(self.pump(gone), "{name} never closed\n{}", self.transcript());
+    }
+
     /// Windows currently showing `buf`.
     fn windows_for(&self, buf: u64) -> Vec<u64> {
         let open = self.open_windows();
@@ -706,14 +742,15 @@ fn choosing_a_model_reports_the_new_selection() {
 }
 
 #[test]
-fn a_model_with_no_options_says_so_instead_of_opening_an_empty_picker() {
-    // The mock driver exposes no `ProviderOptionDescriptor`s, so the effort switcher has nothing to
-    // offer. Opening an empty list and making the user press Escape would be worse than a message.
+fn a_model_with_no_options_says_so_instead_of_opening_an_empty_panel() {
+    // The mock driver exposes no `ProviderOptionDescriptor`s, so the switcher has nothing to offer.
+    // Opening an empty panel and making the user press Escape would be worse than a message — and
+    // the message names the model, because the answer to "why not" is almost always "not that one".
     let sb = Sandbox::new("effort");
     let mut s = sb.start();
     s.wait_for("PROJECTS");
     s.ctrl("e");
-    s.wait_for("has no options to set");
+    s.wait_for("has nothing to set");
 }
 
 // ---------------------------------------------------------------------------
@@ -1008,6 +1045,53 @@ export async function activate({ neosh }: PluginContext) {
 }
 "#;
 
+/// A driver whose top level is a *word* rather than a parameter.
+///
+/// The shape a vendor harness has: a ladder that can be sent, plus a level you buy by saying it. The
+/// handler reads back both halves of what arrived, which is the only way to tell the difference
+/// between "the word was injected" and "the word was sent as the effort, and the endpoint would have
+/// rejected it".
+const SPOKEN_KNOB: &str = r#"
+import type { PluginContext } from "@neosh/api";
+
+export async function activate({ neosh }: PluginContext) {
+  await neosh.provider.register("spoken", [{
+    id: "lab",
+    driver: "spoken",
+    display_name: "Lab",
+    models: [{
+      id: "wordy",
+      display_name: "Wordy",
+      capabilities: {
+        tools: false, vision: false, streaming: true, thinking: true, prompt_caching: false,
+        option_descriptors: [{
+          type: "select",
+          id: "effort",
+          label: "Effort",
+          options: [
+            { id: "low", label: "Low", is_default: false },
+            { id: "high", label: "High", is_default: true },
+            { id: "abracadabra", label: "Abracadabra", is_default: false },
+          ],
+          prompt_injected_values: ["abracadabra"],
+        }],
+      },
+    }],
+  }], async (req, emit) => {
+    const last = req.messages[req.messages.length - 1];
+    const text = last?.content.map((b) => (b.type === "text" ? b.text : "")).join("") ?? "";
+    const effort = req.selection.options?.find((o) => o.id === "effort")?.value ?? "none";
+    emit({ type: "message_start", model: "wordy", usage: {} });
+    emit({ type: "block_start", index: 0, block: { kind: "text" } });
+    emit({ type: "text_delta", index: 0, text: `got[${text.replace(/\n/g, "|")}] effort[${effort}]` });
+    emit({ type: "block_stop", index: 0 });
+    emit({ type: "message_delta", stop_reason: { kind: "end_turn" }, usage: {} });
+    emit({ type: "message_stop" });
+  });
+  neosh.notify("spoken ready");
+}
+"#;
+
 /// A driver with a full ladder in it: three rungs, plus one superseded model.
 const LADDER: &str = r#"
 import type { PluginContext } from "@neosh/api";
@@ -1159,20 +1243,107 @@ fn a_driver_can_invent_an_option_and_the_switcher_renders_it() {
     let mut s = sb.start_letting_config_choose();
     s.wait_for("lab ready");
 
-    // The switcher has never heard of "vibe" and does not need to.
+    // The switcher has never heard of "vibe" and does not need to. Every value is on screen at
+    // once — that is what the panel is for — so both of them are visible before anything is chosen.
     s.ctrl("e");
+    s.wait_open("[model options]");
     s.wait_for("Vibe");
     assert!(s.saw("Chill"), "choices rendered\n{}", s.transcript());
     assert!(s.saw("Intense"), "choices rendered\n{}", s.transcript());
 
-    // Move to the second entry and take it.
-    s.special("down");
+    // Along the row, then out. Right rather than down: the values of one knob run across, and the
+    // knobs run down — which is the difference between this and the two nested lists it replaced.
+    s.special("right");
     s.special("enter");
-    s.wait_for("Vibe: Intense");
+    s.wait_closed("[model options]");
 
-    // And it is really on the selection the next turn would use, not just in a message.
+    // And it is really on the selection the next turn would use. Asserted here rather than from a
+    // notification, because there is no longer one to assert: the panel applies as you move, so the
+    // *state* is the acknowledgement.
     s.send(&command("lab.report"));
     s.wait_for(r#"selection: lab/brainy [{"id":"vibe","value":"intense"}]"#);
+}
+
+#[test]
+fn a_level_that_is_a_word_is_said_rather_than_sent() {
+    // The half of `prompt_injected_values` that never existed. The field has been on the wire since
+    // ADR 0011 and nothing acted on it, so choosing such a level put it where a parameter goes —
+    // `--effort abracadabra`, which is not a level, and the turn fails.
+    let sb = Sandbox::new("spoken");
+    let dir = sb.root.join("config/plugins/lab");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    std::fs::write(
+        dir.join("plugin.toml"),
+        "name = \"lab\"\nversion = \"0.1.0\"\nentry = \"main.ts\"\npermissions = [\"providers\"]\n",
+    )
+    .expect("write manifest");
+    std::fs::write(dir.join("main.ts"), SPOKEN_KNOB).expect("write plugin");
+    sb.write_config("[options]\n\"agent.model\" = \"lab/wordy\"\n");
+
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("spoken ready");
+    s.ctrl("e");
+    s.wait_open("[model options]");
+    // Past the top of the sendable ladder: low, high, and then the word.
+    s.special("right");
+    s.special("right");
+    s.special("enter");
+    s.wait_closed("[model options]");
+
+    for c in ["h", "e", "l", "l", "o"] {
+        s.key(c);
+    }
+    s.special("enter");
+
+    // Both halves at once. The word arrived at the top of the message, and what went in the
+    // parameter is the ladder's own default rather than the word — so a driver that would have
+    // rejected it never sees it, and a driver whose default is lower does not quietly get its way.
+    s.wait_for("got[abracadabra||hello] effort[high]");
+}
+
+#[test]
+fn what_you_typed_is_what_the_transcript_keeps() {
+    // The word belongs to the *request*, not to the conversation. Written into the stored message it
+    // would be replayed on every later turn — so turning the level off would not turn it off — and
+    // it would be sitting in the transcript above an answer, as something you never said.
+    let sb = Sandbox::new("spokenkeep");
+    let dir = sb.root.join("config/plugins/lab");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    std::fs::write(
+        dir.join("plugin.toml"),
+        "name = \"lab\"\nversion = \"0.1.0\"\nentry = \"main.ts\"\npermissions = [\"providers\"]\n",
+    )
+    .expect("write manifest");
+    std::fs::write(dir.join("main.ts"), SPOKEN_KNOB).expect("write plugin");
+    sb.write_config("[options]\n\"agent.model\" = \"lab/wordy\"\n");
+
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("spoken ready");
+    s.ctrl("e");
+    s.wait_open("[model options]");
+    s.special("right");
+    s.special("right");
+    s.special("enter");
+    s.wait_closed("[model options]");
+    for c in ["h", "i"] {
+        s.key(c);
+    }
+    s.special("enter");
+    s.wait_for("got[abracadabra||hi]");
+
+    // Back down the ladder, and ask again. If the first turn's word had been kept, this one would
+    // carry it too.
+    s.ctrl("e");
+    s.wait_open("[model options]");
+    s.special("left");
+    s.special("left");
+    s.special("enter");
+    s.wait_closed("[model options]");
+    for c in ["y", "o"] {
+        s.key(c);
+    }
+    s.special("enter");
+    s.wait_for("got[yo] effort[low]");
 }
 
 #[test]
@@ -1202,10 +1373,11 @@ fn switching_models_keeps_an_option_the_new_one_also_has() {
     let mut s = sb.start_letting_config_choose();
     s.wait_for("lab ready");
     s.ctrl("e");
+    s.wait_open("[model options]");
     s.wait_for("Vibe");
-    s.special("down");
+    s.special("right");
     s.special("enter");
-    s.wait_for("Vibe: Intense");
+    s.wait_closed("[model options]");
 
     // Move to "Plain", which has no options at all.
     s.ctrl("p");

--- a/crates/neosh/tests/sessions.rs
+++ b/crates/neosh/tests/sessions.rs
@@ -312,6 +312,10 @@ export async function activate({ neosh }: PluginContext) {
       neosh.notify(`archive failed: ${e}`);
     }
   });
+  await neosh.cmd.register("t.unread", async () => {
+    const all = await neosh.session.list();
+    neosh.notify(`unread: [${all.filter((s) => s.unread).map((s) => s.label).join(", ")}]`);
+  });
   await neosh.cmd.register("t.rename", async () => {
     const cur = await neosh.session.current();
     await neosh.session.rename(cur.id, "Renamed thread");
@@ -735,6 +739,106 @@ fn switching_away_from_a_running_turn_leaves_it_running_where_it_belongs() {
         "with the question that started it\n{:?}",
         s.chat_now()
     );
+}
+
+/// A model whose turn ends exactly when the test says so.
+///
+/// Everything else here either answers immediately or never, and what is being asserted below
+/// happens *between* the two: you switch away, and only then does the answer arrive. Both halves
+/// have to be under the test's control or it is a race with a sleep in it.
+///
+/// It reports what the conversation list says the moment a turn ends, because that is when the
+/// mark is set — asking afterwards from the test would be asking before the host had finished.
+fn install_held(sb: &Sandbox) {
+    let dir = sb.root.join("config/plugins/held");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    std::fs::write(
+        dir.join("plugin.toml"),
+        "name = \"held\"\nversion = \"0.1.0\"\nentry = \"main.ts\"\npermissions = [\"providers\"]\n",
+    )
+    .expect("manifest");
+    std::fs::write(
+        dir.join("main.ts"),
+        r#"
+import type { PluginContext } from "@neosh/api";
+export async function activate({ neosh }: PluginContext) {
+  let release: null | (() => void) = null;
+  // Numbered, because the test waits for the answer before releasing it and "have I seen this
+  // text" cannot tell the second turn's answer from the first one's.
+  let n = 0;
+  await neosh.provider.register("held", [{
+    id: "held", driver: "held", display_name: "Held",
+    models: [{ id: "held", display_name: "Held" }],
+  }], async (_req, emit) => {
+    n += 1;
+    emit({ type: "message_start", model: "held", usage: {} });
+    emit({ type: "block_start", index: 0, block: { kind: "text" } });
+    emit({ type: "text_delta", index: 0, text: `answer ${n}` });
+    await new Promise<void>((resolve) => { release = resolve; });
+    emit({ type: "block_stop", index: 0 });
+    emit({ type: "message_delta", stop_reason: { kind: "end_turn" }, usage: {} });
+    emit({ type: "message_stop" });
+  });
+  neosh.agent.onTurnEnd(async () => {
+    const all = await neosh.session.list();
+    const news = all.filter((s) => s.unread).map((s) => s.label);
+    neosh.notify(`news: [${news.join(", ")}]`);
+  });
+  await neosh.cmd.register("t.useHeld", async () => {
+    await neosh.agent.setSelection({ instance: "held", model: "held", options: [] });
+    neosh.notify("using held");
+  });
+  await neosh.cmd.register("t.release", async () => {
+    if (release) { release(); release = null; }
+    neosh.notify("released");
+  });
+  neosh.notify("held ready");
+}
+"#,
+    )
+    .expect("plugin");
+}
+
+#[test]
+fn a_turn_that_ended_while_you_were_elsewhere_is_news_until_you_go_and_look() {
+    // The whole reason the flag exists. A turn takes minutes, you go and work in another
+    // conversation, and the row it left behind is the same row it was before — so the answer you
+    // were waiting for is found by opening things until one of them has it.
+    let sb = Sandbox::new("unread");
+    install_driver(&sb);
+    install_held(&sb);
+
+    let mut s = sb.start();
+    s.wait_for("driver ready");
+    s.wait_for("held ready");
+    s.command("t.new");
+    s.wait_for("created");
+    s.command("t.useHeld");
+    s.wait_for("using held");
+
+    s.type_text("ask me later");
+    s.enter();
+    s.wait_for("answer 1");
+
+    // Away first, and only then does it finish.
+    s.command("t.other");
+    s.wait_for("switched to");
+    s.command("t.release");
+    s.wait_for("news: [ask me later]");
+
+    // And going back is what reads it. Nobody pressed a "mark as read": arriving is the gesture.
+    s.command("t.other");
+    s.wait_for("switched to ask me later");
+    s.command("t.unread");
+    s.wait_for("unread: []");
+
+    // The other half, and the one that would make the mark useless if it were wrong: a turn that
+    // ends in the conversation you are sitting in is not news, it is the screen in front of you.
+    s.type_text("and again");
+    s.enter();
+    s.wait_for("answer 2");
+    s.command("t.release");
+    s.wait_for("news: []");
 }
 
 /// A conversation with a driver that runs its own agent loop and never finishes.

--- a/docs/adr/0042-a-finished-turn-you-have-not-seen-is-news.md
+++ b/docs/adr/0042-a-finished-turn-you-have-not-seen-is-news.md
@@ -1,0 +1,77 @@
+# 0042 — A finished turn you have not seen is news
+
+**Status:** accepted
+
+## Context
+
+The panel says what is happening: a spinner while a turn is running, an elapsed clock next to it, a
+dot on the conversations doing work somewhere else. All of it is about the *present*, and all of it
+stops the moment the work does.
+
+Which leaves the one state the panel never had a word for. A turn takes minutes. You start it, you
+go and work in another conversation — that is the whole reason the workspace holds several — and
+some time later the agent finishes. The row it was on stops spinning and becomes an ordinary row:
+same colour, same glyph, same shape as the eleven around it, distinguished only by an age in the
+right-hand column that every other row also has. The answer you were waiting for is now found by
+opening conversations until one of them has it.
+
+It gets worse the better the rest of the workspace works. The daemon means turns survive the
+terminal closing, so the finish can happen while nothing is attached at all; ASCP means some of
+those rows are conversations on another machine. The more work you can start and walk away from,
+the more of it you can lose track of — and "lose track of" here means the agent did what you asked
+and you never read it.
+
+The alternative people reach for is a notification: a toast, a bell, a line in the status bar. It is
+the wrong shape. A toast is gone in four seconds and the wait is measured in minutes, so it is
+precisely the message you are not there for. A bell says something finished and not which thing. And
+neither survives closing the terminal, which is the case that needs it most.
+
+## Decision
+
+**A conversation carries whether you have seen how its last turn ended.** `SessionInfo::unread`,
+set by the host when a turn ends in a conversation that is not the one on screen, and cleared when
+you arrive in it.
+
+**Off screen is the whole test.** A turn ending in the conversation you are looking at is not news —
+it is the screen in front of you. That includes the case where nothing is attached: reattaching
+lands you in that conversation with the answer already in it, so it has been seen by the time it
+could have been missed.
+
+**Arriving is the gesture that reads it.** There is no "mark as read" key and no dismissal. The
+store clears the flag on `switch`, and the host clears it on every other way into a conversation —
+a new one, the one you land on after closing or archiving, the one a restored workspace opens. A
+mark you have to clear by hand is a second chore attached to the first one.
+
+**It is on the conversation, not in the panel.** The sidebar, a status segment and a picker are
+three different lists of the same conversations, and a mark each of them worked out for itself is
+three answers to one question. It is also persisted, because the wait a restart makes longer is
+exactly the wait this is for.
+
+**It looks like attention, and it does not move.** `Status.Unread` is the amber the palette already
+uses for *act now*, bold, sharing a hue with `Status.Approval` because they are asking the same
+thing. The whole row wears it, not just the glyph: a single coloured character five columns in is
+findable if you already know it is there, which is the one thing you cannot assume about a
+conversation you have forgotten you started. And it does not shimmer or pulse — motion is reserved
+for "something is happening you cannot see", and this is the opposite: nothing is happening, it has
+already happened, and it will still be true in an hour.
+
+**A folded project says how much of it is unseen**, as a dot after its name — `● ` or `●3` — because
+folding is the thing that hid the rows. With the project open, the conversations say it themselves
+and the project row says nothing: the same fact on two adjacent lines is how a panel teaches you to
+stop reading it.
+
+## Consequences
+
+- **The mark is at most one per conversation.** Two turns finishing while you were away is still one
+  row asking to be read, because the thing you do about it is the same either way. A count of
+  unread *turns* would be a number nobody acts on differently.
+- **An interrupted turn counts.** `TurnEnded` is `TurnEnded`, and a turn that stopped early
+  somewhere you were not is a thing you probably want to know about. If interrupting from another
+  conversation ever becomes ordinary, this is the line to revisit.
+- **Remote agents do not have one yet.** `AgentState` still says only `Running`, `Idle` or
+  `Blocked`. A conversation on another machine has an owner who may well have read it already, and
+  "unseen by whom" is a question ASCP has no answer for — so the mark stays local until it does.
+- **A plugin can do something else with it entirely.** It is a field on the public `SessionInfo`, so
+  a status segment counting unread conversations, a picker that sorts them first, or a notifier
+  which does send a system notification, are all things a third party writes without an op of its
+  own.

--- a/docs/adr/0042-somewhere-clean-to-try-this.md
+++ b/docs/adr/0042-somewhere-clean-to-try-this.md
@@ -1,0 +1,81 @@
+# 0042 — Somewhere clean to try this, without naming it first
+
+**Status:** accepted
+
+Refines [0029](0029-a-conversation-carries-its-directory.md), which made a conversation belong to a
+directory, and the `^N` picker that came with it.
+
+## Context
+
+Two complaints about starting a conversation, which turn out to be the same complaint.
+
+**`n` and `^N` did different things.** `^N` in the chat opened a picker asking where the
+conversation goes. `n` in the project panel created one immediately in the project under the
+cursor. One letter and a modifier apart, and the only way to learn that they differ is to be
+surprised by it once — press the one you thought was the careful one and find a conversation
+already made. There is no reading of "new conversation" under which the panel's version should
+answer fewer questions than the chat's; if anything the panel is where you are *browsing* and least
+committed.
+
+**Naming a branch is a question asked at the worst possible moment.** The picker's worktree row
+prompted for a branch. That is one field, and it is the field standing between "I want to try
+something without disturbing this" and trying it. You do not know what the work is yet — that is
+why you are opening a clean tree — so the name is either a guess you will fix later or a reason to
+close the picker and keep working where you are. Every tool in this space that people describe as
+pleasant to reach for makes this free: a directory appears, it has a name, you are in it.
+
+The two are the same complaint because both are the program asking for a commitment before the
+work, when it could ask afterwards or not at all.
+
+## Decision
+
+**One question, asked the same way from both keys.** `n` in the panel opens the picker `^N` opens.
+`Here` is the first row in both, so `n ⏎` and `^N ⏎` do what those keys always did, and nothing is
+created until a row is chosen.
+
+**The picker is about a project, not about you.** `session.new` takes the directory it is asking
+about — the conversation's own for `^N`, the row under the cursor for `n`. This is not cosmetic:
+the rows in that picker are *that repository's* worktrees, and a panel listing four projects would
+otherwise offer the branches of whichever conversation happened to be active. A row naming the
+wrong branch is worse than no row.
+
+That required `git_worktrees`, `git_branches` and `git_add_worktree` to take an optional `cwd`.
+Absent means the conversation's own, which is what a status bar or a branch picker means and what
+every existing caller keeps getting. Discovery is one `rev-parse`, so a caller naming a directory
+per call is cheaper than the host keeping a table of open repositories — and the table would be
+stale the moment the cursor moved anyway.
+
+**A worktree you do not have to name.** The first worktree row creates one outright: a generated
+two-word branch, under `worktree.root` as always, and you land in it. `git.worktree.new.auto`. The
+row that asks for a name stays, below it, because knowing the name is a real state to be in — it is
+just not the common one.
+
+The name is an adjective and a noun — `brisk-otter`, `swift-thistle` — because a name you can say
+out loud is a name you can find again in a list of eight of them. `wt-3` is not, and a timestamp is
+neither. Collisions are checked against the branch list the caller already has in hand rather than
+hoped away; with a few dozen trees the birthday problem is real. Renaming later is `git branch -m`,
+like any branch.
+
+**Rows of a picker can carry an icon and a highlight group.** `PickerItem.icon` and `.hl`, on the
+shared widget rather than in this plugin, because the problem is not specific to this list: a
+column of labels where some rows are places, some are machines and some are actions reads as one
+undifferentiated column. A group name and never a colour, so a row follows the theme like
+everything else. The gutter is all-or-nothing per list — giving it only to rows that asked for an
+icon would step every other label one column left.
+
+## Consequences
+
+Starting a clean branch is `^N ↓ ⏎`, and there is no field in it.
+
+`n` is one keystroke longer than it was for the person who always wanted "here, now". That is the
+trade, and it is the right one: the extra keystroke is `⏎` on a preselected row, and what it buys
+is that the two keys named after the same thing do the same thing.
+
+An optional `cwd` on three git calls is a widening of the API surface, and the honest cost is that
+"which repository" is now a question every caller could ask and most should not. The default is the
+one they already meant, so the failure mode is verbosity rather than wrongness.
+
+The generated names are English words, and a repository whose branches are already `amber-*` will
+occasionally collide — which is checked, and falls back to a counter. What is *not* handled is a
+name that is free locally and taken on a remote nobody has fetched; that surfaces as git refusing
+the branch, with git's message, which is the same thing that happens when you type one.

--- a/docs/adr/0043-a-setting-you-cannot-send.md
+++ b/docs/adr/0043-a-setting-you-cannot-send.md
@@ -1,0 +1,126 @@
+# 0043 — A setting you cannot send, and a panel that shows all of them
+
+**Status:** Accepted.
+
+## Context
+
+Three complaints, one shape.
+
+**The knob only existed for one vendor.** `ProviderOptionDescriptor` has been the mechanism for
+per-model options since ADR 0011, and exactly three catalogues filled it in: Anthropic, `claude-cli`
+and `codex-cli`. Every OpenAI-shaped endpoint, Gemini, and every ACP agent advertised nothing — so
+`^E` on a GPT-5 answered "has no options to set" about a model whose *first documented parameter* is
+`reasoning_effort`. The driver was already sending `reasoning_effort` if a selection carried one.
+Nothing ever put one there.
+
+**A field was carried and never read.** `prompt_injected_values` has been on the wire since 0011,
+documented as "some vendors gate reasoning depth on magic words in the user message", and nothing
+anywhere acted on it. Had a catalogue used it, the value would have gone out as the parameter it is
+not: `--effort ultrathink`, which is not a level, and the turn fails.
+
+**Only one knob was ever visible.** The switcher was two nested pickers, and with exactly one
+descriptor it skipped the outer one — so `^E` opened a list of effort levels and nothing on screen
+said that fast mode, the context window or anything else existed.
+
+## Decision
+
+### A knob you cannot send is still a knob
+
+Some settings are words in the message. `claude` reads `ultrathink` and spends past anything
+`--effort` accepts; `ultracode` turns on orchestration that has no flag at all. They are settings by
+every test that matters — you choose one, it changes the next turn, it should be visible while it is
+on — and they cannot travel as parameters.
+
+So they travel in the message, and the plumbing is generic:
+
+* A select declares `prompt_injected_values`; **the value id is the word**. Nothing between the
+  catalogue and the driver holds a table of magic strings.
+* A boolean declares `prompt_injected_word`, for the switches that are a yes/no rather than a rung.
+  Orchestration is not a point on a depth ladder: you can want a fleet of sub-agents on a shallow
+  turn, and asking for one by moving a slider marked "how hard should it think" is a control that
+  does two things and says one.
+* `neosh_provider::injection` takes the words out of the selection and puts them in the message.
+
+Three properties fall out of doing it in the agent rather than in a driver:
+
+1. **Every driver gets it**, including a provider plugin we have never seen.
+2. **The transcript never sees it.** The word goes into the copy of the message this turn sends.
+   What you typed is what stays on screen and what the next turn replays — otherwise every turn
+   after an ultrathink carries the word again and turning it off does not turn it off. For the same
+   reason it is applied on the first round only: a tool result travels as a user message, and the
+   word on that one would be a fresh instruction after every tool call.
+3. **Nothing invalid reaches the wire.** The injected value is replaced with the ladder's own
+   default, so the parameter is one the endpoint accepts. The *ladder's* default, not the driver's:
+   dropping the option instead would hand a driver whose default is `medium` the job of choosing,
+   and quietly lower the depth of the turn you asked to deepen.
+
+**The words are the harness's, not the model's.** `ultrathink` is on `claude-cli` and deliberately
+not on `anthropic`: `api.anthropic.com` serves a model, and a message beginning with that word is a
+message beginning with a word. Offering a level that silently does nothing — on the one provider
+where the same word does something real — would make "it worked yesterday" a difference of instance
+that nothing on screen can explain.
+
+### Discovery where it exists, catalogue where it does not
+
+The same split ADR 0011 made for model *ids*, applied to their knobs.
+
+* **OpenRouter says.** Its `/models` carries `supported_parameters`, which is the only place in the
+  OpenAI-compatible family where "does this model reason" has a real answer. Four hundred models
+  arrive with the right ladder each and no catalogue entry between them.
+* **OpenAI does not**, so its ladder is written down — `minimal` at the bottom, which Anthropic has
+  no equivalent for, and a top rung that differs by generation.
+* **Gemini changed shape between generations**, so the 3 line gets `thinking_level` and the 2.5 line
+  gets a thinking switch. Two knobs rather than one knob and a translation layer nobody can see. 2.5
+  Pro gets neither, because its budget cannot be set to zero and a control the endpoint rejects is
+  worse than no control.
+* **xAI, DeepSeek and Mistral get nothing, and that is the finding.** None of them documents a
+  reasoning knob on the models seeded here. An invented one is a 400 on the first turn.
+
+### Everything at once, on one surface
+
+`^E` opens a panel: one row per knob, values along the row, the one in effect lit. `←`/`→` moves
+along a row, `↑`/`↓` between rows, and what you are looking at *is* the state.
+
+It applies as you move. Changing a reasoning level is reversible, and ADR 0039's rule cuts both
+ways: a control that only takes effect when you press the right key to leave is a control that has
+to be taught.
+
+Every key is an ordinary binding on a named command, scoped to the panel's buffer **kind** — ADR
+0040, and the sidebar's pattern exactly. `^N` and `^P` are pointedly *not* among them: they are the
+two most valuable keys in the program, this panel is on screen for a couple of seconds at a time,
+and a binding that shadows one of them for the duration is a key that sometimes does something else.
+
+## How it is drawn
+
+A value's prominence is its position on **its own** ladder — `Option.Step1`…`Step5` — measured over
+the levels that can actually be sent, so a spoken level bolted past the top does not compress the
+five rungs below it. Weight rather than hue, because the palette keeps its three hues for states and
+a reasoning level is a scale, which prominence carries natively.
+
+The exception is the level that is not on the ladder at all. It gets `Option.Beyond`, and
+`Animation::Spectrum` — a hue travelling along the run — is added to the palette for it. It is the
+one animation that abandons the group's own colour, and it is reserved for the one thing that
+deserves it: what it has to say is "this is not one of the normal settings", and no amount of amber
+says that. It keeps the base colour's lightness and replaces only the hue, so a light theme gets a
+rainbow it can read; without truecolor it rotates the six ANSI hues.
+
+The same group goes on the status segment while a spoken value is in effect, which is the only place
+that *can* say so: the word never appears in the transcript, and the panel it was chosen in has been
+shut for an hour.
+
+The acknowledgement of a choice is a flash on the **strip**, not on the panel. Reverse video, which
+the palette reserves for selection and the one-shot "it moved there" — and it is where the setting
+now lives, which is the thing worth teaching. A flash inside the panel would mean holding the window
+open after the key that dismissed it, and a swallowed `^P` costs more than a lit row is worth.
+
+## Consequences
+
+* A bundled plugin can be more than one file. `neosh:builtin/<name>` was a cannot-be-a-base URL, so
+  `./options.ts` beside it had nothing to resolve against; the prefix is now `neosh:/builtin/` and
+  the entry is `…/main.ts`. Bundled plugins were the only plugins in the system that could not be
+  split up, which sat badly with the claim that they are ordinary.
+* `ModelCapabilities::thinking` is now derived from whether a reasoning knob exists, in one place,
+  because three vendors spell that idea three ways.
+* Two ranged highlights over the same character do not compose — the renderer takes the
+  highest-priority one and stops. A group that means "the value in effect" therefore carries its
+  band *and* its colour; a background mark under a foreground mark silently drew one of them.

--- a/docs/config.md
+++ b/docs/config.md
@@ -154,19 +154,36 @@ footer.
 ```
 New conversation
 >
-❯ Here                  /home/you/work/project
-  In a new worktree…    a branch of its own, checked out somewhere else
-  fix/thing             worktree  ·  ~/.nsh/project/fix-thing
-  Another directory…    somewhere else entirely
+❯ ● Here                       /home/you/work/project
+  + In a new worktree          a clean branch, named for you, nothing to answer
+  + In a new worktree, named…  a branch of its own, checked out somewhere else
+  ⎇ fix/thing                  worktree  ·  ~/.nsh/project/fix-thing
+  → api                        on studio  ·  /home/you/work/api
+  … Another directory…         somewhere else entirely
 ```
 
 `Here` is selected, so `^N ⏎` is what `^N` always did. Outside a git repository the question has
 one answer and is not asked at all — `^N` stays a single key everywhere the choice would be
 theatre. `session.new.here` skips it unconditionally, for a key of your own.
 
-Choosing it asks one question — the branch. The location is a setting, and asking again would be
-asking somebody to repeat themselves; the message says where it landed. `git.worktree.new <branch>
-<path>` takes an explicit path for the times you want one.
+**`n` in the project panel asks the same question**, about the project the cursor is on rather than
+the conversation you are in. It used to create one outright, and that was the bug: one letter and a
+modifier apart, doing visibly different things. `Here` is still the first row, so `n ⏎` is what `n`
+always did — and because the question is about the row and not about you, the worktrees offered are
+that repository's.
+
+The second row is the one you want most days. **A worktree with nothing to answer**: the branch is
+named for you — two words, `brisk-otter`, a thing you can say out loud and find again in a list of
+eight of them — it lands under `worktree.root`, and you are in it. Naming a branch before you know
+what the work is is a decision made at the worst possible moment, and having to make it is what
+stops people reaching for a clean tree at all. Renaming it later is `git branch -m`, like any other
+branch. It is `git.worktree.new.auto` for a key or a script.
+
+The row below it is the same thing when you *do* know the name, and it asks exactly one question —
+the branch. The location is a setting, and asking again would be asking somebody to repeat
+themselves; the message says where it landed. `git.worktree.new <branch> [path] [cwd]` takes an
+explicit path for the times you want one, and a repository for the times it is not the one you are
+in.
 
 A worktree is listed by the repository it belongs to and the branch it is on — `neosh · fix/thing`
 — rather than by its directory name. The directory is named by whoever created it, and a panel of

--- a/plugins/api/src/generated/Animation.ts
+++ b/plugins/api/src/generated/Animation.ts
@@ -36,4 +36,5 @@ export type Animation =
      * How long the lift takes to fall back to nothing.
      */
     ms: number;
-  };
+  }
+  | { "kind": "spectrum"; period_ms: number };

--- a/plugins/api/src/generated/ProviderOptionDescriptor.ts
+++ b/plugins/api/src/generated/ProviderOptionDescriptor.ts
@@ -25,4 +25,14 @@ export type ProviderOptionDescriptor = {
   label: string;
   description?: string | null;
   current_value: boolean;
+  /**
+   * A word to put in the message while this is on, for a switch a vendor reads out of the
+   * prompt rather than off a parameter.
+   *
+   * The switch is then *nothing but* that word: with it on, the word is written into the
+   * turn and no option value is sent at all. The same idea as
+   * [`Self::Select::prompt_injected_values`], for the knobs that are a yes/no rather than a
+   * rung — orchestration modes, personas, anything a harness gates on what you said.
+   */
+  prompt_injected_word?: string | null;
 };

--- a/plugins/api/src/generated/SessionInfo.ts
+++ b/plugins/api/src/generated/SessionInfo.ts
@@ -64,6 +64,20 @@ export type SessionInfo = {
   context_window?: number | null;
   is_active: boolean;
   /**
+   * A turn finished here while you were looking at something else.
+   *
+   * The one thing a list of conversations cannot say without being told. A turn takes minutes,
+   * you switch away, and the row it left behind is indistinguishable from the twelve above it —
+   * so the answer you were waiting for is found by opening conversations until one of them has
+   * it. This is the mark that makes it findable, and it is *news* rather than state: it is set
+   * when a turn ends somewhere you were not, and cleared the moment you arrive.
+   *
+   * Off screen is the whole test. A turn that ended in the conversation on screen has already
+   * been seen — including when nothing was attached, because reattaching lands you in that
+   * conversation with the answer in it.
+   */
+  unread: boolean;
+  /**
    * Put away rather than thrown away.
    *
    * An archived conversation keeps every message and can be brought back; it is simply not in

--- a/plugins/builtin/model/main.ts
+++ b/plugins/builtin/model/main.ts
@@ -10,6 +10,7 @@
 import type {
   AccountKind,
   CredentialInfo,
+  Disposable,
   ModelInfo,
   CredentialSource,
   ModelEntry,
@@ -22,8 +23,7 @@ import type {
 } from "@neosh/api";
 import type { PaneItem, RailItem } from "@neosh/api/ui";
 import { confirmDestructive, defineHighlights, picker, prompt, railPicker } from "@neosh/api/ui";
-
-type SelectDescriptor = Extract<ProviderOptionDescriptor, { type: "select" }>;
+import { installOptions, openOptions } from "./options.ts";
 
 export async function activate({ neosh, subscriptions }: PluginContext) {
   await defineHighlights(neosh);
@@ -38,8 +38,8 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
   await neosh.cmd.register("model.pick", () => pickModel(neosh), {
     desc: "Choose the model for this conversation",
   });
-  await neosh.cmd.register("model.options", () => pickOptions(neosh), {
-    desc: "Choose reasoning effort and other per-model options",
+  await neosh.cmd.register("model.options", () => openOptions(neosh), {
+    desc: "Reasoning effort, and everything else this model can be told",
   });
   await neosh.cmd.register("provider.auth", () => pickProvider(neosh), {
     desc: "Sign in to a provider, or forget a key",
@@ -69,7 +69,15 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
   // The footer. The model and its options belong beside the composer rather than on a settings
   // page: they are the two things you change mid-conversation — and each carries its own key,
   // because a key is only memorable next to the thing it changes.
-  const footer = async () => {
+  /**
+   * `flash` lights the options segment for a moment before settling.
+   *
+   * The "it moved there" flash the palette reserves reverse for, and it is here rather than in the
+   * panel that was just dismissed for two reasons: it is where the setting now lives, which is the
+   * thing worth teaching, and a panel held open to be looked at after the key that closed it is a
+   * panel still swallowing the next key.
+   */
+  const footer = async (flash = false) => {
     const selection = await neosh.agent.selection().catch(() => null);
     if (!selection) {
       await neosh.status.set("model", {
@@ -110,14 +118,31 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
       await neosh.status.set("effort", {
         text: options,
         keys: "^E",
+        // A setting that is not a level — one bought by saying a word rather than by sending a
+        // parameter — wears the group that animates, so the strip itself says the next turn is not
+        // an ordinary one. It is the only place that *can* say it: the word never appears in the
+        // transcript, and the picker it was chosen in has been shut for an hour.
+        hl: flash
+          ? "Option.Chosen"
+          : beyond(selection.options ?? [], descriptors)
+          ? "Option.Beyond"
+          : undefined,
         align: "right",
         priority: 11,
       });
+      // Long enough to be seen, short enough that nobody waits for it. Settling is an ordinary
+      // redraw, so whatever the strip should say — including a rainbow, if what you chose is a word
+      // rather than a level — is said by the same code that would have said it anyway.
+      if (flash) flashOff?.dispose();
+      if (flash) flashOff = neosh.timer.after(320, () => void footer());
     } else {
       await neosh.status.clear("effort");
     }
   };
   await footer();
+  // The sheet's own keys, bound to this plugin's buffer kind rather than handled privately — so
+  // `F1` lists them and `init.ts` can move any of them. See `options.ts`.
+  await installOptions({ neosh, subscriptions }, (flash) => footer(flash));
   subscriptions.push(neosh.session.onChange(() => void footer()));
   subscriptions.push(neosh.agent.onTurnEnd(() => void footer()));
   // Whoever changed it — this plugin, a stored model that would not authenticate, or a provider
@@ -128,6 +153,9 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
 
 /** Set by `activate`, so the pickers can update the footer the moment a choice lands. */
 let refreshFooter: () => Promise<void> = async () => {};
+
+/** The pending "settle back to normal" after a flash, so two in a row do not fight. */
+let flashOff: Disposable | null = null;
 
 /**
  * The option values, as a line short enough to sit in a footer.
@@ -151,6 +179,24 @@ function summarise(
     }
   }
   return out.join(" ");
+}
+
+/**
+ * Whether anything in effect is applied by *saying* it rather than by sending it.
+ *
+ * Asked of the descriptors rather than of the value's name, because which words a vendor reads is
+ * the vendor's business: this file has never heard of "ultrathink" and does not need to.
+ */
+function beyond(
+  chosen: readonly OptionSelection[],
+  descriptors: readonly ProviderOptionDescriptor[],
+): boolean {
+  return descriptors.some((d) => {
+    const value = chosen.find((o) => o.id === d.id)?.value;
+    return d.type === "boolean"
+      ? value === true && typeof d.prompt_injected_word === "string"
+      : typeof value === "string" && (d.prompt_injected_values ?? []).includes(value);
+  });
 }
 
 /**
@@ -708,77 +754,3 @@ async function pickProvider(neosh: Neosh): Promise<void> {
   await refreshFooter();
 }
 
-async function pickOptions(neosh: Neosh): Promise<void> {
-  const current = await neosh.agent.selection();
-  if (!current) {
-    neosh.notify("no model selected", "warn");
-    return;
-  }
-  const entries = await neosh.agent.listModels(current.instance);
-  const descriptors =
-    entries.find((e) => e.model.id === current.model)?.model.capabilities?.option_descriptors ?? [];
-  if (descriptors.length === 0) {
-    neosh.notify(`${current.model} has no options to set`);
-    return;
-  }
-
-  // One knob goes straight to its values; more than one asks which knob first. Keeping the common
-  // case — reasoning effort, and nothing else — a single keystroke is worth the branch.
-  const descriptor =
-    descriptors.length === 1
-      ? descriptors[0]
-      : await picker(
-          neosh,
-          descriptors.map((d) => ({ label: d.label, detail: d.description ?? "", value: d })),
-          { title: `${current.model} options`, width: 64 },
-        );
-  if (!descriptor) return;
-
-  if (descriptor.type === "boolean") {
-    const chosen = await picker<boolean>(
-      neosh,
-      [
-        { label: "On", value: true },
-        { label: "Off", value: false },
-      ],
-      { title: descriptor.label, height: 2, width: 40 },
-    );
-    if (chosen === null) return;
-    await applyOption(neosh, current, descriptor.id, chosen);
-    neosh.notify(`${descriptor.label}: ${chosen ? "on" : "off"}`);
-    return;
-  }
-
-  const select: SelectDescriptor = descriptor;
-  const currentValue =
-    current.options?.find((o) => o.id === select.id)?.value ??
-    select.current_value ??
-    select.options.find((o) => o.is_default)?.id;
-
-  const items = select.options.map((o) => ({
-    label: o.label,
-    detail: o.description ?? (o.is_default ? "default" : ""),
-    value: o.id,
-  }));
-
-  const chosen = await picker(neosh, items, {
-    title: select.label,
-    selected: Math.max(0, items.findIndex((i) => i.value === currentValue)),
-    width: 64,
-  });
-  if (chosen === null) return;
-  await applyOption(neosh, current, select.id, chosen);
-  neosh.notify(`${select.label}: ${select.options.find((o) => o.id === chosen)?.label ?? chosen}`);
-}
-
-async function applyOption(
-  neosh: Neosh,
-  current: ModelSelection,
-  id: string,
-  value: string | boolean,
-): Promise<void> {
-  const options: OptionSelection[] = (current.options ?? []).filter((o) => o.id !== id);
-  options.push({ id, value });
-  await neosh.agent.setSelection({ ...current, options });
-  await refreshFooter();
-}

--- a/plugins/builtin/model/options.ts
+++ b/plugins/builtin/model/options.ts
@@ -1,0 +1,446 @@
+/**
+ * Everything the chosen model can be told, on one surface.
+ *
+ * # Why this is not a picker
+ *
+ * It used to be two: a list of knobs, and then a list of that knob's values. Which meant the answer
+ * to "what can I change about this model" was three keystrokes and a modal you had to back out of
+ * to see the other knob — and, on the common path, no answer at all: with exactly one knob the
+ * outer list was skipped, so `^E` opened a list of effort levels and nothing anywhere said that
+ * fast mode or the context window existed. A setting you cannot see is a setting you do not have.
+ *
+ * So: every knob at once, one row each, values laid out along the row with the current one lit.
+ * `←`/`→` moves along a row, `↑`/`↓` between rows, and what you are looking at *is* the state —
+ * there is no "current value" to go and read somewhere else.
+ *
+ * # Why it is a panel and not a private key handler
+ *
+ * Because ADR 0040 says so, and the sidebar proved why: every key here is an ordinary binding
+ * pointed at a named command, scoped to this buffer's **kind**. `F1` lists them, `^K` runs them,
+ * and `init.ts` can move any of them. A `switch` on the key inside this file is exactly the thing
+ * that rule replaced.
+ *
+ * # What is drawn, and why it moves
+ *
+ * A value's prominence is its position on its own ladder — `Option.Step1`…`Step5`, which is weight
+ * rather than hue, because a reasoning level is a *scale* and the palette keeps its three hues for
+ * states. The exception is a level that is not on the ladder at all: one bought by putting a word
+ * in the message rather than by sending a parameter. That gets `Option.Beyond`, the one group in
+ * the theme that animates a rainbow — because what it has to say is "this is not one of the normal
+ * settings", and no amount of amber says that.
+ */
+
+import type {
+  Disposable,
+  ModelEntry,
+  ModelSelection,
+  Neosh,
+  OptionSelection,
+  ProviderOptionDescriptor,
+} from "@neosh/api";
+import { byteLength, clipToWidth, padToWidth, width } from "@neosh/api";
+
+const KIND = "neosh.model.options";
+const NS = "neosh.model.options";
+
+/** One value a knob can take. */
+interface Choice {
+  id: string;
+  label: string;
+  detail: string;
+  /** Applied by saying it in the message rather than by sending it. */
+  spoken: boolean;
+}
+
+/** One knob, flattened so a boolean and a select draw identically. */
+interface Row {
+  id: string;
+  label: string;
+  description: string;
+  choices: Choice[];
+  /** Which choice is in effect. */
+  at: number;
+  /** Booleans come back as flags, selects as strings. */
+  boolean: boolean;
+}
+
+interface Sheet {
+  win: number;
+  buf: number;
+  ns: number;
+  rows: Row[];
+  /** Which row the keys act on. */
+  cursor: number;
+  selection: ModelSelection;
+  title: string;
+  /** Inside the border. What the description line has to fit in. */
+  inner: number;
+  close(): Promise<void>;
+}
+
+let sheet: Sheet | null = null;
+
+/**
+ * The keys, in the order they were pressed.
+ *
+ * Every verb here is several round trips — set the lines, clear the marks, set a dozen more, hand
+ * the selection back to the agent — and the host dispatches each key as its own command *without
+ * waiting for the last one to finish*. Three keys in flight at once therefore finish in length
+ * order rather than press order, and the shortest verb is `done`: press `→ → ⏎` quickly and the
+ * panel shuts first, leaving two redraws to fail against a window that is already gone. Chaining
+ * them costs nothing — they were serial in effect anyway, because they all touch one buffer — and
+ * it is the same reason the sidebar serialises its own redraws.
+ */
+let queue: Promise<void> = Promise.resolve();
+
+/**
+ * Turn what a driver said into rows.
+ *
+ * A boolean becomes a two-value row, because "off / on" laid out like every other ladder is one
+ * fewer shape to learn than a checkbox that behaves differently from the row above it — and it
+ * gives the spoken switches somewhere to put their word.
+ */
+function rowsFrom(
+  descriptors: readonly ProviderOptionDescriptor[],
+  chosen: readonly OptionSelection[],
+): Row[] {
+  return descriptors.map((d) => {
+    const value = chosen.find((o) => o.id === d.id)?.value;
+    if (d.type === "boolean") {
+      const on = typeof value === "boolean" ? value : d.current_value;
+      // The word, if this switch is one. A switch that is a word is not a parameter at all — see
+      // `prompt_injected_word` — so it wears the same mark as a spoken level.
+      const spoken = typeof d.prompt_injected_word === "string";
+      return {
+        id: d.id,
+        label: d.label,
+        description: d.description ?? "",
+        choices: [
+          { id: "off", label: "off", detail: "", spoken: false },
+          { id: "on", label: "on", detail: "", spoken },
+        ],
+        at: on ? 1 : 0,
+        boolean: true,
+      };
+    }
+    const injected = d.prompt_injected_values ?? [];
+    const current =
+      (typeof value === "string" ? value : undefined) ??
+      d.current_value ??
+      d.options.find((o) => o.is_default)?.id;
+    const choices = d.options.map((o) => ({
+      id: o.id,
+      label: o.label,
+      // What the *driver* said about this level, and nothing invented. A value with nothing to
+      // say falls through to what the knob says, which is better than a row that reads "the
+      // default" where the sentence explaining the control used to be.
+      detail: o.description ?? "",
+      spoken: injected.includes(o.id),
+    }));
+    return {
+      id: d.id,
+      label: d.label,
+      description: d.description ?? "",
+      choices,
+      at: Math.max(0, choices.findIndex((c) => c.id === current)),
+      boolean: false,
+    };
+  });
+}
+
+/**
+ * Which step of the five-rung ramp a value sits on.
+ *
+ * Computed from where it is in *its own* ladder rather than from its name, because the ladders are
+ * different lengths — five levels on Claude, three on an aggregator, two on Gemini — and a `high`
+ * that is the top rung of one and the middle of another should not be drawn the same weight.
+ */
+function step(at: number, of: number): string {
+  if (of <= 1) return "Option.Step3";
+  const rung = Math.round((at / (of - 1)) * 4) + 1;
+  return `Option.Step${Math.min(5, Math.max(1, rung))}`;
+}
+
+/**
+ * The group a value is drawn in, given whether it is the one in effect.
+ *
+ * The ramp is measured over the levels that are *sendable*, so a ladder with a spoken level bolted
+ * past the top of it does not compress: five rungs stay five rungs, and the word on the end is
+ * drawn as the thing off the scale that it is.
+ */
+function groupFor(row: Row, at: number, live: boolean): string {
+  if (!live) return "Option.Unset";
+  const choice = row.choices[at]!;
+  if (choice.spoken) return "Option.Beyond";
+  // A switch is the ends of the scale and nothing in between, said explicitly rather than left to
+  // the ramp: a spoken switch has one ordinary value and one word, and a ladder of length one puts
+  // its only rung in the middle — so `off` on the switch beside it came out brighter than `off` on
+  // an ordinary one, for no reason a reader could ever recover.
+  if (row.boolean) return at === 0 ? "Option.Step1" : "Option.Step5";
+  const ladder = row.choices.filter((c) => !c.spoken);
+  return step(ladder.findIndex((c) => c.id === choice.id), ladder.length);
+}
+
+/** One row's worth of text, and where every value landed in it. */
+interface Painted {
+  text: string;
+  /** `[start, end]` byte offsets, one per choice. */
+  spans: [number, number][];
+}
+
+function paint(row: Row, labelWidth: number, mark: string, glyph: string): Painted {
+  let text = `${mark}${padToWidth(row.label, labelWidth)}  `;
+  const spans: [number, number][] = [];
+  for (const choice of row.choices) {
+    const label = choice.spoken ? `${glyph}${choice.label}` : choice.label;
+    const start = byteLength(text);
+    text += ` ${label} `;
+    spans.push([start, byteLength(text)]);
+  }
+  return { text, spans };
+}
+
+async function draw(neosh: Neosh, s: Sheet, hints: string): Promise<void> {
+  // The panel this frame is about may have been dismissed while the frame was being computed —
+  // every line of it is a round trip. Drawing into a window that is gone is this widget racing
+  // itself, not something the user did wrong.
+  if (sheet !== s) return;
+  const glyph = (await neosh.opt.get<boolean>("ui.ascii_only").catch(() => false)) ? "*" : "✦ ";
+  const labelWidth = Math.max(...s.rows.map((r) => width(r.label)));
+  const painted = s.rows.map((r, i) => paint(r, labelWidth, i === s.cursor ? "❯ " : "  ", glyph));
+
+  const here = s.rows[s.cursor];
+  // A description line that appeared and disappeared with the cursor would move every row below it
+  // on every keystroke, so it has a permanent home at the foot. What it says is whatever the driver
+  // said about the value under the cursor, falling back to what it said about the knob.
+  // Clipped rather than allowed to size the float: this line changes with every keystroke, and a
+  // panel that got wider when the cursor moved onto the row with the long sentence would be a panel
+  // that never stops moving.
+  const said = clipToWidth(here?.choices[here.at]?.detail || here?.description || "", s.inner - 3);
+  const lines = [...painted.map((p) => p.text), "", `  ${said}`, ` ${hints}`];
+  await neosh.buf.setLines(s.buf, 0, -1, lines);
+
+  // Cleared before anything is drawn, every frame. A mark clamps rather than dies when the line
+  // under it is replaced, so a row rewritten on every keypress otherwise accumulates them and ends
+  // up painted by the narrowest one from three keystrokes ago.
+  await neosh.ns.clear(s.ns, s.buf);
+  for (let i = 0; i < s.rows.length; i++) {
+    const row = s.rows[i]!;
+    const p = painted[i]!;
+    if (i === s.cursor) {
+      await neosh.ns.mark(s.ns, s.buf, i, 0, { hlGroup: "Comment", endCol: byteLength("❯ ") });
+    }
+    await neosh.ns.mark(s.ns, s.buf, i, byteLength(i === s.cursor ? "❯ " : "  "), {
+      hlGroup: i === s.cursor ? "Title" : "Comment",
+      endCol: byteLength(p.text.slice(0, p.spans[0]?.[0] ?? 0)),
+    });
+    for (let c = 0; c < row.choices.length; c++) {
+      const [start, end] = p.spans[c]!;
+      const live = c === row.at;
+      // One mark, not a band under a colour: the renderer takes the highest-priority ranged group
+      // covering a character and stops, so two of them here would draw one and silently drop the
+      // other. `Option.Step*` carries the band as well as the step for exactly that reason.
+      await neosh.ns.mark(s.ns, s.buf, i, start, {
+        hlGroup: groupFor(row, c, live),
+        endCol: end,
+      });
+    }
+  }
+  const detail = s.rows.length + 1;
+  await neosh.ns.mark(s.ns, s.buf, detail, 0, {
+    hlGroup: "Picker.Detail",
+    endCol: byteLength(lines[detail] ?? ""),
+  });
+  await neosh.ns.mark(s.ns, s.buf, detail + 1, 0, {
+    hlGroup: "Sidebar.Dim",
+    endCol: byteLength(lines[detail + 1] ?? ""),
+  });
+  await neosh.win.setCursor(s.win, s.cursor, 0);
+}
+
+/**
+ * Put the whole sheet into effect.
+ *
+ * Every keystroke, rather than on the way out. Changing a reasoning level is reversible — you can
+ * see what it is and put it back — and "everything irreversible asks, and nothing reversible does"
+ * cuts both ways: a control that only takes effect when you press the right key to leave is a
+ * control you have to be taught. The footer moves as you move, which is the whole feedback loop.
+ */
+async function apply(
+  neosh: Neosh,
+  s: Sheet,
+  refresh: (flash?: boolean) => Promise<void>,
+): Promise<void> {
+  const options: OptionSelection[] = s.rows.map((row) => {
+    const choice = row.choices[row.at]!;
+    return {
+      id: row.id,
+      value: row.boolean ? row.at === 1 : choice.id,
+    };
+  });
+  s.selection = { ...s.selection, options };
+  await neosh.agent.setSelection(s.selection);
+  await refresh();
+}
+
+/** The keys, as words, read off what is actually bound rather than written out here. */
+function hintsFor(): string {
+  return "↵ done   ←→ change   ↑↓ knob   ⇥ cycle   esc close";
+}
+
+export async function installOptions(
+  { neosh, subscriptions }: { neosh: Neosh; subscriptions: Disposable[] },
+  refresh: (flash?: boolean) => Promise<void>,
+): Promise<void> {
+  const scope = { kind: "buf_kind", name: KIND } as const;
+
+  /** Register a verb and bind it inside the sheet. See the sidebar's `verb` — same reasoning. */
+  const verb = async (
+    name: string,
+    keys: string[],
+    desc: string,
+    fn: (s: Sheet) => Promise<void> | void,
+  ): Promise<void> => {
+    subscriptions.push(
+      await neosh.cmd.register(name, () => {
+        const mine = queue.then(async () => {
+          if (!sheet) return;
+          await fn(sheet);
+        });
+        // One verb that fails must not stop the ones behind it: the panel would look alive and
+        // ignore every key from then on, which is worse than the failure it is hiding.
+        queue = mine.catch((e: unknown) => neosh.notify(String(e), "warn"));
+        return mine;
+      }, { desc }),
+    );
+    for (const key of keys) {
+      await neosh.keymap.set("chat", key, name, { scope, desc });
+    }
+  };
+
+  const redraw = async (s: Sheet) => draw(neosh, s, hintsFor());
+
+  const move = async (s: Sheet, delta: number) => {
+    s.cursor = Math.min(s.rows.length - 1, Math.max(0, s.cursor + delta));
+    await redraw(s);
+  };
+
+  /**
+   * Along the current row.
+   *
+   * `wrap` is the difference between the arrows and the cycle key, and it is deliberate: an arrow
+   * that teleported from `max` back to `low` would be the same surprise as a downgrade key that
+   * lands on the most expensive model in the catalogue, which `ModelTier::step` refuses to be. A
+   * key whose whole job is "the next one" may wrap, because that is what it says it does.
+   */
+  const shift = async (s: Sheet, delta: number, wrap: boolean) => {
+    const row = s.rows[s.cursor];
+    if (!row) return;
+    const n = row.choices.length;
+    row.at = wrap
+      ? (row.at + delta + n) % n
+      : Math.min(n - 1, Math.max(0, row.at + delta));
+    // Drawn before it is applied. Both are round trips and the panel is where you are looking, so
+    // putting the several calls that update the *strip* first makes every keypress wait on work
+    // whose result is behind the window you are reading — and keys arriving meanwhile queue up
+    // against a panel that has not caught up with the last one.
+    await redraw(s);
+    await apply(neosh, s, refresh);
+  };
+
+  // No `^N`/`^P` here, unlike the list widgets. Those two are the most valuable keys in the
+  // program — new conversation, and the model picker — and this panel is on screen for a couple of
+  // seconds at a time. A binding that shadows one of them for the duration is a key that sometimes
+  // does something else, which is the property a keyboard interface can least afford.
+  await verb(`${NS}.next`, ["j", "<Down>"], "Next knob", (s) => move(s, 1));
+  await verb(`${NS}.prev`, ["k", "<Up>"], "Previous knob", (s) => move(s, -1));
+  await verb(`${NS}.higher`, ["l", "<Right>"], "More", (s) => shift(s, 1, false));
+  await verb(`${NS}.lower`, ["h", "<Left>"], "Less", (s) => shift(s, -1, false));
+  await verb(`${NS}.cycle`, ["<Tab>", "<Space>"], "The next value along", (s) => shift(s, 1, true));
+  await verb(`${NS}.close`, ["<Esc>", "q", "<C-c>"], "Back to the composer", (s) => s.close());
+  // Nothing left to apply — every change is already in effect — so what this adds is where the
+  // acknowledgement *goes*: the panel shuts and the strip it moved to flashes, which is the answer
+  // to "fine, but where does that live now". Deliberately not a flash inside the panel: anything
+  // that holds the window open after the key that dismissed it is a window still eating keys, and
+  // a swallowed `^P` costs more than a lit row is worth.
+  await verb(`${NS}.done`, ["<CR>"], "Done", async (s) => {
+    await s.close();
+    await refresh(true);
+  });
+
+  subscriptions.push({ dispose: () => void sheet?.close() });
+}
+
+/**
+ * Open the sheet for whatever model this conversation is on.
+ *
+ * Reads the descriptors afresh every time rather than caching them: they arrive from the *driver*,
+ * and a driver that learned what it accepts by asking — `codex` does — reports a different set
+ * after a refresh than it did at startup.
+ */
+export async function openOptions(neosh: Neosh): Promise<void> {
+  if (sheet) {
+    await sheet.close();
+    return;
+  }
+  const current = await neosh.agent.selection().catch(() => null);
+  if (!current) {
+    neosh.notify("no model is selected", "warn");
+    return;
+  }
+  const entries = await neosh.agent.listModels(current.instance).catch(() => [] as ModelEntry[]);
+  const model = entries.find((e) => e.model.id === current.model)?.model;
+  const descriptors = model?.capabilities?.option_descriptors ?? [];
+  if (descriptors.length === 0) {
+    // Which model, because the answer to "why not" is almost always "not that one" — a small model
+    // in a lineup whose big one has five levels, or an endpoint that told us only an id.
+    neosh.notify(`${model?.display_name ?? current.model} has nothing to set`, "info");
+    return;
+  }
+
+  const rows = rowsFrom(descriptors, current.options ?? []);
+  const buf = await neosh.buf.create({
+    name: "[model options]",
+    scratch: true,
+    kind: KIND,
+  });
+  const ns = await neosh.ns.create(NS);
+  // Wide enough for the longest ladder plus its labels, and no wider: this is a control panel, not
+  // a page, and a float that spans the terminal reads as something you have to finish reading.
+  const labelWidth = Math.max(...rows.map((r) => width(r.label)));
+  const widest = Math.max(
+    ...rows.map((r) => r.choices.reduce((n, c) => n + width(c.label) + (c.spoken ? 5 : 2) + 1, 0)),
+    width(hintsFor()),
+  );
+  const inner = Math.min(96, labelWidth + widest + 8);
+  const win = await neosh.float.open(buf, {
+    anchor: { kind: "screen" },
+    width: { kind: "max", n: inner },
+    height: { kind: "fixed", n: rows.length + 3 },
+    border: "rounded",
+    title: ` ${model?.display_name ?? current.model} `,
+    focusable: true,
+    closeOnBlur: true,
+    z: 200,
+  });
+  await neosh.focus.push(win);
+
+  const s: Sheet = {
+    win,
+    buf,
+    ns,
+    rows,
+    cursor: 0,
+    selection: current,
+    title: model?.display_name ?? String(current.model),
+    inner,
+    close: async () => {
+      if (sheet !== s) return;
+      sheet = null;
+      await neosh.focus.pop().catch(() => {});
+      await neosh.win.close(win).catch(() => {});
+    },
+  };
+  sheet = s;
+  await draw(neosh, s, hintsFor());
+}

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -2079,11 +2079,33 @@ function projectRow(
   // Which other computers have this project. The whole reason a project key is a normalised git
   // remote rather than a path: on two machines the path is different and this is the same.
   const elsewhere = opts.hosts.get(p.key) ?? [];
-  const name = clip(p.name, Math.max(6, opts.width - 8 - (elsewhere.length ? 8 : 0)));
+
+  // What is finished and unseen inside a project you have folded shut. Only when folded, because
+  // folding is the thing that hid it: with the project open the conversation says so on its own
+  // row, and saying it twice on two adjacent lines is how a panel teaches you to stop reading it.
+  //
+  // It sits after the name rather than in the right-hand column: that column is already spoken for
+  // by the elapsed time of whatever is running, and a project can perfectly well have one turn
+  // still going and another that finished an hour ago.
+  const unseen = folded ? p.sessions.filter((s) => !s.active_turn && s.unread).length : 0;
+  const mark = unseen === 0 ? "" : unseen === 1
+    ? opts.ascii ? " !" : " ●"
+    : opts.ascii ? ` !${unseen}` : ` ●${unseen}`;
+
+  const name = clip(
+    p.name,
+    Math.max(6, opts.width - 8 - byteLength(mark) - (elsewhere.length ? 8 : 0)),
+  );
+  const spans: Array<{ from: number; to: number; hl: string }> = [];
+  if (p.favorite) spans.push({ from: 1, to: 1 + byteLength(star), hl: "Sidebar.Favorite" });
+  if (mark !== "") {
+    const from = byteLength(` ${star} ${arrow} ${name}`);
+    spans.push({ from, to: from + byteLength(mark), hl: "Status.Unread" });
+  }
   return {
-    text: ` ${star} ${arrow} ${name}`,
+    text: ` ${star} ${arrow} ${name}${mark}`,
     hl: here ? "Directory" : "Sidebar.Dim",
-    spans: p.favorite ? [{ from: 1, to: 1 + byteLength(star), hl: "Sidebar.Favorite" }] : undefined,
+    spans: spans.length > 0 ? spans : undefined,
     right: elsewhere.length > 0
       // The machines take the column the count would have used. A project that is in two places is
       // a more useful thing to know than how many conversations are in it here.
@@ -2124,25 +2146,37 @@ function sessionRow(s: SessionInfo, now: number, opts: DrawOptions): ListRow<Tar
   // deliberately static: twenty animating rows carry no more information than one and cost twenty
   // times the attention.
   const working = Boolean(s.active_turn);
+  // Finished while you were somewhere else. The one row in this column that is asking for
+  // something, so it is the one row that gets the attention colour — and it does not move, because
+  // it is not going to stop being true on its own and a mark that pulses forever is a mark you
+  // learn to look past. It goes away by being opened. See ADR 0042.
+  const unread = !working && s.unread;
   const glyph = working
     ? s.is_active
       ? spinnerFrame()
       : opts.ascii ? "*" : "◍"
-    : s.is_active
-      ? opts.ascii ? ">" : "▸"
-      : " ";
+    : unread
+      ? opts.ascii ? "!" : "●"
+      : s.is_active
+        ? opts.ascii ? ">" : "▸"
+        : " ";
   const right = working ? turnFor(s, now) : s.updated_at > 0 ? ago(now / 1000 - s.updated_at) : "";
   return {
     text: `     ${glyph} ${clip(s.label, Math.max(8, opts.width - 9 - right.length))}`,
     hl: working
       ? s.is_active && pulseBright() ? "Status.Working" : "Status.Monitoring"
-      : s.is_active
-        ? "Accent"
-        : undefined,
+      : unread
+        // The whole row, not only the dot: a single coloured character five columns in is findable
+        // if you already know it is there, which is the one thing you cannot assume about the
+        // conversation you have forgotten you started.
+        ? "Status.Unread"
+        : s.is_active
+          ? "Accent"
+          : undefined,
     // A trailing space so the age does not sit flush against the panel's edge rule.
     right: {
       text: right === "" ? "" : `${right} `,
-      hl: working ? "Status.Working" : "Sidebar.Dim",
+      hl: working ? "Status.Working" : unread ? "Status.Unread" : "Sidebar.Dim",
     },
     value: { kind: "session", id: s.id, cwd: s.cwd },
   };


### PR DESCRIPTION
Three things, in nineteen commits.

## A setting you cannot send is still a setting — ADR 0043

**The knob only existed for one vendor.** `ProviderOptionDescriptor` has been the mechanism for per-model options since ADR 0011, and exactly three catalogues filled it in. `^E` on a GPT-5 answered "has no options to set" about a model whose first documented parameter is `reasoning_effort`. Now the seeds say what each vendor takes — per model, because that is how ladders differ — and the OpenAI-shaped driver *discovers* from OpenRouter's `supported_parameters`, so four hundred models arrive with the right ladder each and no catalogue entry between them. Gemini's two generations get two knobs, because the API changed shape rather than gaining a level.

**The panel only showed one knob.** `^E` was two nested pickers, and on the common path the outer one was skipped — so it opened a list of effort levels and nothing said fast mode or the context window existed. Now every knob is on one surface, `←→` along a row, `↑↓` between them, applying as you move.

**The levels that are words did not work at all.** `prompt_injected_values` had been on the wire since ADR 0011 with nothing acting on it, so choosing `ultrathink` sent it where a parameter goes and the turn failed. Injection now happens once, above every driver, on the copy of the message this turn sends — never the transcript, never a tool round, and always with a sendable value put back in the selection's place. `ultracode` joins it as a switch of its own, since you can want sub-agents on a shallow turn.

Adds `Animation::Spectrum` for the one thing three hues cannot say: a level that is off the scale.

## A finished turn you have not seen is news — ADR 0042

The panel says what is *happening* and stops when it stops, so an answer that arrived while you were in another conversation looks exactly like one you read yesterday. `SessionInfo::unread` is set when a turn ends off screen and cleared by *arriving* — no dismissal key. It lives on the conversation and is persisted, so every list agrees and a restart does not lose it. A folded project carries a dot for what it is hiding.

## Somewhere clean to try this — ADR 0042

Docs and reasoning for the `^N` picker as it ships: `n` in the panel now asks the same question `^N` does, and the row most people want has nothing to answer — a worktree on a branch named for you.

## Also

Bundled plugins may be more than one file. `neosh:builtin/<name>` was a cannot-be-a-base URL, so a relative import next to a plugin's entry failed — which made bundled plugins the only ones in the system that could not be split up.

## Verification

- `cargo test` green for `neosh-core`, `neosh-proto`, `neosh-agent`, `neosh-provider`, `neosh-tui`, `neosh-script`
- `cargo test -p neosh --test sessions` — 29 passed, including the new end-to-end unread test
- `cargo test -p neosh --test builtin_plugins` — 118 passed, 2 failed, both the known macOS `/var` vs `/private/var` path-compare failures that fail on a clean tree too
- bindings regenerate with no drift; `npx tsc --noEmit` clean

Note: `docs/adr/` now has two `0042-`s, matching the existing two `0040-`s. Say the word if you would rather one were renumbered.