### PR TITLE
feat(sidebar): a worktree lives inside its project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,15 @@ per decision, and records the *reasoning*, not the choice.
   what the alternative is — the destructive answer wears `Diagnostic.Error`, and the cursor starts
   on the one that changes nothing. `ui.confirm_destructive = false` is the way out, and it is the
   user's setting rather than the program's guess. See ADR 0039.
+- **A worktree lives inside its project, and a display string is not a grouping key.** The sidebar
+  nests a worktree under the repository it is a tree of, named by its branch — four scratch trees
+  of one repository are not four projects — and it groups on `SessionInfo::repo_root`, never by
+  parsing `neosh · fix/thing` back apart. Each nested tree is an ordinary project row: its own
+  fold, rank and `n`; counts, unread marks and recency fold upward into the repository's row. A
+  *relative* `worktree.root` puts trees inside the repository as `<repo>/<configured>/<branch>` —
+  no `<repo>` level, nothing else's trees can land there — and `add_worktree` writes the directory
+  into `.git/info/exclude`, or every `git status` reads as one giant untracked directory. See ADR
+  0046.
 - **What you have archived is not in the sidebar.** The panel is the list you work in; a section of
   things you are finished with is the only part of that column that is never the answer, and it
   grows forever. One row with a count, `a` in the panel or `^F` anywhere, and it opens as a picker

--- a/crates/neosh-agent/src/session.rs
+++ b/crates/neosh-agent/src/session.rs
@@ -250,6 +250,8 @@ impl Session {
                 .file_name()
                 .map(|n| n.to_string_lossy().into_owned())
                 .unwrap_or_else(|| self.cwd.display().to_string()),
+            repo_root: None,
+            branch: None,
             message_count: self.messages.len() as u32,
             active_turn: self.active_turn.clone(),
             turn_started_at: self.turn_started_at,

--- a/crates/neosh-proto/src/agent.rs
+++ b/crates/neosh-proto/src/agent.rs
@@ -145,6 +145,21 @@ pub struct SessionInfo {
     /// Computed by the host so every frontend and plugin agrees, the same as `label`.
     #[serde(default)]
     pub project: String,
+    /// The main checkout of the repository `cwd` is in, when it is in one.
+    ///
+    /// This is what lets a list *group* rather than merely label: `project` says `neosh ·
+    /// fix/thing` about a linked worktree, but a string made for reading is not a key — the only
+    /// way to find the worktree's siblings in it is to parse a display format back apart. The
+    /// sidebar nests a worktree under the project it is a worktree *of*, and this is the field
+    /// that says which one that is. Equal to `cwd` in the main checkout itself; `None` outside a
+    /// repository.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_root: Option<String>,
+    /// The branch checked out at `cwd` when the host last looked, `None` on a detached head or
+    /// outside a repository. A label, not a fact about *now*: it is refreshed when the directory
+    /// is next visited, not on every `git switch` someone runs in a shell.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
     pub message_count: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_turn: Option<TurnId>,

--- a/crates/neosh-vcs/src/lib.rs
+++ b/crates/neosh-vcs/src/lib.rs
@@ -280,7 +280,54 @@ impl Git {
             args.push(path.display().to_string());
             args.push(branch.to_string());
         }
-        self.git(args).await.map(|_| ())
+        self.git(args).await?;
+        self.exclude_if_inside(path).await;
+        Ok(())
+    }
+
+    /// Keep an in-tree worktree out of `git status`.
+    ///
+    /// Git is happy to put a worktree inside the repository it belongs to, and then reports the
+    /// whole checkout as one untracked directory — in every status, forever. The fix is a line in
+    /// `.git/info/exclude`: local to this clone, so it never appears in anyone's diff, and about
+    /// this machine's layout, which is exactly what that file is for.
+    ///
+    /// The entry is the worktree's own directory, not its parent: excluding `/<parent>/` would
+    /// swallow any other untracked file somebody later puts there, and this function cannot know
+    /// the parent exists only for worktrees.
+    ///
+    /// Best-effort by design. The worktree already exists when this runs; failing the call over a
+    /// status-noise fix would report an operation as failed after it worked.
+    async fn exclude_if_inside(&self, path: &Path) {
+        let Ok(out) = self.git(["rev-parse", "--path-format=absolute", "--git-common-dir"]).await
+        else {
+            return;
+        };
+        let common = PathBuf::from(out.stdout.trim());
+        // "Inside the repository" means inside the *main* checkout — the common dir's parent —
+        // not inside whichever worktree this command happened to run from.
+        let Some(main) = common.parent() else { return };
+        let Ok(rel) = path.strip_prefix(main) else { return };
+        let rel = rel.to_string_lossy().replace('\\', "/");
+        if rel.is_empty() {
+            return;
+        }
+        let exclude = common.join("info").join("exclude");
+        let line = format!("/{}/", rel.trim_matches('/'));
+        let current = tokio::fs::read_to_string(&exclude).await.unwrap_or_default();
+        if current.lines().any(|l| l.trim() == line) {
+            return;
+        }
+        let mut next = current;
+        if !next.is_empty() && !next.ends_with('\n') {
+            next.push('\n');
+        }
+        next.push_str(&line);
+        next.push('\n');
+        if let Some(dir) = exclude.parent() {
+            let _ = tokio::fs::create_dir_all(dir).await;
+        }
+        let _ = tokio::fs::write(&exclude, next).await;
     }
 
     pub async fn remove_worktree(&self, path: &Path, force: bool) -> Result<(), VcsError> {

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -388,8 +388,10 @@ pub struct Host {
     repos: std::collections::HashMap<std::path::PathBuf, Option<neosh_vcs::Git>>,
     /// Where neosh was started, and the fallback for a session that names nowhere.
     cwd: std::path::PathBuf,
-    /// What to call each directory a conversation lives in, worked out once when it is first seen.
-    projects: std::collections::HashMap<std::path::PathBuf, String>,
+    /// What to call each directory a conversation lives in — and what checkout it is, so a list
+    /// can group worktrees under the repository they belong to. Worked out once when the
+    /// directory is first seen.
+    projects: std::collections::HashMap<std::path::PathBuf, ProjectFacts>,
     /// What each directory is called *across machines*. See [`neosh_proto::ProjectKey`].
     ///
     /// Separate from `projects`, which is a label for this screen. This is an identity, resolved
@@ -6199,7 +6201,14 @@ impl Host {
             // Asked once, when the directory is first seen, and remembered. A label is read on
             // every redraw of the panel and is not worth a `rev-parse` each time.
             let (branch, main) = g.identity().await;
-            self.projects.insert(dir.clone(), project_name(&dir, branch, main));
+            self.projects.insert(
+                dir.clone(),
+                ProjectFacts {
+                    name: project_name(&dir, branch.clone(), main.clone()),
+                    repo_root: main.map(|p| p.display().to_string()),
+                    branch,
+                },
+            );
             // Asked here for the same reason and at the same time as the name: once per directory,
             // and the answer does not change while a checkout is open.
             if let Some(key) = g.origin_url().await.and_then(|u| neosh_proto::ProjectKey::from_remote(&u)) {
@@ -6215,8 +6224,10 @@ impl Host {
     /// the repository, which is the host's job — the store holds conversations and knows nothing
     /// about git.
     fn named(&self, mut info: neosh_proto::SessionInfo) -> neosh_proto::SessionInfo {
-        if let Some(name) = self.projects.get(std::path::Path::new(&info.cwd)) {
-            info.project = name.clone();
+        if let Some(facts) = self.projects.get(std::path::Path::new(&info.cwd)) {
+            info.project = facts.name.clone();
+            info.repo_root = facts.repo_root.clone();
+            info.branch = facts.branch.clone();
         }
         info
     }
@@ -6945,7 +6956,9 @@ impl Host {
                 default: OptionValue::Str(default_worktree_root()),
                 description: Some(
                     "Where `git.worktree.new` puts a new worktree, as `<root>/<repo>/<branch>`. \
-                     A leading `~` is expanded. Empty means beside the repository instead, in \
+                     A leading `~` is expanded. A relative path is inside the repository itself — \
+                     `.worktrees` puts them at `<repo>/.worktrees/<branch>`, kept out of `git \
+                     status` for you. Empty means beside the repository instead, in \
                      `<repo>-worktrees/`."
                         .into(),
                 ),
@@ -7796,6 +7809,20 @@ fn chunk(text: impl Into<String>, hl: &str) -> neosh_proto::VirtChunk {
 fn display_width(s: &str) -> usize {
     use unicode_width::UnicodeWidthStr;
     s.width()
+}
+
+/// What the host learned about a directory the first time it looked: the display name, and the
+/// checkout facts the name was made from. Kept whole because [`SessionInfo`] carries both — the
+/// name for reading, the root for grouping — and deriving one from the other means parsing a
+/// display format back apart.
+///
+/// [`SessionInfo`]: neosh_proto::SessionInfo
+struct ProjectFacts {
+    name: String,
+    /// The main checkout's path; `None` outside a repository.
+    repo_root: Option<String>,
+    /// The branch at that directory when it was first seen; `None` detached.
+    branch: Option<String>,
 }
 
 /// What to call a checkout.

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -1954,14 +1954,15 @@ fn a_worktree_is_created_under_the_configured_root_and_you_land_in_it() {
     );
 }
 
-/// A worktree is named by the repository it belongs to and the branch it is on, not by whatever
-/// the directory happens to be called.
+/// A worktree is a row *inside* the repository it belongs to, named by its branch.
 ///
-/// The directory is named by whoever created it, which for a worktree made by another tool is a
-/// string like `wt-fe3c0d93`. A panel of those says nothing about which checkout is which, and
-/// reads as somebody else's directory having wandered into your workspace.
+/// It used to be a top-level project named `work · sideline` — correct in that a worktree is a
+/// place conversations live, and wrong as a list: four scratch trees of one repository read as
+/// four unrelated projects, and the name carried the relationship precisely because the structure
+/// did not. Nested, the repository's name is said once by the row above, and what is left to say
+/// about the tree is the branch.
 #[test]
-fn a_worktree_is_listed_by_its_repository_and_branch() {
+fn a_worktree_nests_under_the_repository_it_belongs_to() {
     let sb = Sandbox::new("wtname");
     sb.git_init();
     let root = sb.root.join("trees");
@@ -1978,8 +1979,18 @@ fn a_worktree_is_listed_by_its_repository_and_branch() {
 
     s.send(&command_with("git.worktree.new", "sideline"));
     assert!(
-        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("work \u{b7} sideline"))),
-        "and the worktree says which repository and which branch\n{:?}",
+        s.pump(|s| {
+            let rows = s.sidebar_now();
+            let repo = rows.iter().position(|l| l.contains("work") && !l.contains("sideline"));
+            let tree = rows.iter().position(|l| l.contains("sideline"));
+            match (repo, tree) {
+                // Below its repository, indented past the repository's own arrow, and the branch
+                // alone — `work · sideline` is the flat list this replaced.
+                (Some(r), Some(t)) => t > r && rows[t].starts_with("     ") && !rows[t].contains('\u{b7}'),
+                _ => false,
+            }
+        }),
+        "the worktree is a nested row named by its branch\n{:?}",
         s.sidebar_now()
     );
 }
@@ -2095,6 +2106,42 @@ fn an_empty_worktree_root_puts_them_beside_the_repository() {
     assert!(
         s.pump(|_| std::path::Path::new(&want).is_dir()),
         "the worktree went beside the repository, at {want}"
+    );
+}
+
+/// A relative root is inside the repository itself — `<repo>/.worktrees/<branch>`, with no
+/// `<repo>` level, because inside the repository nothing else's worktrees can collide with yours.
+///
+/// The exclude entry is the half that makes the layout livable: git happily creates a worktree
+/// inside its own repository and then reports the entire checkout as one untracked directory, in
+/// every status, forever. `.git/info/exclude` is local to the clone, so opting into this layout
+/// never shows up in anyone's diff.
+#[test]
+fn a_relative_worktree_root_lives_inside_the_repository_and_stays_out_of_status() {
+    let sb = Sandbox::new("wtinside");
+    sb.git_init();
+    sb.write_config("[options]\n\"worktree.root\" = \".worktrees\"\n");
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("PROJECTS");
+
+    s.send(&command("git.worktree.new"));
+    s.wait_for("Branch for the new worktree");
+    s.type_text("inside");
+    s.enter();
+
+    let repo = sb.root.join("work");
+    let want = repo.join(".worktrees/inside");
+    assert!(
+        s.pump(|_| want.is_dir()),
+        "the worktree is inside the repository, at {}",
+        want.display()
+    );
+    let exclude = repo.join(".git/info/exclude");
+    assert!(
+        s.pump(|_| std::fs::read_to_string(&exclude)
+            .is_ok_and(|t| t.lines().any(|l| l.trim() == "/.worktrees/inside/"))),
+        "and .git/info/exclude keeps it out of git status\n{:?}",
+        std::fs::read_to_string(&exclude)
     );
 }
 

--- a/docs/adr/0046-a-worktree-lives-inside-its-project.md
+++ b/docs/adr/0046-a-worktree-lives-inside-its-project.md
@@ -1,0 +1,77 @@
+# 0046 — A worktree lives inside its project
+
+**Status:** accepted
+
+Refines [0029](0029-a-conversation-carries-its-directory.md), which said "a worktree is a
+project", and [0042](0042-somewhere-clean-to-try-this.md), which made getting one free.
+
+## Context
+
+0042 made worktrees cheap enough to use casually, and casual use is what found the two problems.
+
+**Four scratch trees of one repository read as four unrelated projects.** "A worktree is a
+project" was the right call about *capability* — a worktree needs its own conversations, its own
+branch in the footer, its own fold — and the wrong call about *layout*. The sidebar listed
+`neosh`, `neosh · brisk-otter`, `neosh · swift-thistle` and `neosh · fix/thing` as peers, and the
+name was carrying the relationship precisely because the structure did not: every row had to
+repeat the repository so that a reader could reassemble, in their head, the tree the panel had
+flattened. The thing the trees have in common is the thing the column never said.
+
+**Worktrees elsewhere are worktrees you forget.** `worktree.root` defaults to a directory of
+neosh's own, and that remains right — a worktree is not part of the project, and littering the
+repository's parent is how checkouts stop being accounted for. But plenty of people keep their
+trees *inside* the repository, `.worktrees/`, where `rm -rf` of the project takes everything with
+it and nothing lives outside the tree they already back up. The relative-path case half worked:
+`worktree.root = ".worktrees"` resolved against the repository root, then appended a `<repo>`
+level that is pure noise inside the repository it names — and git reported the new checkout as one
+giant untracked directory in every `git status`, forever, because nothing excluded it.
+
+## Decision
+
+**The repository is the row; its worktrees nest under it, named by their branch.** `SessionInfo`
+grows `repo_root` — the main checkout's path, equal to `cwd` in the main checkout itself — and
+`branch`, because the sidebar was grouping on a *display string* and a string made for reading is
+not a key: the only way to find `neosh · fix/thing`'s siblings in it is to parse a format back
+apart. The host already had both in hand when it built the name (`remember_repo` calls
+`identity()`) and threw them away.
+
+A nested worktree is an ordinary `Project` to the panel — its own cwd, so its own fold, rank and
+`n` — and its row carries the branch alone, because the repository's name is said once by the row
+above. Counts fold upward: a folded repository counts and marks everything inside it, worktrees
+included, and its recency is its newest conversation *anywhere in it*, so a repository whose only
+activity is in a scratch tree floats with that work. `f` on a worktree pins the repository, the
+same way `f` on a conversation pins the project it is in — pinning is about the top of the column,
+and a worktree is never at the top of the column. A repository whose every conversation is in its
+worktrees still gets a row of its own to hang them from; `↵` on it folds, and `n` on it is how a
+conversation starts in the main checkout — which is also the answer to "go back to main and pull":
+the checkout is one row up from the tree you were in, never elsewhere in the list.
+
+**A relative `worktree.root` is inside the repository, laid out `<repo>/<configured>/<branch>`.**
+No `<repo>` level — inside the repository, nothing else's worktrees can land there, so the
+disambiguator disambiguates nothing. And `git worktree add` into the repository writes the new
+directory into `.git/info/exclude`: local to the clone, absent from every diff, and exactly what
+that file is for — facts about this machine's layout. The entry is the worktree's own directory,
+not its parent, because excluding `/{parent}/` would swallow any other untracked file somebody
+later puts there. It is written in `neosh-vcs`, against the *main* checkout resolved from
+`--git-common-dir` rather than against whichever worktree the command ran from, and best-effort:
+the worktree exists by the time it runs, and failing the call over a status-noise fix would report
+an operation as failed after it worked.
+
+## Consequences
+
+The `project` display string is unchanged — `neosh · fix/thing` still names a worktree conversation
+everywhere a flat label is the right shape: the archive picker, another machine's inventory, a
+title bar. Structure where there is structure, the string where there is a string.
+
+A pinned worktree directory with no conversations has nobody to say which repository it belongs
+to, and stays a top-level row until a conversation gives it one. Graceful, and honest: the panel
+nests on knowledge, not on guesses.
+
+`repo_root` is stamped when a directory is first seen and cached, like the name it feeds. A
+repository moved on disk mid-session keeps its old grouping until the workspace looks again, which
+is the existing bargain for every fact in that cache.
+
+Sub-directory conversations group under their repository too, labelled by branch — the same
+approximation `project_name` has always made. The alternative is a third field that says "linked
+worktree" as distinct from "inside the main checkout", and nothing yet needs the distinction badly
+enough to pay for it.

--- a/docs/config.md
+++ b/docs/config.md
@@ -146,8 +146,10 @@ told per turn, through `TurnRequest.cwd`.
 
 A worktree is a second checkout of the same repository on a different branch, and it is the answer
 to "I want to try something without disturbing what is checked out". neosh treats one as a
-*project*: it gets its own group in the sidebar, its own conversations, and its own branch in the
-footer.
+*project*: it has its own conversations and its own branch in the footer, and in the sidebar it
+sits **inside the repository it is a tree of** — the repository is the row, its worktrees nest
+under it by branch, and each folds, reorders and starts conversations on its own. Run as many
+conversations in one worktree as you like; `n` on its row is how a second one starts there.
 
 `^N` asks where a new conversation goes when there is something to ask:
 
@@ -185,9 +187,9 @@ themselves; the message says where it landed. `git.worktree.new <branch> [path] 
 explicit path for the times you want one, and a repository for the times it is not the one you are
 in.
 
-A worktree is listed by the repository it belongs to and the branch it is on — `neosh · fix/thing`
-— rather than by its directory name. The directory is named by whoever created it, and a panel of
-those says nothing about which checkout is which.
+A worktree is listed by the branch it is on, under the repository it belongs to, rather than by its
+directory name. The directory is named by whoever created it, and a panel of those says nothing
+about which checkout is which.
 
 New worktrees go under `worktree.root`, laid out as `<root>/<repo>/<branch>`:
 
@@ -201,6 +203,18 @@ of the project you are working on and littering its parent with `project-worktre
 end up with checkouts they cannot account for. The repository name is a level of its own so two
 projects with a `main` branch do not collide, and a slash in a branch becomes a dash — `feat/thing`
 is one directory, not two, because the directory is a name and not a path.
+
+A **relative** root keeps the trees inside the repository itself:
+
+```toml
+[options]
+"worktree.root" = ".worktrees"   # <repo>/.worktrees/<branch>
+```
+
+No `<repo>` level there — inside the repository, nothing else's worktrees can collide with yours —
+and neosh writes the directory into `.git/info/exclude` when it creates the tree, so an in-repo
+checkout never sits in `git status` as one giant untracked directory. That file is local to the
+clone; nothing about this layout appears in anyone's diff.
 
 Setting it to `""` restores the sibling layout, for anyone who wants their trees next to the thing
 they are trees of.

--- a/plugins/api/src/generated/SessionInfo.ts
+++ b/plugins/api/src/generated/SessionInfo.ts
@@ -19,6 +19,23 @@ export type SessionInfo = {
    * Computed by the host so every frontend and plugin agrees, the same as `label`.
    */
   project: string;
+  /**
+   * The main checkout of the repository `cwd` is in, when it is in one.
+   *
+   * This is what lets a list *group* rather than merely label: `project` says `neosh ·
+   * fix/thing` about a linked worktree, but a string made for reading is not a key — the only
+   * way to find the worktree's siblings in it is to parse a display format back apart. The
+   * sidebar nests a worktree under the project it is a worktree *of*, and this is the field
+   * that says which one that is. Equal to `cwd` in the main checkout itself; `None` outside a
+   * repository.
+   */
+  repo_root?: string | null;
+  /**
+   * The branch checked out at `cwd` when the host last looked, `None` on a detached head or
+   * outside a repository. A label, not a fact about *now*: it is refreshed when the directory
+   * is next visited, not on every `git switch` someone runs in a shell.
+   */
+  branch?: string | null;
   message_count: number;
   active_turn?: TurnId | null;
   /**

--- a/plugins/builtin/git/main.ts
+++ b/plugins/builtin/git/main.ts
@@ -697,6 +697,12 @@ const SCRATCH_NOUNS = [
  * end up with checkouts they cannot account for. The repository name is a level of its own so two
  * projects with a `main` branch do not collide.
  *
+ * A *relative* root is inside the repository — `worktree.root = ".worktrees"` puts every tree at
+ * `<repo>/.worktrees/<branch>` — and there the repository's name is a level of noise rather than a
+ * disambiguator: nothing but this repository's worktrees can land in its own directory. The host
+ * keeps an in-tree checkout out of `git status` via `.git/info/exclude`, so choosing this layout
+ * does not mean reading past an untracked directory forever.
+ *
  * An empty `worktree.root` restores the sibling layout, for anyone who wants their trees next to
  * the thing they are trees of.
  *
@@ -708,8 +714,8 @@ async function worktreePath(neosh: Neosh, repoRoot: string, branch: string): Pro
   const repoName = repoRoot.split("/").filter(Boolean).pop() ?? "repo";
   const configured = ((await neosh.opt.get<string>("worktree.root")) ?? "").trim();
   if (configured === "") return `${parentOf(repoRoot)}/${repoName}-worktrees/${leaf}`;
-  const base = configured.startsWith("/") ? configured : `${repoRoot}/${configured}`;
-  return `${base}/${repoName}/${leaf}`;
+  if (configured.startsWith("/")) return `${configured}/${repoName}/${leaf}`;
+  return `${repoRoot}/${configured}/${leaf}`;
 }
 
 async function removeWorktree(neosh: Neosh): Promise<void> {

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -139,6 +139,17 @@ interface Project {
   sessions: SessionInfo[];
   /** The cross-machine identity, for matching against what other computers have. */
   key: string;
+  /**
+   * Linked worktrees of this checkout, nested rather than listed beside it.
+   *
+   * A worktree used to be a top-level project — correct by ADR 0029's "a worktree is a project",
+   * and wrong as a *list*: four scratch trees of one repository read as four unrelated projects,
+   * and the thing they have in common is the thing the column no longer said. The name carried
+   * the relationship (`neosh · brisk-otter`) precisely because the structure did not. Each entry
+   * is an ordinary {@link Project} — its own cwd, its own fold and rank vars — whose `worktrees`
+   * is always empty, because git does not nest them either.
+   */
+  worktrees: Project[];
 }
 
 const NS = "neosh.sidebar";
@@ -275,7 +286,9 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
     // Land on the conversation you are in, not wherever the cursor happened to be.
     const current = await neosh.session.current().catch(() => null);
     if (current) {
-      // Unfold the project it lives in, or "go to where I am" lands on a collapsed heading.
+      // Unfold the project it lives in, or "go to where I am" lands on a collapsed heading. For a
+      // conversation in a worktree that is two folds: the repository's, then the worktree's own.
+      if (current.repo_root) arrangement.unfold(current.repo_root);
       arrangement.unfold(current.cwd);
       list.select((t) => t.kind === "session" && t.id === current.id);
     }
@@ -541,7 +554,10 @@ class Arrangement {
    * you undo.
    */
   async move(groups: Project[][], cwd: string, delta: number): Promise<boolean> {
-    const group = groups.find((g) => g.some((p) => p.cwd === cwd));
+    // A worktree moves among its siblings under the same repository; a project among its group.
+    const group: Project[] | undefined =
+      groups.flat().find((p) => p.worktrees.some((t) => t.cwd === cwd))?.worktrees ??
+        groups.find((g) => g.some((p) => p.cwd === cwd));
     if (!group) return false;
     const from = group.findIndex((p) => p.cwd === cwd);
     const to = from + delta;
@@ -663,8 +679,14 @@ async function registerCommands(w: Wiring): Promise<void> {
     await arrangement.toggleFold(target.cwd);
   });
   await verb(`${NS}.favorite`, "f", "Pin this project to the top", async (target) => {
-    const cwd = owningProject(target);
+    let cwd = owningProject(target);
     if (cwd === null) return;
+    // Pinning is about the top of the column, and a worktree is never at the top of the column —
+    // `f` on one pins the repository it belongs to, the same way `f` on a conversation pins the
+    // project it is in.
+    const inside = (await neosh.session.list().catch(() => [] as SessionInfo[]))
+      .find((s) => s.cwd === cwd && s.repo_root && s.repo_root !== s.cwd);
+    if (inside?.repo_root) cwd = inside.repo_root;
     const now = await arrangement.toggleFavorite(cwd);
     neosh.notify(now ? `favourited ${short(cwd)}` : `unfavourited ${short(cwd)}`, "info");
   });
@@ -1152,8 +1174,10 @@ async function activateTarget(
   }
   if (target.kind === "project") {
     // A pinned project with nothing in it yet: `↵` should start something, not fold an empty list.
+    // A repository whose conversations are all in its worktrees is not that — the row has children
+    // to fold, which is what `s.repo_root === target.cwd` finds.
     const sessions = await neosh.session.list().catch(() => [] as SessionInfo[]);
-    if (!sessions.some((s) => s.cwd === target.cwd)) {
+    if (!sessions.some((s) => s.cwd === target.cwd || s.repo_root === target.cwd)) {
       await neosh.session.create({ cwd: target.cwd });
       await w.leave();
       return;
@@ -1830,6 +1854,15 @@ function group(
     else by.set(s.cwd, [s]);
   }
 
+  // Which checkout each directory is a linked worktree of, learned from its conversations. A
+  // pinned directory with nothing in it has nobody to say, and stays top-level until it does.
+  const rootOf = new Map<string, string>();
+  for (const s of sessions) {
+    if (s.repo_root && s.repo_root !== s.cwd && !rootOf.has(s.cwd)) {
+      rootOf.set(s.cwd, s.repo_root);
+    }
+  }
+
   // `session.list()` is most-recently-used first, so index in it is recency. Anything you have
   // never dragged sorts by that, after everything you have.
   const recency = new Map<string, number>();
@@ -1837,7 +1870,7 @@ function group(
     if (!recency.has(s.cwd)) recency.set(s.cwd, i);
   });
 
-  const projects: Project[] = [...by.entries()].map(([cwd, list]) => ({
+  const make = (cwd: string, list: SessionInfo[]): Project => ({
     cwd,
     // What the host decided to call it. For a worktree that is the repository and the branch,
     // rather than whatever the directory happens to be named — a row reading `wt-fe3c0d93`
@@ -1847,17 +1880,52 @@ function group(
     favorite: arrangement.isFavorite(cwd),
     sessions: list,
     key: keys.get(cwd) ?? `dir:${basename(cwd)}`,
-  }));
+    worktrees: [],
+  });
+
+  const tops = new Map<string, Project>();
+  const linked: Project[] = [];
+  for (const [cwd, list] of by) {
+    const root = rootOf.get(cwd);
+    if (!root) {
+      tops.set(cwd, make(cwd, list));
+      continue;
+    }
+    // Nested under the repository, the repository's name is said by the row above — what is left
+    // to say is which tree this one is. The branch, like the host's own label; the directory only
+    // on a detached head, where it is all there is.
+    linked.push({ ...make(cwd, list), name: list[0]?.branch || basename(cwd) });
+  }
+  for (const child of linked) {
+    const root = rootOf.get(child.cwd)!;
+    // A repository whose every conversation is in a worktree still has a row of its own — the
+    // worktrees have to hang from something, and the checkout is a real place `↵` can start a
+    // conversation in.
+    const parent = tops.get(root) ?? make(root, []);
+    tops.set(root, parent);
+    parent.worktrees.push(child);
+  }
+
+  // A project's recency is its newest conversation *anywhere in it* — a repository whose only
+  // activity is in a worktree should float with that work, not sink because its own checkout is
+  // quiet.
+  const newest = (p: Project): number =>
+    Math.min(
+      recency.get(p.cwd) ?? Number.MAX_SAFE_INTEGER,
+      ...p.worktrees.map((t) => recency.get(t.cwd) ?? Number.MAX_SAFE_INTEGER),
+    );
 
   const sort = (a: Project, b: Project) => {
     const ra = arrangement.rank(a.cwd);
     const rb = arrangement.rank(b.cwd);
     if (ra !== rb) return ra - rb;
-    const fa = recency.get(a.cwd) ?? Number.MAX_SAFE_INTEGER;
-    const fb = recency.get(b.cwd) ?? Number.MAX_SAFE_INTEGER;
+    const fa = newest(a);
+    const fb = newest(b);
     return fa !== fb ? fa - fb : a.name.localeCompare(b.name);
   };
 
+  const projects = [...tops.values()];
+  for (const p of projects) p.worktrees.sort(sort);
   return [
     projects.filter((p) => p.favorite).sort(sort),
     projects.filter((p) => !p.favorite).sort(sort),
@@ -1932,11 +2000,22 @@ async function collect(
     rows.push(projectRow(p, arrangement, opts, now));
     if (arrangement.isFolded(p.cwd)) continue;
     for (const s of p.sessions) rows.push(sessionRow(s, now, opts));
+    // Its worktrees, inside it. Each is a project row one level down — its own fold, its own
+    // rank, `n` makes another conversation in it — because a worktree of a repository is not a
+    // neighbour of the repository, and the column should say so.
+    for (const t of p.worktrees) {
+      rows.push(worktreeRow(t, arrangement, opts, now));
+      if (arrangement.isFolded(t.cwd)) continue;
+      for (const s of t.sessions) rows.push(sessionRow(s, now, opts, 1));
+    }
     // The same project, being worked on elsewhere. Under the same heading rather than in a section
     // of their own: they are not a different kind of thing, they are the same work on a different
     // computer, and a separate `REMOTE` block would make you check two places for one project.
     for (const r of remote.get(p.key) ?? []) rows.push(remoteRow(r, opts, now));
-    if (p.sessions.length === 0 && (remote.get(p.key) ?? []).length === 0) {
+    if (
+      p.sessions.length === 0 && p.worktrees.length === 0 &&
+      (remote.get(p.key) ?? []).length === 0
+    ) {
       rows.push({ text: "       nothing here yet", hl: "Sidebar.Dim", inert: true });
     }
   }
@@ -2052,15 +2131,19 @@ function projectRow(
 ): ListRow<Target> {
   const folded = arrangement.isFolded(p.cwd);
   const arrow = opts.ascii ? (folded ? ">" : "v") : folded ? "▸" : "▾";
-  const busy = p.sessions.find((s) => s.active_turn);
+  // "Inside it" includes its worktrees: a repository whose only running turn is in a scratch tree
+  // is still a repository where something is happening, and the folded count has to count what
+  // folding hid.
+  const within = [...p.sessions, ...p.worktrees.flatMap((t) => t.sessions)];
+  const busy = within.find((s) => s.active_turn);
   const here = p.sessions.some((s) => s.is_active);
 
   // The count is the useful thing when a project is folded, and the elapsed time is the useful
   // thing when something inside it is working. Never both — there is one column.
   const right = busy
     ? { text: `${turnFor(busy, now)} `, hl: "Status.Working" }
-    : p.sessions.length > 0
-      ? { text: `${p.sessions.length} `, hl: "Sidebar.Dim" }
+    : within.length > 0
+      ? { text: `${within.length} `, hl: "Sidebar.Dim" }
       : { text: "" };
 
   // The star sits before the fold arrow rather than after the name: it is what you scan the
@@ -2087,7 +2170,7 @@ function projectRow(
   // It sits after the name rather than in the right-hand column: that column is already spoken for
   // by the elapsed time of whatever is running, and a project can perfectly well have one turn
   // still going and another that finished an hour ago.
-  const unseen = folded ? p.sessions.filter((s) => !s.active_turn && s.unread).length : 0;
+  const unseen = folded ? within.filter((s) => !s.active_turn && s.unread).length : 0;
   const mark = unseen === 0 ? "" : unseen === 1
     ? opts.ascii ? " !" : " ●"
     : opts.ascii ? ` !${unseen}` : ` ●${unseen}`;
@@ -2111,6 +2194,44 @@ function projectRow(
       // a more useful thing to know than how many conversations are in it here.
       ? { text: `${clip(elsewhere.join(" "), 14)} `, hl: "Sidebar.Remote" }
       : right,
+    value: { kind: "project", cwd: p.cwd },
+  };
+}
+
+/**
+ * A worktree, one level inside the repository it is a tree of.
+ *
+ * The same kind of row as a project — same `Target`, so folding, `n`, `f` and `J`/`K` need no
+ * second code path — drawn at the indent of the conversations beside it, because that is the
+ * claim the nesting makes: this belongs to the row above. No star column; pinning is the
+ * repository's, and a second ragged column of stars is what the alignment here pays for.
+ */
+function worktreeRow(
+  p: Project,
+  arrangement: Arrangement,
+  opts: DrawOptions,
+  now: number,
+): ListRow<Target> {
+  const folded = arrangement.isFolded(p.cwd);
+  const arrow = opts.ascii ? (folded ? ">" : "v") : folded ? "▸" : "▾";
+  const busy = p.sessions.find((s) => s.active_turn);
+  const here = p.sessions.some((s) => s.is_active);
+  const right = busy
+    ? { text: `${turnFor(busy, now)} `, hl: "Status.Working" }
+    : p.sessions.length > 0
+      ? { text: `${p.sessions.length} `, hl: "Sidebar.Dim" }
+      : { text: "" };
+  const unseen = folded ? p.sessions.filter((s) => !s.active_turn && s.unread).length : 0;
+  const mark = unseen === 0 ? "" : unseen === 1
+    ? opts.ascii ? " !" : " ●"
+    : opts.ascii ? ` !${unseen}` : ` ●${unseen}`;
+  const name = clip(p.name, Math.max(6, opts.width - 10 - byteLength(mark)));
+  const from = byteLength(`     ${arrow} ${name}`);
+  return {
+    text: `     ${arrow} ${name}${mark}`,
+    hl: here ? "Directory" : "Sidebar.Dim",
+    spans: mark === "" ? undefined : [{ from, to: from + byteLength(mark), hl: "Status.Unread" }],
+    right,
     value: { kind: "project", cwd: p.cwd },
   };
 }
@@ -2141,7 +2262,12 @@ function remoteRow(r: SwarmAgent, opts: DrawOptions, now: number): ListRow<Targe
     };
 }
 
-function sessionRow(s: SessionInfo, now: number, opts: DrawOptions): ListRow<Target> {
+function sessionRow(
+  s: SessionInfo,
+  now: number,
+  opts: DrawOptions,
+  depth = 0,
+): ListRow<Target> {
   // Working is the only state that moves, and only where the work is. An idle row's status is
   // deliberately static: twenty animating rows carry no more information than one and cost twenty
   // times the attention.
@@ -2161,8 +2287,11 @@ function sessionRow(s: SessionInfo, now: number, opts: DrawOptions): ListRow<Tar
         ? opts.ascii ? ">" : "▸"
         : " ";
   const right = working ? turnFor(s, now) : s.updated_at > 0 ? ago(now / 1000 - s.updated_at) : "";
+  // Two more columns per level: a conversation inside a worktree sits inside the worktree's row
+  // the way the worktree sits inside its repository's.
+  const pad = "     " + "  ".repeat(depth);
   return {
-    text: `     ${glyph} ${clip(s.label, Math.max(8, opts.width - 9 - right.length))}`,
+    text: `${pad}${glyph} ${clip(s.label, Math.max(8, opts.width - 9 - 2 * depth - right.length))}`,
     hl: working
       ? s.is_active && pulseBright() ? "Status.Working" : "Status.Monitoring"
       : unread


### PR DESCRIPTION
## What

- **Worktrees nest under their repository in the sidebar**, named by branch, instead of appearing as top-level projects named `repo · branch`. Each nested tree is an ordinary project row: its own fold, its own `J`/`K` rank, and `n` on it starts another conversation in that worktree. Counts, unread dots, running-turn time and recency fold upward into the repository's row; `f` on a worktree pins the repository.
- **`SessionInfo` gains `repo_root` and `branch`** so lists can group on data rather than parse a display string. The host already computed both in `remember_repo()`; now it keeps them. Generated TS updated.
- **A relative `worktree.root` is inside the repository**: `".worktrees"` → `<repo>/.worktrees/<branch>`, dropping the redundant `<repo>` level, and `add_worktree` writes the directory into `.git/info/exclude` (resolved against the main checkout via `--git-common-dir`) so an in-tree checkout never pollutes `git status`.

## Why

Four scratch trees of one repository read as four unrelated projects; the name carried the relationship because the structure did not. Reasoning in ADR 0046.

## Testing

- New: `a_relative_worktree_root_lives_inside_the_repository_and_stays_out_of_status`
- Rewritten: `a_worktree_nests_under_the_repository_it_belongs_to` (asserts position, indent, branch-only name)
- Full `builtin_plugins`: 125 passed; only the two known environmental failures on the dev Mac (`/var` vs `/private/var` symlink compares)
- `neosh-core`, `neosh-vcs`, `sessions`, `export_bindings`, and both `tsc --noEmit` runs green
- Layout verified on the real screen via `scripts/shot.py`