### PR TITLE
feat: a panel that has the keyboard, and a project that stays

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,18 @@ per decision, and records the *reasoning*, not the choice.
   key in a panel is an ordinary binding pointed at a named command, so `F1` lists it and `init.ts`
   can move it; a `switch` on `KeyContext` inside a plugin is the thing this replaced. Keep the
   capture, but only as a sink for keys nothing claimed. See ADR 0040.
+- **A panel you are in the middle of using has the keyboard.** `FloatConfig::modal` takes
+  `KeymapScope::Global` out of the chain, and a key nothing claimed is swallowed rather than reaching
+  the composer behind the float. Shadowing the keys a widget wants is the other half and not a
+  substitute: a panel can name the keys it *wants* and never the ones it merely does not want to
+  happen, so `^N` over the option sheet opened a conversation behind it and `^T` opened the project
+  panel underneath with focus in neither. Nearer scopes still resolve, so a modal is exactly as
+  rebindable as any other panel. `ui.modal_escape_keys` — `^Q` and `^R` — resolve globally anyway,
+  consulted only *after* the panel has declined the key; **absent is not empty**, because the one
+  thing between a broken panel and a lost terminal must not depend on somebody having declared a
+  default. A modal that borrows a global key to open itself owes a binding to close itself, which is
+  why `^E` shuts the sheet from inside. Answering a question is not this: `^T` is how you reach a
+  question waiting in another conversation. See ADR 0047.
 - **Pairing is a decision each machine makes, and neither of them restarts.** A node presents its
   identity to anyone who connects — as an SSH server presents a host key — so adding a computer is
   typing an address and being shown a name and a fingerprint that came from the far end. The other
@@ -126,9 +138,11 @@ per decision, and records the *reasoning*, not the choice.
   takes (OpenRouter's `supported_parameters`, `codex`'s `model/list`), written down where it will
   not — and a provider with no knobs listed is a bug in a catalogue, not a model without options.
   Some of them are words rather than parameters: `ultrathink` and `ultracode` are read by a
-  *harness*, so they live on `claude-cli` and never on `anthropic`, they travel as
-  `prompt_injected_values` / `prompt_injected_word`, and the injection happens once, above every
-  driver, on the copy of the message this turn sends — never on the transcript, never on a tool
+  *harness*, so they live on `claude-cli` and never on `anthropic`, they are **two rungs past the
+  top of the same ladder** rather than a level and a switch beside it — one message carries one
+  word, and a slider marked "how hard should it think" with an `off / on` under it is two questions
+  about one decision — they travel as `prompt_injected_values`, and the injection happens once,
+  above every driver, on the copy of the message this turn sends — never on the transcript, never on a tool
   round, and always with a sendable value put back in the selection's place. `^E` shows *all* of
   them at once and applies as you move, because a knob you cannot see is a knob you do not have. See
   ADR 0043.
@@ -174,6 +188,14 @@ per decision, and records the *reasoning*, not the choice.
   no `<repo>` level, nothing else's trees can land there — and `add_worktree` writes the directory
   into `.git/info/exclude`, or every `git status` reads as one giant untracked directory. See ADR
   0046.
+- **A project outlives the conversations in it.** The panel's list is written down (`sidebar.projects`,
+  a workspace var) rather than worked out from where the conversations happen to be — derived, it
+  deleted the directory you had worked in all month the moment you cleared out the last thread in
+  it, and left nothing to start the next one from. A project arrives by being added or by a
+  conversation being started in it, keeps the name the host gave it (`sidebar.name`, so emptying a
+  worktree does not rename it to `wt-fe3c0d93`), and leaves by `X` on its heading and nothing else.
+  Empty, that asks nothing — `o` puts it back; with conversations still in it, it is a delete of
+  every one of them and asks like one. See ADR 0039.
 - **What you have archived is not in the sidebar.** The panel is the list you work in; a section of
   things you are finished with is the only part of that column that is never the answer, and it
   grows forever. One row with a count, `a` in the panel or `^F` anywhere, and it opens as a picker
@@ -186,6 +208,16 @@ per decision, and records the *reasoning*, not the choice.
   every list agrees and a restart does not lose it; it wears `Status.Unread`, the amber the palette
   already uses for *act now*, and it never moves — motion means "something is happening you cannot
   see", and this is the opposite. A folded project carries a dot for what it is hiding. See ADR 0042.
+- **A conversation that is asking you something is not a conversation that is working.** Its turn is
+  still in flight — blocked on the hook — so `active_turn` is set and every list draws the spinner,
+  which is the one row in the panel that most needs finding drawn as the nineteen that do not. Which
+  ones are waiting travels as `question.asking`, a **workspace var** written by whatever serves
+  `ask_user` and read by whatever draws conversations, because it is a fact about them rather than
+  about the panel that happened to learn it. It **outranks working** wherever the two meet, it wears
+  `Status.Pending` and therefore *moves* — a block ends when you answer, which is exactly what
+  `Status.Unread` must not do — and the queue behind it is in memory while the var is on disk, so it
+  is announced once at startup, empty, and that is what clears the one left behind by a workspace
+  that stopped mid-question. See ADR 0043.
 - **A card is a row until you ask for more.** A call that only *looked* at something folds to its
   header with the size of what came back on the end of it; a command keeps its output, an edit keeps
   its diff, and a failure always shows. See ADR 0033.
@@ -260,6 +292,14 @@ per decision, and records the *reasoning*, not the choice.
   row of a transcript that no longer existed. Reading is a place *in* a conversation, so the switch
   takes you out of it too. ADR 0036's rule, one more time: a value that is only forwarded is a value
   that comes back wrong.
+- **Following the newest is not a row, and row zero is.** `top_line` is an `Option`: `None` is
+  unscrolled — the frontend's own answer, the last screenful of a transcript and the first of
+  everything else — and `Some(0)` is the top. Encoded as the same `0`, the first row of a
+  conversation was the one place in it nothing could ask for: `^U` and `PageUp` up to the top asked
+  for row zero, which was read as "follow the tail", and the window drew the *end* instead — cursor
+  off screen, and nothing on the way there to say what had happened. A frontend decides where an
+  unscrolled window sits, which is why the state has to be sayable rather than spelled with a row
+  number that means something else.
 
 ## Verification
 
@@ -322,7 +362,7 @@ registry — this table is what ships.
 | `^V` | Attach the image on the clipboard. A key rather than a paste, because a terminal's paste can only ever hand over text |
 | `⌥V` | Take the last attached image back off |
 | `^P` | Pick a model. Mid-turn too — the running agent is told, and thinks the rest with it |
-| `^E` | Everything this model can be told, on one panel: effort, thinking, fast mode, context, and whatever a driver invented. `←→` along a row, `↑↓` between them, and it applies as you move |
+| `^E` | Everything this model can be told, on one panel: effort, thinking, fast mode, context, and whatever a driver invented. `←→` along a row, `↑↓` between them, and it applies as you move. Nothing else reaches the keyboard while it is open; `^E` again closes it |
 | `⌥↑` `⌥↓` | One rung up or down the capability ladder, same provider |
 | `⇧⇥` | Permission mode — full access to start with, then ask, allow-listed, deny. Belongs to this conversation, saved with it, and takes effect on the turn that is running |
 | `^T` | Projects and conversations. Switching is never refused — turns keep running where they are |
@@ -426,7 +466,7 @@ says how many are asking, `^T` is where you go, and it opens when you get there.
 | `f` | Pin a project to the top |
 | `J` `K` | Reorder within a group |
 | `r` | Rename a conversation |
-| `x` `X` | Archive, delete |
+| `x` `X` | Archive, delete. On a project heading, `X` takes the project off the list — the only thing that does |
 | `a` | The archive. Nothing archived is ever a row in this panel — `↵` restores one, `^U` puts it back without going there, `^X` deletes |
 | `?` | The keys for whatever row you are on |
 | `Esc` | Back to the composer |

--- a/crates/neosh-agent/src/session.rs
+++ b/crates/neosh-agent/src/session.rs
@@ -153,8 +153,14 @@ impl Session {
         match first.map(str::trim).filter(|t| !t.is_empty()) {
             // Truncated by *character*, not byte: slicing a multi-byte boundary would panic, and
             // the frontend measures display width anyway.
+            //
+            // Generously, and deliberately more generously than any list will draw. This is a value
+            // that is *forwarded*, so cutting it here cuts it for everybody — and a panel that can
+            // unfold the row under the cursor to show the rest of a title cannot show a rest that
+            // was thrown away three crates ago. Every consumer clips to its own column; the bound
+            // here is only so that a pasted wall of text does not become a label.
             Some(text) => {
-                let mut out: String = text.lines().next().unwrap_or(text).chars().take(48).collect();
+                let mut out: String = text.lines().next().unwrap_or(text).chars().take(160).collect();
                 if out.chars().count() < text.chars().count() {
                     out.push('\u{2026}');
                 }

--- a/crates/neosh-core/src/editor.rs
+++ b/crates/neosh-core/src/editor.rs
@@ -27,6 +27,12 @@ use crate::options::OptionRegistry;
 use crate::text;
 use crate::window::{Viewport, Window};
 
+/// The keys that reach the workspace even under a modal float, when nothing has said otherwise.
+///
+/// Quit and reload configuration: the two things you need when a panel is wrong. `ui.modal_escape_keys`
+/// replaces this, including with an empty list — see [`Editor::is_modal_escape`].
+const MODAL_ESCAPES: &[&str] = &["<C-q>", "<C-r>"];
+
 /// Work the core cannot do itself, drained by the host after every apply.
 #[derive(Debug, Clone, PartialEq)]
 pub enum CoreEffect {
@@ -465,8 +471,38 @@ impl Editor {
                 }
             }
         }
-        scopes.push(KeymapScope::Global);
+        if !self.focus_is_modal() {
+            scopes.push(KeymapScope::Global);
+        }
         scopes
+    }
+
+    /// Whether the focused window has declared itself modal. See [`FloatConfig::modal`].
+    fn focus_is_modal(&self) -> bool {
+        self.focus
+            .current()
+            .and_then(|win| self.windows.get(&win))
+            .is_some_and(crate::window::Window::modal)
+    }
+
+    /// The keys that resolve globally even under a modal.
+    ///
+    /// Read out of `ui.modal_escape_keys` on every press rather than cached, because it is a
+    /// setting and `^R` reloads settings — and a stale copy of *this* list is the one that cannot
+    /// be corrected without restarting, since the key to reload is on it.
+    fn is_modal_escape(&self, seq: &[KeyPress]) -> bool {
+        let keys = match self.options.get("ui.modal_escape_keys") {
+            Some(neosh_proto::OptionValue::List(keys)) => keys.clone(),
+            // Absent is not the same as empty. Absent means nothing has *declared* the option —
+            // a bare `Editor`, a frontend that never registered it — and falling through to "no
+            // escapes" there would make the one thing standing between a buggy panel and a
+            // terminal you have to kill contingent on somebody having remembered to declare a
+            // default. An empty list is honoured, because that is a person saying so.
+            _ => MODAL_ESCAPES.iter().map(|k| (*k).to_string()).collect(),
+        };
+        keys.iter()
+            .filter_map(|lhs| crate::keymap::parse_keys(&self.with_leader(lhs)).ok())
+            .any(|k| k == seq)
     }
 
     /// Whatever `mapleader` is, or Neovim's default.
@@ -490,7 +526,17 @@ impl Editor {
         self.pending_keys.push(key.clone());
         let scopes = self.active_scopes();
         let seq = self.pending_keys.clone();
-        let res = self.keymaps.resolve(self.mode, &scopes, &seq);
+        let mut res = self.keymaps.resolve(self.mode, &scopes, &seq);
+        // A modal drops `Global` from its scopes, so the escape hatches have to be let back in by
+        // name. Consulted only once the panel's own scopes have declined the key: a modal that
+        // binds `<C-r>` for something of its own keeps it, which is the same rule every other
+        // scope follows.
+        if matches!(res, KeyResolution::Unhandled)
+            && self.focus_is_modal()
+            && self.is_modal_escape(&seq)
+        {
+            res = self.keymaps.resolve(self.mode, &[KeymapScope::Global], &seq);
+        }
         match &res {
             KeyResolution::Pending => {}
             KeyResolution::Matched { command, .. } => {
@@ -532,8 +578,14 @@ impl Editor {
     /// A key no binding wanted.
     ///
     /// A capture claims what the keymaps did not, so a picker gets its filter keys while `<C-q>`
-    /// still quits. Checked here rather than before `resolve` for exactly that reason: a modal that
-    /// swallowed every binding would be a trap.
+    /// still quits. Checked here rather than before `resolve` for exactly that reason: a capture
+    /// that swallowed every binding would be a trap.
+    ///
+    /// Under a [modal](neosh_proto::FloatConfig::modal) with no capture the key stops here. It has
+    /// already been offered to the panel's own scopes and to the escape list and neither wanted
+    /// it; the only place left is the host, which would put a character in the composer behind the
+    /// float or read `<Esc>` as "interrupt the turn". Typing into a field you cannot see is worse
+    /// than a key that does nothing.
     fn unclaimed(&mut self, key: KeyPress) {
         let captured = self.focus.current().and_then(|w| self.captures.get(&w).cloned());
         match captured {
@@ -541,6 +593,7 @@ impl Editor {
                 let ctx = KeyContext { key, mode: self.mode, win: self.focus.current() };
                 self.invoke_command(&command, Vec::new(), Some(ctx));
             }
+            None if self.focus_is_modal() => {}
             None => self.effects.push(CoreEffect::UnhandledKey { key, mode: self.mode }),
         }
     }

--- a/crates/neosh-core/src/palette.rs
+++ b/crates/neosh-core/src/palette.rs
@@ -552,6 +552,18 @@ pub fn groups(variant: Variant) -> Vec<(&'static str, HighlightDef)> {
         // what it has to say is "this is not one of the normal settings" — and that is a thing no
         // amount of amber can say. See `Animation::Spectrum`.
         ("Option.Beyond", spec(spectrum(bold(lit(r.accent)), 3200))),
+        // The value the arrow keys are on *right now*, as against the value in effect on a row
+        // they are not. Reverse, which the rules at the top of this file reserve for selection —
+        // and this is selection. It exists because a ladder with one rung lit looks exactly the
+        // same whether or not pressing `←` would move it: the panel was a live control that read
+        // as a summary, and the answer to "is this a thing I can change" has to be legible before
+        // anybody presses a key to find out. Rows the cursor is not on keep their rung on the
+        // ramp, because that is a statement about the setting rather than about the cursor.
+        ("Option.Cursor", spec(reverse(bold(fg(r.accent))))),
+        // The chevrons that say a row is a horizontal control. Drawn on every row so the shape is
+        // learnt once, lit only on the one the keys act on.
+        ("Option.Rail", spec(dim(fg(r.faint)))),
+        ("Option.RailLive", spec(bold(fg(r.accent)))),
         // The value you just settled on, for the moment before the panel closes. Reverse, which
         // the rules at the top of this file reserve for selection and for the one-shot "it moved
         // there" flash — this is the second of those, and it is the only acknowledgement a control

--- a/crates/neosh-core/src/window.rs
+++ b/crates/neosh-core/src/window.rs
@@ -21,14 +21,19 @@ pub struct Window {
     pub layout: WindowLayout,
     /// `(row, byte_col)` in the buffer.
     pub cursor: (u32, u32),
-    /// The first buffer row the window was last asked to show.
+    /// The first buffer row the window was last asked to show, or `None` for unscrolled.
     ///
     /// What was *asked for*, not what the frontend reported drawing — the two differ for exactly
     /// as long as it takes a frame to come back, and the frontend's report is the one that arrives
     /// too late to be scrolled from. Kept here rather than only in whoever did the scrolling
     /// because a client attaching to a workspace that is already running has to be told where the
     /// transcript sits, and "wherever the top is" would drop it back to the beginning.
-    pub top_line: u32,
+    ///
+    /// `None` is unscrolled and is the frontend's decision — the end of a transcript, the start of
+    /// everything else — which is why it is an `Option` rather than a row that happens to be zero.
+    /// Row zero is a place you can scroll to, and it stopped being reachable the moment it shared
+    /// an encoding with "wherever this window starts".
+    pub top_line: Option<u32>,
     /// Where a selection started, if one is running. The other end is always the cursor.
     ///
     /// Held per window rather than per buffer: the same buffer shown twice is two places you can
@@ -50,7 +55,7 @@ impl Window {
             buf,
             layout,
             cursor: (0, 0),
-            top_line: 0,
+            top_line: None,
             anchor: None,
             goal_col: None,
             viewport: None,
@@ -73,6 +78,14 @@ impl Window {
     pub fn close_on_blur(&self) -> bool {
         match &self.layout {
             WindowLayout::Float { config } => config.close_on_blur,
+            WindowLayout::Docked { .. } => false,
+        }
+    }
+
+    /// Whether this window takes the keyboard to itself. See [`FloatConfig::modal`].
+    pub fn modal(&self) -> bool {
+        match &self.layout {
+            WindowLayout::Float { config } => config.modal,
             WindowLayout::Docked { .. } => false,
         }
     }

--- a/crates/neosh-core/tests/key_capture.rs
+++ b/crates/neosh-core/tests/key_capture.rs
@@ -240,3 +240,164 @@ fn closing_a_window_takes_the_keys_it_claimed_with_it() {
     e.apply(&plugin, ApiCall::WinClose { win }).expect("close");
     assert_eq!(listed(&mut e), 0, "and gone with it");
 }
+
+// ---------------------------------------------------------------------------
+// Modal floats
+// ---------------------------------------------------------------------------
+//
+// The other half of the same problem, and the half a capture cannot solve. A widget shadows the
+// keys it *wants*; it has no way to name the keys it merely does not want to happen, and there is
+// no list it could write down anyway — `^T`, `^G`, `^L` and whatever a plugin binds next week.
+// `FloatConfig::modal` is that statement, made once: while this has focus, global bindings do not
+// resolve.
+
+/// An editor with a modal float focused, and `quit` bound globally to stand in for `^Q`.
+fn modal_setup() -> (Editor, PluginId, WindowId) {
+    let mut e = Editor::new();
+    let plugin = PluginId::from("panel");
+    let buf = e.create_buffer("[panel]");
+    let win = e.open_window(buf, WindowLayout::Float {
+        config: neosh_proto::FloatConfig { modal: true, ..Default::default() },
+    });
+    for name in ["quit", "session.new", "panel.key"] {
+        e.apply(&plugin, ApiCall::CmdRegister { name: name.into(), desc: None }).expect("registers");
+    }
+    for (lhs, command) in [("<C-q>", "quit"), ("<C-n>", "session.new")] {
+        e.apply(&plugin, ApiCall::KeymapSet {
+            mode: Mode::Normal,
+            lhs: lhs.into(),
+            command: command.into(),
+            scope: None,
+            desc: None,
+        })
+        .expect("binds");
+    }
+    e.apply(&plugin, ApiCall::FocusPush { win }).expect("focuses");
+    e.drain_effects();
+    (e, plugin, win)
+}
+
+#[test]
+fn a_modal_takes_the_global_bindings_out_of_reach() {
+    let (mut e, _plugin, _win) = modal_setup();
+    e.feed_key(ctrl("n"));
+    let effects = e.drain_effects();
+    assert!(invoked(&effects).is_empty(), "`^N` must not start a conversation behind the panel");
+}
+
+#[test]
+fn a_modal_keeps_its_own_bindings() {
+    // Scoped to the window, which is what every widget here does with the keys it wants. Modality
+    // is about *global* bindings; it must not cost a panel the keys it bound for itself.
+    let (mut e, plugin, win) = modal_setup();
+    e.apply(&plugin, ApiCall::KeymapSet {
+        mode: Mode::Normal,
+        lhs: "<C-n>".into(),
+        command: "panel.key".into(),
+        scope: Some(neosh_proto::KeymapScope::Window { win }),
+        desc: None,
+    })
+    .expect("binds");
+    e.drain_effects();
+
+    e.feed_key(ctrl("n"));
+    assert_eq!(invoked(&e.drain_effects()), vec!["panel.key"]);
+}
+
+#[test]
+fn the_escape_hatches_survive_a_modal() {
+    // The reason this is safe at all. A panel that failed to bind a way out would otherwise be a
+    // terminal somebody has to kill, and "the panel is buggy" must never be the same event as
+    // "the program is gone".
+    let (mut e, _plugin, _win) = modal_setup();
+    e.feed_key(ctrl("q"));
+    assert_eq!(invoked(&e.drain_effects()), vec!["quit"]);
+}
+
+#[test]
+fn a_modal_that_binds_an_escape_key_itself_keeps_it() {
+    // Nearer scope wins, exactly as it does everywhere else — the escape list is consulted only
+    // once the panel's own scopes have declined the key.
+    let (mut e, plugin, win) = modal_setup();
+    e.apply(&plugin, ApiCall::KeymapSet {
+        mode: Mode::Normal,
+        lhs: "<C-q>".into(),
+        command: "panel.key".into(),
+        scope: Some(neosh_proto::KeymapScope::Window { win }),
+        desc: None,
+    })
+    .expect("binds");
+    e.drain_effects();
+
+    e.feed_key(ctrl("q"));
+    assert_eq!(invoked(&e.drain_effects()), vec!["panel.key"]);
+}
+
+#[test]
+fn an_emptied_escape_list_is_honoured_and_an_undeclared_one_is_not() {
+    // Absent means nobody declared the option; empty means somebody said so. Defaulting the first
+    // to "no escapes" would make the safety net depend on a declaration having been remembered.
+    let (mut e, plugin, _win) = modal_setup();
+    e.apply(&plugin, ApiCall::OptDeclare {
+        spec: neosh_proto::OptionSpec {
+            name: "ui.modal_escape_keys".into(),
+            ty: neosh_proto::OptionType::List,
+            default: neosh_proto::OptionValue::List(Vec::new()),
+            description: None,
+        },
+    })
+    .expect("declares");
+    e.drain_effects();
+
+    e.feed_key(ctrl("q"));
+    assert!(invoked(&e.drain_effects()).is_empty(), "an empty list means no way past the panel");
+}
+
+#[test]
+fn a_modal_swallows_what_nothing_claimed() {
+    // Otherwise the key reaches the host, which puts characters in the composer behind the float
+    // and reads `<Esc>` as "interrupt the turn". Typing into a field you cannot see is worse than
+    // a key that does nothing.
+    let (mut e, _plugin, _win) = modal_setup();
+    e.feed_key(key("x"));
+    let effects = e.drain_effects();
+    assert_eq!(unhandled(&effects), 0);
+    assert!(invoked(&effects).is_empty());
+}
+
+#[test]
+fn a_modal_with_a_capture_still_gets_its_raw_keys() {
+    // A filter box in a modal panel: the capture is what makes typing work, and modality must not
+    // take it away.
+    let (mut e, plugin, win) = modal_setup();
+    e.apply(&plugin, ApiCall::KeymapCapture { win, command: "panel.key".into() }).expect("captures");
+    e.drain_effects();
+
+    e.feed_key(key("x"));
+    assert_eq!(invoked(&e.drain_effects()), vec!["panel.key"]);
+}
+
+#[test]
+fn an_ordinary_float_is_unaffected() {
+    // `modal` defaults off, and every float that has ever been opened here relies on that.
+    let mut e = Editor::new();
+    let plugin = PluginId::from("panel");
+    let buf = e.create_buffer("[hint]");
+    let win = e.open_window(buf, WindowLayout::Float { config: neosh_proto::FloatConfig::default() });
+    e.apply(&plugin, ApiCall::CmdRegister { name: "quit".into(), desc: None }).expect("registers");
+    e.apply(&plugin, ApiCall::KeymapSet {
+        mode: Mode::Normal,
+        lhs: "<C-q>".into(),
+        command: "quit".into(),
+        scope: None,
+        desc: None,
+    })
+    .expect("binds");
+    e.apply(&plugin, ApiCall::FocusPush { win }).expect("focuses");
+    e.drain_effects();
+
+    e.feed_key(ctrl("q"));
+    assert_eq!(invoked(&e.drain_effects()), vec!["quit"]);
+    e.feed_key(key("x"));
+    assert_eq!(unhandled(&e.drain_effects()), 1, "still reaches the composer");
+}

--- a/crates/neosh-proto/src/api.rs
+++ b/crates/neosh-proto/src/api.rs
@@ -294,9 +294,16 @@ pub enum ApiCall {
     WinGetViewport {
         win: WindowId,
     },
+    /// Put a buffer row at the top of a window, or give the scroll position back.
+    ///
+    /// `None` means *unscrolled* — the frontend's own answer, which for the transcript is the last
+    /// screenful and for everything else is the first. It is a different place from `Some(0)`, and
+    /// the difference is the whole point: while the two shared an encoding, scrolling a transcript
+    /// to its first row asked for the state that draws its last one, so reaching the top of a long
+    /// answer showed the bottom of it.
     WinScrollTo {
         win: WindowId,
-        top_line: u32,
+        top_line: Option<u32>,
     },
     /// Every window that is open, what is in it, and where it sits.
     ///

--- a/crates/neosh-proto/src/ui.rs
+++ b/crates/neosh-proto/src/ui.rs
@@ -148,6 +148,34 @@ pub struct FloatConfig {
     /// Whether the float can take focus at all. `false` for passive hints and hover cards.
     #[serde(default)]
     pub focusable: bool,
+    /// While this float has focus, global bindings stop resolving.
+    ///
+    /// # Why this is not "bind over the keys you care about"
+    ///
+    /// That is what every panel here did, and it only ever worked for the keys the panel itself
+    /// used. A widget shadows `<C-n>` because *it* wants `<C-n>` for "next" — so `<C-t>`, `<C-g>`,
+    /// `<C-l>` and the rest still fell through to the workspace, and pressing one over an open
+    /// picker opened a second panel behind the first and left focus somewhere neither of them
+    /// expected. A control that is on screen for two seconds cannot be asked to enumerate every
+    /// key the program will ever bind; the question it can answer is "does anything else reach me",
+    /// and the answer for a panel you are answering a question with is no.
+    ///
+    /// Window, buffer and kind scopes still resolve, so a modal is exactly as extensible as any
+    /// other panel: a third party binds against its **kind** and that binding is nearer than a
+    /// global one, which is the ordering [`KeymapScope`](crate::KeymapScope) already promises.
+    ///
+    /// # The escape hatches survive
+    ///
+    /// `ui.modal_escape_keys` — `<C-q>` and `<C-r>` by default — resolve globally anyway. A modal
+    /// that failed to bind a way out would otherwise be a terminal you have to kill, and "the
+    /// panel is buggy" must never be the same event as "the program is gone". It is an option
+    /// rather than a constant because which keys those are is the user's, like every other key
+    /// here.
+    ///
+    /// A key nothing claimed is *swallowed* rather than reported unhandled: a modal that let
+    /// characters through to the composer would be typing into a field you cannot see.
+    #[serde(default)]
+    pub modal: bool,
 }
 
 impl Default for FloatConfig {
@@ -163,6 +191,7 @@ impl Default for FloatConfig {
             title: None,
             close_on_blur: false,
             focusable: true,
+            modal: false,
         }
     }
 }
@@ -637,9 +666,14 @@ pub enum UiEvent {
         col: u32,
     },
     /// Scroll position requested by the core (e.g. follow streaming output).
+    ///
+    /// `None` is *unscrolled*, which is not the same place as row zero: a transcript that has never
+    /// been scrolled shows its end, and every other window shows its beginning. Row zero is
+    /// `Some(0)`, and it has to be sayable — encoded as `0`, the top of a transcript was the one
+    /// row in it nothing could reach, and asking for it drew the bottom instead.
     ScrollTo {
         win: WindowId,
-        top_line: u32,
+        top_line: Option<u32>,
     },
 
     HighlightDefined {

--- a/crates/neosh-provider/src/catalog.rs
+++ b/crates/neosh-provider/src/catalog.rs
@@ -108,16 +108,6 @@ fn boolean(id: &str, label: &str, desc: &str) -> ProviderOptionDescriptor {
     }
 }
 
-/// A switch that is a word in the message rather than a parameter. The id is the word.
-fn spoken(id: &str, label: &str, desc: &str) -> ProviderOptionDescriptor {
-    ProviderOptionDescriptor::Boolean {
-        id: id.into(),
-        label: label.into(),
-        description: Some(desc.into()),
-        current_value: false,
-        prompt_injected_word: Some(id.into()),
-    }
-}
 /// How a reasoning level reads in a list.
 ///
 /// Title case for almost all of them, and a lookup for the ones where it is wrong: `xhigh` is a
@@ -172,11 +162,31 @@ const EFFORT_46: &[&str] = &["low", "medium", "high", "max"];
 /// Advertising them where they do not work would be worse than not having them: the picker would
 /// offer a level that silently does nothing, on the one provider where the same word does something
 /// real — and "it worked yesterday" would be a difference of instance nobody can see.
-const CLAUDE_WORDS: &[Magic] = &[Magic {
-    id: "ultrathink",
-    label: "Ultrathink",
-    description: "Past the top of the ladder — said in the message, not sent as a level.",
-}];
+///
+/// # Why both of them are rungs
+///
+/// `ultracode` used to be a switch of its own, on the reasoning that orchestration is not depth and
+/// a control that does two things says one. Which is true of the *mechanism* and wrong about the
+/// choice: nobody sets a reasoning level and then separately decides how hard the harness should
+/// work, they pick one thing off one scale and get on with it — and a switch sitting under the
+/// ladder, drawn `off / on`, is a second question about the same decision. Every reference
+/// implementation that has shipped this puts it on the ladder for that reason.
+///
+/// The cost is real and is the point: these are mutually exclusive now, because one message
+/// carries one of these words. "Ultracode at max effort" is no longer expressible — it was, and
+/// almost nobody meant it.
+const CLAUDE_WORDS: &[Magic] = &[
+    Magic {
+        id: "ultracode",
+        label: "Ultracode",
+        description: "Let it orchestrate sub-agents by default. Slower, and thorough.",
+    },
+    Magic {
+        id: "ultrathink",
+        label: "Ultrathink",
+        description: "Past the top of the ladder — said in the message, not sent as a level.",
+    },
+];
 
 /// One entry in the Anthropic catalogue.
 ///
@@ -340,15 +350,6 @@ pub fn claude_cli_models() -> Vec<ModelInfo> {
             let mut descriptors = Vec::new();
             if let Some(levels) = efforts {
                 descriptors.push(effort_with(levels, "high", CLAUDE_WORDS));
-                // Orchestration rather than depth, so a switch of its own rather than a rung on the
-                // effort ladder: you can want a fleet of sub-agents on a shallow turn, and asking
-                // for one by moving a slider marked "how hard should it think" is a control that
-                // does two things and says one.
-                descriptors.push(spoken(
-                    "ultracode",
-                    "Ultracode",
-                    "Let it orchestrate sub-agents by default. Slower, and thorough.",
-                ));
             } else {
                 descriptors.push(boolean(
                     "thinking",
@@ -1035,14 +1036,22 @@ mod tests {
         else {
             panic!("expected an effort select");
         };
-        assert_eq!(prompt_injected_values, &["ultrathink".to_string()]);
-        assert_eq!(options.last().map(|o| o.id.as_str()), Some("ultrathink"), "past the top rung");
+        assert_eq!(
+            prompt_injected_values,
+            &["ultracode".to_string(), "ultrathink".to_string()],
+            "both words are rungs on the one ladder"
+        );
+        let tail: Vec<&str> = options.iter().rev().take(2).map(|o| o.id.as_str()).collect();
+        assert_eq!(tail, ["ultrathink", "ultracode"], "past the top rung, in order");
+        // And nowhere else. A switch left behind would be a second control for a choice the ladder
+        // now owns, and turning it on beside `max` would put a word in the message that the level
+        // beside it contradicts.
         assert!(
-            cli.capabilities.option_descriptors.iter().any(|d| matches!(
+            !cli.capabilities.option_descriptors.iter().any(|d| matches!(
                 d,
-                ProviderOptionDescriptor::Boolean { prompt_injected_word: Some(w), .. } if w == "ultracode"
+                ProviderOptionDescriptor::Boolean { prompt_injected_word: Some(_), .. }
             )),
-            "orchestration is a switch of its own, not a rung on the depth ladder"
+            "no spoken switch survives beside the ladder"
         );
 
         let api = find(&anthropic_models(), "claude-opus-5");

--- a/crates/neosh-tui/src/mirror.rs
+++ b/crates/neosh-tui/src/mirror.rs
@@ -23,7 +23,8 @@ pub struct MirrorWindow {
     pub buf: BufferId,
     pub layout: WindowLayout,
     pub cursor: (u32, u32),
-    pub top_line: u32,
+    /// `None` is unscrolled: the end of a window that follows its tail, the start of every other.
+    pub top_line: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -90,7 +91,7 @@ impl Mirror {
                     buf,
                     layout,
                     cursor: (0, 0),
-                    top_line: 0,
+                    top_line: None,
                 });
                 if !self.window_order.contains(&win) {
                     self.window_order.push(win);

--- a/crates/neosh-tui/src/render.rs
+++ b/crates/neosh-tui/src/render.rs
@@ -618,9 +618,10 @@ pub fn draw(frame: &mut Frame, mirror: &Mirror, theme: &Theme) -> Option<(u16, u
                         _ => BorderType::Rounded,
                     },
                 );
-                b = b.border_style(
-                    theme.style(config.border_hl.as_deref().unwrap_or("Float.Border")),
-                );
+                b = b.border_style(border_style(
+                    theme,
+                    config.border_hl.as_deref().unwrap_or("Float.Border"),
+                ));
                 if let Some(t) = &config.title {
                     b = b.title(Span::styled(t.clone(), theme.style("Float.Title")));
                 }
@@ -644,9 +645,12 @@ pub fn draw(frame: &mut Frame, mirror: &Mirror, theme: &Theme) -> Option<(u16, u
 
         // Follow the tail. Taking the *first* n lines shows a long conversation's opening and
         // never its answer, which is the wrong end of every transcript ever written. An explicit
-        // `top_line` still means "start here", so paging keeps working.
+        // `top_line` still means "start here", so paging keeps working — and `Some(0)` is one of
+        // those, not this. Read as "unscrolled" it was impossible to scroll to the first row of a
+        // transcript: asking put the window back at the last one.
         let height = inner.height as usize;
-        let lines: Vec<Line> = if w.follows_tail() && w.top_line == 0 && rendered.len() > height {
+        let unscrolled = w.follows_tail() && w.top_line.is_none();
+        let lines: Vec<Line> = if unscrolled && rendered.len() > height {
             rendered[rendered.len() - height..].to_vec()
         } else {
             rendered.into_iter().take(height).collect()
@@ -705,6 +709,27 @@ pub fn draw(frame: &mut Frame, mirror: &Mirror, theme: &Theme) -> Option<(u16, u
 /// Shared by drawing and by the caret, which is the point: gravity moves content down by however
 /// many rows it falls short, and the caret has to move by the *same* number. Two calculations of
 /// "how many lines is this" would agree until the first wrapped line, and then quietly stop.
+/// A float's border style, with whatever motion its group carries applied to the frame as a whole.
+///
+/// A `Block` draws its own glyphs and takes one style for all of them, so a border cannot carry a
+/// travelling gradient the way a run of text can. What it *can* carry is the colour that gradient
+/// is currently passing through: animate one cluster, keep the style it came back with, and the
+/// whole frame drifts together. Which is the better reading anyway — a rainbow chasing itself
+/// round a border is something you end up watching, and a border is the edge of the thing you are
+/// meant to be looking at.
+///
+/// Gated on `ui.motion` like every other animation here, and `Animation::Flash` never fires: it
+/// counts from the moment its *mark* first appeared and a border has no mark.
+fn border_style(theme: &Theme, name: &str) -> ratatui::style::Style {
+    let base = theme.style(name);
+    match theme.animation(name).filter(|_| theme.motion()) {
+        Some(anim) => crate::shimmer::animate("─", base, anim, theme.truecolor(), None)
+            .first()
+            .map_or(base, |span| span.style),
+        None => base,
+    }
+}
+
 fn rendered_lines(
     mirror: &Mirror,
     w: &crate::mirror::MirrorWindow,
@@ -721,7 +746,7 @@ fn rendered_lines(
         .map(|b| {
             b.lines
                 .iter()
-                .skip(w.top_line as usize)
+                .skip(w.top_line.unwrap_or(0) as usize)
                 .flat_map(|l| render_line_in(l, theme, Some(width as usize)))
                 .flat_map(|l| if wraps { wrap_line(&l, width as usize) } else { vec![l] })
                 .map(|l| fill_to_edge(l, width as usize))
@@ -792,8 +817,9 @@ fn caret_position(
 
     // Saturating throughout: a row far below `top_line` must clamp to "off-screen" rather than
     // wrap around into a plausible-looking coordinate.
-    let mut line = u16::try_from(row.saturating_sub(w.top_line)).unwrap_or(u16::MAX);
-    line = line.saturating_add(virt_rows_before(buffer, w.top_line, row));
+    let top = w.top_line.unwrap_or(0);
+    let mut line = u16::try_from(row.saturating_sub(top)).unwrap_or(u16::MAX);
+    line = line.saturating_add(virt_rows_before(buffer, top, row));
     // Content pushed down by gravity takes the caret with it.
     if let WindowLayout::Docked { gravity: neosh_proto::Gravity::End, .. } = &w.layout {
         let rows = rendered_lines(mirror, w, theme, inner.width).len();

--- a/crates/neosh-tui/tests/attaching.rs
+++ b/crates/neosh-tui/tests/attaching.rs
@@ -98,7 +98,7 @@ fn a_workspace() -> (Editor, BufferId, neosh_proto::WindowId) {
         other => panic!("{other:?}"),
     };
 
-    e.apply(&p, ApiCall::WinScrollTo { win: main, top_line: 12 }).expect("scroll");
+    e.apply(&p, ApiCall::WinScrollTo { win: main, top_line: Some(12) }).expect("scroll");
     e.apply(&p, ApiCall::WinSetCursor { win: bottom, row: 0, col: 5 }).expect("cursor");
     e.apply(&p, ApiCall::FocusPush { win: bottom }).expect("focus");
     (e, chat, main)

--- a/crates/neosh-tui/tests/rendering.rs
+++ b/crates/neosh-tui/tests/rendering.rs
@@ -900,10 +900,36 @@ fn an_explicit_scroll_position_still_means_start_here() {
     // Tail-following must not take paging away.
     let lines: Vec<String> = (0..40).map(|i| format!("line {i}")).collect();
     let mut m = main_window_with(lines.iter().map(String::as_str).collect());
-    m.apply(UiEvent::ScrollTo { win: WindowId(1), top_line: 10 });
+    m.apply(UiEvent::ScrollTo { win: WindowId(1), top_line: Some(10) });
     let rows = rows_of(&m, 20, 5).join("\n");
     assert!(rows.contains("line 10"), "started where asked:\n{rows}");
     assert!(!rows.contains("line 39"), "and did not jump to the end:\n{rows}");
+}
+
+/// Row zero is a place, and asking for it is not asking to follow the tail.
+///
+/// The two shared an encoding, so the top of a transcript was the one row in it nothing could
+/// reach: `^U` up to the first line asked for `0`, which was read as "unscrolled", and the window
+/// drew the last screenful instead. Reading upwards ended at the bottom.
+#[test]
+fn scrolling_to_the_first_row_shows_the_first_row() {
+    let lines: Vec<String> = (0..40).map(|i| format!("line {i}")).collect();
+    let mut m = main_window_with(lines.iter().map(String::as_str).collect());
+    m.apply(UiEvent::ScrollTo { win: WindowId(1), top_line: Some(0) });
+    let rows = rows_of(&m, 20, 5).join("\n");
+    assert!(rows.contains("line 0"), "the top of the transcript:\n{rows}");
+    assert!(!rows.contains("line 39"), "and not the bottom of it:\n{rows}");
+}
+
+/// And giving the position back is still how you follow the newest.
+#[test]
+fn an_unscrolled_transcript_is_back_at_the_end() {
+    let lines: Vec<String> = (0..40).map(|i| format!("line {i}")).collect();
+    let mut m = main_window_with(lines.iter().map(String::as_str).collect());
+    m.apply(UiEvent::ScrollTo { win: WindowId(1), top_line: Some(0) });
+    m.apply(UiEvent::ScrollTo { win: WindowId(1), top_line: None });
+    let rows = rows_of(&m, 20, 5).join("\n");
+    assert!(rows.contains("line 39"), "the newest line is on screen:\n{rows}");
 }
 
 #[test]

--- a/crates/neosh/src/frontend.rs
+++ b/crates/neosh/src/frontend.rs
@@ -163,7 +163,10 @@ impl TerminalUi {
     /// Tell the core where each window ended up, but only when it moved.
     fn report_geometry(&mut self, geometry: &[(neosh_proto::WindowId, neosh_proto::Rect)]) {
         for (win, rect) in geometry {
-            let top = self.mirror.windows.get(win).map(|w| w.top_line).unwrap_or(0);
+            // Unscrolled reports as zero: what the frontend chose for a tail-following window is
+            // a *rendered* row, and the core counts in buffer rows — there is no honest number to
+            // put here, and every plugin reading it wants "the top of what is drawn".
+            let top = self.mirror.windows.get(win).and_then(|w| w.top_line).unwrap_or(0);
             let now = (rect.width, rect.height, top);
             if self.reported.get(win) == Some(&now) {
                 continue;

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -145,12 +145,17 @@ pub struct Host {
 
     chat: BufferId,
     chat_win: WindowId,
-    /// Where the transcript is scrolled to, as the host intends it.
+    /// Where the transcript is scrolled to, as the host intends it. `None` follows the newest.
     ///
     /// Not read back from the frontend's report: two page-ups inside one 16 ms coalescing window
     /// would both compute from the same stale value and the second would do nothing. The frontend
     /// reports what it drew; this is what we asked for.
-    chat_top: u32,
+    ///
+    /// Following the tail is `None` and the first row is `Some(0)`, which are two different places
+    /// — the frontend draws the last screenful for one and the first for the other. Sharing zero
+    /// between them made the top of a long answer unreachable: `^U` up to it asked for row zero,
+    /// which was read as "follow", and the transcript jumped back to the end.
+    chat_top: Option<u32>,
     composer: BufferId,
     composer_win: WindowId,
     /// Marks for the chrome around the composer: the prompt, the placeholder, the shortcut row.
@@ -682,7 +687,7 @@ impl Host {
             frontend,
             chat,
             chat_win,
-            chat_top: 0,
+            chat_top: None,
             composer,
             composer_win,
             status,
@@ -3701,10 +3706,11 @@ impl Host {
     fn place_cursor_line(&mut self, at: u32) {
         let row = self.chat_cursor().0;
         let top = row.saturating_sub(at);
-        self.chat_top = top.max(1);
-        let _ = self
-            .editor
-            .apply(&PluginId::from(BUILTIN), ApiCall::WinScrollTo { win: self.chat_win, top_line: top });
+        self.chat_top = Some(top);
+        let _ = self.editor.apply(&PluginId::from(BUILTIN), ApiCall::WinScrollTo {
+            win: self.chat_win,
+            top_line: Some(top),
+        });
     }
 
     /// `v` and `V`: start a selection of that shape, change a running one into it, or — pressed on
@@ -4111,10 +4117,13 @@ impl Host {
         let row = w.cursor.0;
         let Some(v) = w.viewport else { return };
         let height = (v.height as u32).max(1);
-        let top = self.chat_top;
         let lines = self.editor.buffer(self.chat).map(|b| b.line_count()).unwrap_or(0);
-        // `chat_top == 0` means "following the tail", which is a different place from line zero.
-        let showing = if top == 0 { lines.saturating_sub(height) } else { top };
+        // `None` means "following the tail", which is a different place from line zero — and the
+        // first row of the transcript is a place the reader arrives at, so it has to be sayable.
+        // Sent as a bare `0` it was read as "follow" instead, and `^U` up to the top of a long
+        // answer put the window back at the bottom of it, cursor off screen, with nothing on the
+        // way there to say what had happened.
+        let showing = self.chat_top.unwrap_or_else(|| lines.saturating_sub(height));
         let next = if row < showing {
             row
         } else if row >= showing + height {
@@ -4122,10 +4131,10 @@ impl Host {
         } else {
             return;
         };
-        self.chat_top = next.max(1);
+        self.chat_top = Some(next);
         let _ = self.editor.apply(&PluginId::from(BUILTIN), ApiCall::WinScrollTo {
             win: self.chat_win,
-            top_line: next,
+            top_line: Some(next),
         });
     }
 
@@ -4163,7 +4172,7 @@ impl Host {
         // that no longer has those rows.
         self.working = false;
         self.plan_rows = 0;
-        self.chat_top = 0;
+        self.chat_top = None;
         let ascii = self.option_bool("ui.ascii_only");
         let limits = self.limits();
         let width = self.chat_width();
@@ -4190,7 +4199,7 @@ impl Host {
             lines,
         });
         self.draw_marks(&marks, 0);
-        // Where the window *is*, and not only what this end believes about it. `chat_top = 0` above
+        // Where the window *is*, and not only what this end believes about it. `chat_top = None`
         // says "following the tail"; the window has to be told, because it is still sitting at
         // whatever row the last conversation was scrolled to — and a scroll offset is kept rather
         // than derived, precisely so that a client attaching later can be told it. Read a long
@@ -4203,7 +4212,7 @@ impl Host {
         // shorter one.
         let _ = self
             .editor
-            .apply(&plugin, ApiCall::WinScrollTo { win: self.chat_win, top_line: 0 });
+            .apply(&plugin, ApiCall::WinScrollTo { win: self.chat_win, top_line: None });
         let _ = self
             .editor
             .apply(&plugin, ApiCall::WinSetCursor { win: self.chat_win, row: 0, col: 0 });
@@ -5831,7 +5840,7 @@ impl Host {
                 // declarative geometry it already has. Redraw so it takes effect.
                 let _ = self.editor.apply(&PluginId::from(BUILTIN), ApiCall::WinScrollTo {
                     win: self.composer_win,
-                    top_line: 0,
+                    top_line: Some(0),
                 });
                 // Except the welcome, which is drawn to a width: the word at the top of it has to
                 // fit or not be there.
@@ -6511,8 +6520,10 @@ impl Host {
 
     /// Page the transcript. `0` returns to following the tail.
     ///
-    /// `top_line == 0` is the "follow the newest" state, which is why jumping to the end is a reset
+    /// Following the newest is `None` rather than a row, which is why jumping to the end is a reset
     /// rather than a seek: the renderer already shows the last screenful when nothing has scrolled.
+    /// Row zero is `Some(0)` and means the top — paging up to it used to ask for "follow" and land
+    /// back at the end, one page short of the beginning every time.
     fn scroll_chat(&mut self, direction: i32) {
         let plugin = PluginId::from(BUILTIN);
         let lines = self.editor.buffer(self.chat).map(|b| b.line_count() as u32).unwrap_or(0);
@@ -6527,17 +6538,22 @@ impl Host {
         let current = self.chat_top;
 
         let top = match direction {
-            0 => 0,
+            0 => None,
             d if d < 0 => {
                 // From "following", scrolling up starts from where the tail actually begins.
-                let from = if current == 0 { lines.saturating_sub(page) } else { current };
-                from.saturating_sub(page)
+                let from = current.unwrap_or_else(|| lines.saturating_sub(page));
+                Some(from.saturating_sub(page))
             }
-            _ => {
-                let next = current.saturating_add(page);
-                // Past the end means back to following, so a user cannot scroll into blank space.
-                if current == 0 || next + page >= lines { 0 } else { next }
-            }
+            _ => match current {
+                // Already at the end, and there is nowhere past it to scroll into.
+                None => None,
+                Some(c) => {
+                    let next = c.saturating_add(page);
+                    // Past the end means back to following, so a user cannot scroll into blank
+                    // space.
+                    if next + page >= lines { None } else { Some(next) }
+                }
+            },
         };
         self.chat_top = top;
         let _ = self.editor.apply(&plugin, ApiCall::WinScrollTo { win, top_line: top });
@@ -6979,6 +6995,22 @@ impl Host {
                     "Show a shortcut row under the composer. Off by default: the sidebar's footer \
                      carries the same keys and `F1` carries all of them, so the row mostly cost \
                      the transcript a line."
+                        .into(),
+                ),
+            },
+            // The way out of a panel that has taken the keyboard. A modal float stops global
+            // bindings resolving — which is what makes `^N` over an open picker do nothing instead
+            // of opening a conversation behind it — so these are named to survive that. A list
+            // rather than a constant because they are keys, and every key here is the user's; empty
+            // it and the only way out of a panel is the way the panel gives you.
+            OptionSpec {
+                name: "ui.modal_escape_keys".into(),
+                ty: OptionType::List,
+                default: OptionValue::List(vec!["<C-q>".into(), "<C-r>".into()]),
+                description: Some(
+                    "Keys that still reach the workspace while a modal panel is open. Quit and \
+                     reload by default, so a panel that fails to bind a way out is never a \
+                     terminal you have to kill."
                         .into(),
                 ),
             },

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -2075,6 +2075,56 @@ fn a_worktree_nests_under_the_repository_it_belongs_to() {
     );
 }
 
+/// And it is still inside it once you have deleted everything you were doing in there.
+///
+/// Which tree belongs to which repository is read off a conversation's `repo_root` — so an emptied
+/// worktree has nobody left to say it, and a project that outlives its conversations would jump out
+/// of the repository it belongs to and land at the top level as a project of its own. A tree does
+/// not become a project by being idle: the relationship is written down (`sidebar.root`) while
+/// something still knows it.
+#[test]
+fn an_emptied_worktree_is_still_inside_its_repository() {
+    let sb = Sandbox::new("wtempty");
+    sb.git_init();
+    let root = sb.root.join("trees");
+    sb.write_config(&format!(
+        "[options]\n\"worktree.root\" = \"{}\"\n\"ui.confirm_destructive\" = false\n",
+        root.display()
+    ));
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("PROJECTS");
+
+    s.send(&command_with("git.worktree.new", "sideline"));
+    assert!(
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("sideline"))),
+        "the worktree is there to begin with\n{:?}",
+        s.sidebar_now()
+    );
+
+    // The conversation the worktree was made for is the active one, so this empties the tree. Wait
+    // for it to actually go: every claim below is true of the panel *before* the delete as well, so
+    // a test that only asserted the shape would pass without waiting for anything to happen.
+    s.send(&command("session.close"));
+    assert!(
+        s.pump(|s| s.sidebar_now().iter().filter(|l| l.contains("New conversation")).count() == 1),
+        "the tree's only conversation is gone\n{:?}",
+        s.sidebar_now()
+    );
+    assert!(
+        s.pump(|s| {
+            let rows = s.sidebar_now();
+            let repo = rows.iter().position(|l| l.contains("work") && !l.contains("sideline"));
+            let tree = rows.iter().position(|l| l.contains("sideline"));
+            match (repo, tree) {
+                (Some(r), Some(t)) => t > r && rows[t].starts_with("     "),
+                _ => false,
+            }
+        }),
+        "the emptied tree is still nested under its repository\n{:?}",
+        s.sidebar_now()
+    );
+}
+
 /// No questions at all. A branch named before the work is a decision made at the worst possible
 /// moment, and needing to make it is what stops people reaching for a clean tree in the first
 /// place.

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -1302,6 +1302,86 @@ fn a_level_that_is_a_word_is_said_rather_than_sent() {
 }
 
 #[test]
+fn nothing_else_reaches_the_keyboard_while_the_option_sheet_is_open() {
+    // Every global key used to fall straight through it. `^N` opened a new conversation *behind*
+    // the panel, which stayed on screen; `^T` opened the project panel underneath and moved focus
+    // into it. Shadowing the keys the panel wants could never have fixed this — a panel can name
+    // the keys it wants and never the ones it merely does not want to happen. See ADR 0047.
+    let sb = Sandbox::new("modalsheet");
+    let dir = sb.root.join("config/plugins/lab");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    std::fs::write(
+        dir.join("plugin.toml"),
+        "name = \"lab\"\nversion = \"0.1.0\"\nentry = \"main.ts\"\npermissions = [\"providers\"]\n",
+    )
+    .expect("write manifest");
+    std::fs::write(dir.join("main.ts"), INVENTED_KNOB).expect("write plugin");
+    sb.write_config("[options]\n\"agent.model\" = \"lab/brainy\"\n");
+
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("lab ready");
+    s.ctrl("e");
+    s.wait_open("[model options]");
+
+    s.ctrl("n");
+    s.ctrl("t");
+    // A letter, too: a modal that let characters through would be typing into the composer behind
+    // the float, where you cannot see what you are writing.
+    s.key("z");
+    // Nothing to wait *for* — the assertion is that none of those three did anything — so this is
+    // the one case that has to spend real time before it can say so.
+    s.drain_for(Duration::from_millis(1200));
+
+    assert!(
+        s.buffers_named("[New conversation]").is_empty(),
+        "`^N` opened a conversation behind the panel\n{}",
+        s.transcript()
+    );
+    let sheet = s.buffers_named("[model options]");
+    assert!(
+        sheet.iter().any(|b| !s.windows_for(*b).is_empty()),
+        "the panel that ate the keys is not even on screen\n{}",
+        s.transcript()
+    );
+
+    // And the key that opened it closes it, which is the obligation modality creates: the global
+    // `^E` no longer arrives to toggle it off.
+    s.ctrl("e");
+    s.wait_closed("[model options]");
+}
+
+#[test]
+fn a_knob_row_says_it_is_a_control_before_you_press_anything() {
+    // A ladder with one rung lit reads identically whether or not `←→` do anything to it — which is
+    // how a live control came to look like a summary, and why `↵` on it (which means "done") felt
+    // like a key that does nothing at all.
+    let sb = Sandbox::new("railsheet");
+    let dir = sb.root.join("config/plugins/lab");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    std::fs::write(
+        dir.join("plugin.toml"),
+        "name = \"lab\"\nversion = \"0.1.0\"\nentry = \"main.ts\"\npermissions = [\"providers\"]\n",
+    )
+    .expect("write manifest");
+    std::fs::write(dir.join("main.ts"), INVENTED_KNOB).expect("write plugin");
+    sb.write_config("[options]\n\"agent.model\" = \"lab/brainy\"\n");
+
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("lab ready");
+    s.ctrl("e");
+    s.wait_open("[model options]");
+    s.wait_for("Vibe");
+
+    assert!(
+        s.texts().iter().any(|l| l.contains("‹") && l.contains("›") && l.contains("Chill")),
+        "the row is drawn without the rail that says it is one\n{}",
+        s.transcript()
+    );
+    // And the key that changes something is named before the key that leaves.
+    assert!(s.saw("←→ change"), "the hints lead with the key that does the thing\n{}", s.transcript());
+}
+
+#[test]
 fn what_you_typed_is_what_the_transcript_keeps() {
     // The word belongs to the *request*, not to the conversation. Written into the stored message it
     // would be replayed on every later turn — so turning the level off would not turn it off — and
@@ -2221,6 +2301,91 @@ fn a_second_project_can_be_opened_and_dragged_above_the_first() {
             matches!((w, e), (Some(w), Some(e)) if w < e)
         }),
         "the project moved above the one that was newer\n{:?}",
+        s.sidebar_now()
+    );
+}
+
+/// A project is a place you work, not a property of the work in it.
+///
+/// The list used to be derived from where the conversations were, so emptying a project deleted it:
+/// you cleared out a month of threads and the directory you had been working in all month went with
+/// them, leaving nothing to start the next one from.
+#[test]
+fn a_project_outlives_the_conversations_in_it() {
+    let sb = Sandbox::new("emptyproject");
+    sb.write_config("[options]\n\"ui.confirm_destructive\" = false\n");
+    let other = sb.root.join("elsewhere");
+    std::fs::create_dir_all(&other).expect("mkdir");
+
+    {
+        let mut s = sb.start();
+        s.wait_for("PROJECTS");
+        s.send(&command_with("project.open", &other.display().to_string()));
+        assert!(
+            s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("elsewhere"))),
+            "the second project appears\n{:?}",
+            s.sidebar_now()
+        );
+
+        // The conversation `project.open` started is the active one, so this is the last thing in
+        // that directory going away.
+        s.send(&command("session.close"));
+        assert!(
+            s.pump(|s| {
+                let p = s.sidebar_now();
+                p.iter().any(|l| l.contains("elsewhere"))
+                    && p.iter().any(|l| l.contains("nothing here yet"))
+            }),
+            "the project is still a row, with nothing in it\n{:?}",
+            s.sidebar_now()
+        );
+    }
+
+    // And still there next time: the list is written down rather than worked out again from
+    // whatever happens to be in it.
+    let mut s = sb.start();
+    assert!(
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("elsewhere"))),
+        "the project survived a restart\n{:?}",
+        s.sidebar_now()
+    );
+}
+
+/// Which means there has to be a way off the list, and it is the key that already means "for good".
+#[test]
+fn a_project_is_removed_by_the_key_on_its_heading() {
+    let sb = Sandbox::new("removeproject");
+    sb.write_config("[options]\n\"ui.confirm_destructive\" = false\n");
+    let other = sb.root.join("elsewhere");
+    std::fs::create_dir_all(&other).expect("mkdir");
+
+    let mut s = sb.start();
+    s.wait_for("PROJECTS");
+    s.send(&command_with("project.open", &other.display().to_string()));
+    assert!(s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("elsewhere"))));
+    s.send(&command("session.close"));
+    assert!(s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("nothing here yet"))));
+
+    // The cursor lands on the conversation you are in — the one left in `work` — and the row under
+    // it is the empty project's heading.
+    s.enter_panel();
+    s.down();
+    assert!(
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("X remove"))),
+        "the cursor is on a project, and the strip says the verb\n{:?}",
+        s.sidebar_now()
+    );
+
+    s.key("X");
+    assert!(
+        s.pump(|s| !s.sidebar_now().iter().any(|l| l.contains("elsewhere"))),
+        "the project is off the list\n{:?}",
+        s.sidebar_now()
+    );
+    // And the one it was sitting next to is untouched.
+    assert!(
+        s.sidebar_now().iter().any(|l| l.contains("work")),
+        "the other project is still here\n{:?}",
         s.sidebar_now()
     );
 }
@@ -5261,6 +5426,50 @@ fn a_plugins_own_provider_appears_in_the_plan_strip() {
     );
 }
 
+/// Whose allowance it is, said on the strip.
+///
+/// Three bars and no name answers "how much is left" without ever saying *of what* — and on a
+/// machine with a Claude plan and a Codex one it was two identical-looking stacks with nothing to
+/// tell them apart. The account row carries the provider's display name and its plan, and the
+/// provider here is one a plugin registered, so nothing in the sidebar or the usage plugin has
+/// heard of it: the name is read off the credential list, like the model picker reads it.
+#[test]
+fn the_plan_strip_says_which_account_it_is_about() {
+    let sb = Sandbox::new("planwho");
+    install_planner(&sb);
+    sb.write_config("[options]\n\"agent.model\" = \"planner/planner-1\"\n");
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("planner ready");
+
+    s.send(&command("planner.publish"));
+    s.wait_for("published");
+
+    assert!(
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("Planner"))),
+        "the account is named, not left as an instance id\n{:?}",
+        s.sidebar_now()
+    );
+
+    // What the vendor calls the plan, and the way into the panel. Both are right-aligned virtual
+    // text rather than buffer content, because only the frontend knows how wide the column is.
+    let virt = s.sidebar_virt().join("|");
+    assert!(virt.contains("flightplan"), "the plan's own name sits on the account row:\n{virt}");
+    assert!(
+        virt.contains("^L"),
+        "and the heading says how to see the rest of it:\n{virt}"
+    );
+
+    // The one row here that is a sentence. Every other row is a measurement whose direction you
+    // have to already know: a bar that fills as an allowance is *spent* reads as "how much is left"
+    // to about half of everyone. `session` is at 12% and is the window the provider marked active,
+    // so the strip says 88 — the number in the direction people ask the question.
+    let strip = s.sidebar_now().join("\n");
+    assert!(
+        strip.contains("88% left"),
+        "the binding window, in words and the right way round:\n{strip}"
+    );
+}
+
 /// A mid-turn report patches; it does not replace.
 ///
 /// `claude`'s `rate_limit_event` carries exactly one window and says nothing at all about the
@@ -5411,4 +5620,152 @@ export async function activate({ neosh }: PluginContext) {
     s.send(&command("liar.try"));
     assert!(s.pump(|s| s.saw("liar refused")), "refused, by name\n{}", s.transcript());
     assert!(!s.saw("liar accepted"), "and not accepted\n{}", s.transcript());
+}
+
+#[test]
+fn a_conversation_waiting_on_an_answer_is_marked_in_the_panel() {
+    // A conversation that has asked you something looks *exactly* like one that is thinking: the
+    // turn is still in flight, blocked on the hook, so the row is a spinner and the only way to
+    // find it is to open conversations until one of them asks. The footer can only say how many —
+    // it is one line and it is shared — so the panel is the only place that can say which.
+    //
+    // The two halves are both under test: the `questions` plugin writing `question.asking`, and
+    // this panel reading it. They are separate plugins and neither imports the other, which is the
+    // point — a question panel of your own writes the same var and this row still lights up.
+    const ASKER: &str = r#"
+import type { PluginContext } from "@neosh/api";
+
+export async function activate({ neosh }: PluginContext) {
+  await neosh.cmd.register("t.ask", async () => {
+    const answers = await neosh.ask([{
+      question: "Tabs or spaces?",
+      header: "Indentation",
+      multi_select: false,
+      options: [
+        { label: "Tabs", description: "tab characters" },
+        { label: "Spaces", description: "space characters" },
+      ],
+    }]);
+    neosh.notify(`answered: ${answers === null ? "nothing" : JSON.stringify(answers)}`);
+  });
+  // To the other conversation if there is one, to a new one if there is not.
+  await neosh.cmd.register("t.switch", async () => {
+    const list = await neosh.session.list();
+    const other = list.find((x) => !x.is_active);
+    if (other) await neosh.session.switch(other.id);
+    else await neosh.session.create({ activate: true });
+  });
+  neosh.notify("asker ready");
+}
+"#;
+    let sb = Sandbox::new("asking-row");
+    let dir = sb.root.join("config/plugins/asker");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    std::fs::write(
+        dir.join("plugin.toml"),
+        "name = \"asker\"\nversion = \"0.1.0\"\nentry = \"main.ts\"\n",
+    )
+    .expect("manifest");
+    std::fs::write(dir.join("main.ts"), ASKER).expect("plugin");
+
+    let mut s = sb.start();
+    s.wait_for("asker ready");
+    s.wait_for("PROJECTS");
+
+    s.send(&command("t.ask"));
+    s.wait_for("Tabs or spaces?");
+    // Away, so the question is one you cannot see. This is the whole case: on screen it is a panel
+    // over the composer and nothing needs saying twice.
+    s.send(&command("t.switch"));
+    s.wait_for("conversation is asking");
+
+    let marked = |s: &Session| {
+        s.sidebar_now().iter().filter(|l| l.trim_start().starts_with("? ")).count()
+    };
+    assert!(
+        s.pump(|s| marked(s) == 1),
+        "one row says a question is waiting on it\n{:?}",
+        s.sidebar_now()
+    );
+    // And in the colour the palette keeps for waiting on something outside the program — the same
+    // one the footer's `Question.Waiting` links to. A glyph nobody can pick out of a column of
+    // thirty is a glyph that is not there.
+    let buf = s.buffer_named("[sidebar]").expect("sidebar buffer");
+    assert!(
+        s.groups_of(buf).iter().flatten().any(|g| g == "Status.Pending"),
+        "the row is coloured, not only marked\n{:?}",
+        s.groups_of(buf)
+    );
+
+    // Answering is what takes it off. Nothing to dismiss, and nothing left behind on a row that is
+    // not waiting on anybody any more.
+    //
+    // Counted rather than waited for: the question has already been on screen once, so anything
+    // scanning everything ever drawn is satisfied before the panel has come back — and the key
+    // would land in the composer of the conversation being switched to.
+    let drawn = |s: &Session| s.texts().iter().filter(|l| l.contains("Tabs or spaces?")).count();
+    let quiet = drawn(&s);
+    s.send(&command("t.switch"));
+    assert!(
+        s.pump(move |x| drawn(x) > quiet + 1),
+        "the question is in front of you again\n{}",
+        s.transcript()
+    );
+    s.key("2");
+    s.wait_for(r#""answers":["Spaces"]"#);
+    assert!(
+        s.pump(|s| marked(s) == 0),
+        "and the mark goes with the answer\n{:?}",
+        s.sidebar_now()
+    );
+}
+
+/// The row under the cursor says all of a title the column had to cut.
+///
+/// A conversation's title is the only thing telling two of them in one project apart, and a
+/// generated title is a sentence rather than a word — so a 34-column panel cuts it at about the
+/// point where it was going to say which of them this is. Arriving on the row is what asks for the
+/// rest; leaving it folds the row back, so the column is still something you read down.
+#[test]
+fn the_sidebar_row_under_the_cursor_says_all_of_a_title_it_had_to_cut() {
+    let sb = Sandbox::new("unfold");
+    let mut s = sb.start();
+    s.wait_for("PROJECTS");
+
+    let title = "a conversation whose title is longer than the panel it has to fit inside";
+    for c in title.chars() {
+        s.key(&c.to_string());
+    }
+    s.enter();
+    s.wait_for("longer than the panel");
+
+    // Cut, first of all — otherwise this test would pass on a panel that never had the problem.
+    assert!(
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains('…'))),
+        "the title does not fit the column\n{:?}",
+        s.sidebar_now()
+    );
+    // And the tail of it is nowhere, because nothing has the cursor on it yet.
+    assert!(
+        !s.sidebar_now().iter().any(|l| l.contains("has to fit inside")),
+        "a row nobody is on stays one row\n{:?}",
+        s.sidebar_now()
+    );
+
+    // Onto the conversation, which is where the cursor already is: the panel keeps it on the
+    // conversation you are in, which is the whole point of anchoring it to a value.
+    s.enter_panel();
+    assert!(
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("has to fit inside"))),
+        "the row under the cursor says the rest of itself\n{:?}",
+        s.sidebar_now()
+    );
+
+    // Up onto the project, and it folds away again.
+    s.key("k");
+    assert!(
+        s.pump(|s| !s.sidebar_now().iter().any(|l| l.contains("has to fit inside"))),
+        "and folds back when the cursor leaves\n{:?}",
+        s.sidebar_now()
+    );
 }

--- a/crates/neosh/tests/questions.rs
+++ b/crates/neosh/tests/questions.rs
@@ -125,6 +125,28 @@ export async function activate({ neosh }: PluginContext) {
     ]);
     neosh.notify(`answered: ${answers === null ? "nothing" : JSON.stringify(answers)}`);
   });
+  // One question whose descriptions are longer than any column can hold, for the panel's rule that
+  // the row under the cursor says all of itself.
+  await neosh.cmd.register("t.ask.long", async () => {
+    const answers = await neosh.ask([
+      {
+        question: "Which database should this use?",
+        header: "Database",
+        multi_select: false,
+        options: [
+          {
+            label: "Postgres",
+            description: "the primary write database, the one everything else already points at and the one a fixture suite must never be aimed anywhere-near",
+          },
+          {
+            label: "SQLite",
+            description: "one file and no server, which stops being a simplification the moment a second process wants to write to it concurrently-somehow",
+          },
+        ],
+      },
+    ]);
+    neosh.notify(`answered: ${answers === null ? "nothing" : JSON.stringify(answers)}`);
+  });
   // Toggles: to the other conversation if there is one, and to a new one if there is not. Enough
   // for a test to move the screen off a question and back onto it.
   await neosh.cmd.register("t.switch", async () => {
@@ -510,4 +532,95 @@ fn dismissing_leaves_what_you_had_typed_where_you_typed_it() {
         "what was typed is still in the composer\n{}",
         s.transcript()
     );
+}
+
+/// The panel, with one question on it, raised by `command`.
+fn open_with(name: &str, command: &str, question: &str) -> Session {
+    let sb = Sandbox::new(name);
+    sb.install_asker(ASKER);
+    let mut s = sb.start();
+    s.wait_for("asker ready");
+    s.command(command);
+    s.wait_for(question);
+    std::mem::forget(sb);
+    s
+}
+
+/// The row under the cursor says all of itself, and the rows either side of it do not.
+///
+/// A description is the *only* thing that says what taking an option would mean, and it is the
+/// first thing a two-column row inside a bordered float runs out of room for. Clipped, four options
+/// are four sentences that stop at the same word and the answer is a guess — which is the failure
+/// this panel exists to prevent, arrived at from the other direction.
+#[test]
+fn the_option_under_the_cursor_says_all_of_itself() {
+    let mut s = open_with("expand", "t.ask.long", "Which database should this use?");
+
+    // The cursor starts on the first option, so the end of its description is on screen — which it
+    // can only be by having been continued onto another line.
+    assert!(
+        s.pump(|s| s.saw("anywhere-near")),
+        "the whole description of the option under the cursor is drawn\n{}",
+        s.transcript()
+    );
+    // And the one below it is still one row. Asserted before moving, because `saw` scans everything
+    // the session has ever drawn and cannot tell a row that folded back from one never unfolded.
+    assert!(
+        !s.saw("concurrently-somehow"),
+        "an option the cursor is not on stays a row\n{}",
+        s.transcript()
+    );
+
+    // Moving swaps which of them is spelled out.
+    s.special("down");
+    s.wait_for("concurrently-somehow");
+}
+
+/// There is a row for the answer nobody listed, and it is a row rather than a rumour.
+///
+/// Typing has always been how you answer a question none of the options answer, and for as long as
+/// the only thing that said so was one phrase in a dim strip at the foot, it was a capability
+/// nobody had: nothing on the panel looked like a field, so four options read as four options and a
+/// dead end.
+#[test]
+fn the_row_at_the_foot_takes_an_answer_nobody_listed() {
+    let mut s = open_with("other", "t.ask.one", "Tabs or spaces?");
+    assert!(s.saw("Other"), "the row is on the panel\n{}", s.transcript());
+    assert!(
+        s.saw("type an answer of your own"),
+        "and it says what it is for\n{}",
+        s.transcript()
+    );
+
+    // `0` is the digit the options deliberately do not use: on a numbered list it already reads as
+    // *none of them*, which is what this row is.
+    s.key("0");
+    s.wait_for("send this answer");
+
+    for c in "two spaces".chars() {
+        s.key(&c.to_string());
+    }
+    s.special("enter");
+    s.wait_for(r#""answers":["two spaces"]"#);
+    assert!(
+        s.saw(r#""custom":true"#),
+        "an answer of your own is marked as one\n{}",
+        s.transcript()
+    );
+}
+
+/// Backspacing off the front of an empty field puts you back among the options.
+///
+/// The one key people already reach for, and the reason the field can be entered without it being a
+/// trap: a panel you can get into and not out of is worse than one with no field at all.
+#[test]
+fn backspacing_off_an_empty_answer_goes_back_to_the_options() {
+    let mut s = open_with("unwrite", "t.ask.one", "Tabs or spaces?");
+    s.key("0");
+    s.wait_for("send this answer");
+    s.special("backspace");
+    // The shortcuts come back, which is the panel saying a digit is a digit again.
+    s.wait_for("1-2 pick");
+    s.key("1");
+    s.wait_for(r#""answers":["Tabs"]"#);
 }

--- a/crates/neosh/tests/reading.rs
+++ b/crates/neosh/tests/reading.rs
@@ -822,8 +822,9 @@ fn switching_conversation_puts_the_transcript_back_at_the_end() {
     let sb = Sandbox::new("switchscroll");
     let mut s = sb.start();
     s.answered_and_reading();
+    s.chat_viewport(100, 6);
     s.to_top();
-    assert!(s.pump(|s| s.chat_scrolls().last() == Some(&0)), "at the top");
+    assert!(s.pump(|s| s.chat_scrolls().last() == Some(&Some(0))), "at the top");
 
     // Somewhere that is not the end, and not the beginning either.
     s.ch("j");
@@ -831,8 +832,36 @@ fn switching_conversation_puts_the_transcript_back_at_the_end() {
     let before = s.chat_scrolls().len();
 
     s.run_command("session.new", move |s| {
-        s.chat_scrolls().len() > before && s.chat_scrolls().last() == Some(&0)
+        s.chat_scrolls().len() > before && s.chat_scrolls().last() == Some(&None)
     });
+}
+
+/// Reading upwards ends at the top of the transcript, and not at the bottom of it.
+///
+/// Following the newest was encoded as row zero, so the first row of a conversation was the one
+/// place in it nothing could ask for: `^U` up to the top asked for `0`, which was read as "follow
+/// the tail", and the window drew the last screenful instead — cursor off screen, and nothing on
+/// the way there to say what had happened. The two are separate states now, and only one of them
+/// is a row.
+#[test]
+fn paging_up_to_the_top_stays_at_the_top() {
+    let sb = Sandbox::new("readtotop");
+    let mut s = sb.start();
+    s.answered_and_reading();
+    s.chat_viewport(100, 6);
+
+    // Half a screen at a time, the way `^U` does it, until the cursor can go no further up.
+    for _ in 0..40 {
+        s.press(json!({"kind": "char", "c": "u"}), &["ctrl"]);
+    }
+    // Pumped on the scroll rather than on the cursor: the two are one batch and the cursor moves
+    // first, so stopping at it answers from the events read *before* the window was told anything.
+    assert!(
+        s.pump(|s| s.chat_scrolls().last() == Some(&Some(0))),
+        "the window was told to draw from the first row, not put back at the end: {:?}",
+        s.chat_scrolls()
+    );
+    assert_eq!(s.chat_cursor(), Some(0), "and the cursor is on it");
 }
 
 /// And it takes the reader out with it.
@@ -907,13 +936,32 @@ impl Session {
     }
 
     /// Every row the transcript window has been told to start drawing at, in order.
-    fn chat_scrolls(&self) -> Vec<u64> {
+    ///
+    /// `None` is unscrolled — the frontend's own answer, which for a transcript is its last
+    /// screenful. A row of `Some(0)` is the top and is a different place, which is the whole point:
+    /// they shared an encoding, and the first row of a long answer was unreachable.
+    fn chat_scrolls(&self) -> Vec<Option<u64>> {
         let Some(win) = self.chat_win() else { return Vec::new() };
         self.events
             .iter()
             .filter(|e| e["type"] == "scroll_to" && e["win"].as_u64() == Some(win))
-            .filter_map(|e| e["top_line"].as_u64())
+            .map(|e| e["top_line"].as_u64())
             .collect()
+    }
+
+    /// Tell the core how tall the transcript really is.
+    ///
+    /// A stdio frontend has no geometry of its own, so nothing reports this unless a test does —
+    /// and keeping the cursor on screen is the one thing the reader cannot do without it. Left
+    /// unsaid, every motion here scrolls nothing at all and the assertions are about a window that
+    /// was never laid out.
+    fn chat_viewport(&mut self, width: u16, height: u16) {
+        assert!(self.pump(|s| s.chat_win().is_some()), "the transcript window exists");
+        let win = self.chat_win().expect("the transcript window");
+        self.send(
+            &json!({"type": "viewport_changed", "win": win, "width": width, "height": height,
+                    "top_line": 0}),
+        );
     }
 
     /// Run a registered command by name — the way a menu entry, a palette row or another plugin

--- a/docs/adr/0000-index.md
+++ b/docs/adr/0000-index.md
@@ -51,3 +51,5 @@ implementation — and in two cases (0005, 0008) it did not, which is itself rec
 | [0043](0043-a-question-is-not-a-permission.md) | A question is not a permission | Accepted |
 | [0044](0044-what-the-plan-has-left.md) | What the plan has left is not a number you can count | Accepted |
 | [0045](0045-a-card-that-lands-says-so.md) | A card that lands says so | Accepted |
+| [0046](0046-a-worktree-lives-inside-its-project.md) | A worktree lives inside its project | Accepted |
+| [0047](0047-a-panel-that-has-the-keyboard.md) | A panel that has the keyboard | Accepted |

--- a/docs/adr/0039-the-archive-is-a-place-you-go.md
+++ b/docs/adr/0039-the-archive-is-a-place-you-go.md
@@ -70,3 +70,48 @@ changes nothing.
 - **An archive with nothing to reclaim it is still an archive.** 0023's note stands: nothing sweeps
   it, and deleting someone's history on a timer remains the move neither ADR is willing to make.
   What is new is that emptying it by hand is now something you can actually do.
+
+## What was added afterwards: a project outlives the conversations in it
+
+The panel had no list of projects. It had a list of *conversations*, grouped by the directory each
+one named, with pinned directories seeded in so that a favourite with nothing in it still drew a
+row. Everything else about a project was inferred from what was inside it.
+
+Which meant deleting was two things at once. `X` on the last conversation in a directory removed the
+conversation, and then — with nothing left to infer the heading from — removed the directory too.
+You cleared out a month of finished threads in a repository you work in every day and the repository
+left the panel with them: no row, no `n`, nothing to start the next conversation from except `^O`
+and typing the path again. The pinned exception is the tell. Somebody had already hit this, and the
+fix was a special case for favourites rather than the observation that a project is a place you
+work rather than a property of the work in it.
+
+**The list is written down.** `sidebar.projects`, a workspace var, is now the panel's list rather
+than an index into one. A directory joins it by being added, by a conversation being started there,
+or by anybody setting a project var on it, and it leaves it by exactly one route — see below. The
+draw path also writes `sidebar.name` for every project that has a conversation to read a name off,
+because the name comes from the host by way of a conversation and a project with none has nobody to
+ask: without it, emptying a worktree renamed it from `neosh (feat/thing)` to `wt-fe3c0d93` at the
+moment you were least likely to recognise it.
+
+**`X` on a heading removes the project**, and it is the only thing that does. That verb did not
+exist — there was nothing to remove, because the list removed itself — and a list that can only grow
+is the other half of this being a list at all. It is the key that already means *for good* on the
+row below, saying the same thing about the row it is on.
+
+It asks by 0039's rule and not by a rule of its own. An empty project is a row and no files: nothing
+is at stake, `o` puts it back, and a dialog there is the kind you learn to clear without reading.
+With conversations still in it, removing the project is deleting every one of them, so it asks like
+the delete it is — how many, how many of those you would still have found in your list, and that
+`x` archives instead. The conversations go first and the project only goes if all of them did: the
+store refuses to delete the very last conversation in a workspace, and a project removed anyway
+would take a row off the list that still had something in it.
+
+### Consequences
+
+- **A directory you visited once is a row until you say otherwise.** That is the trade: the old
+  behaviour cleaned up after itself and took your projects with it. `X` is the broom.
+- **Removing a var is not an announcement.** The arrangement adds any directory somebody sets a
+  project var on, which is how a plugin can pin something this panel has never seen — so a *removal*
+  had to stop counting, or `forget` would put the project straight back as it cleared it.
+- **Only this panel's vars go.** Another plugin's note about the directory is that plugin's to keep,
+  and a directory it still cares about comes back the next time it says so.

--- a/docs/adr/0043-a-question-is-not-a-permission.md
+++ b/docs/adr/0043-a-question-is-not-a-permission.md
@@ -132,6 +132,31 @@ is not on screen waits, says so in the footer, and opens when you switch to it. 
 takes its unanswered question with it — the driver has already told the agent, and a panel with
 nothing behind it is one whose `↵` writes into a pipe that has moved on.
 
+**Which conversation is asking is a fact about the conversation.** The footer can only ever say
+*how many* — it is one line and it is shared — so on its own it turns "somebody is waiting on you"
+into a hunt through the conversations for the one that is. Worse, the row you are hunting for is the
+one that looks least like it needs you: a conversation blocked on a question still has its turn in
+flight, so `active_turn` is set and every list draws it as thinking, identically to the twenty above
+it that really are.
+
+So the panel writes `question.asking` — the session ids currently waiting — as a **workspace var**,
+and the sidebar reads it. A var rather than this plugin's state for the ordinary reason (ADR 0040):
+it is about the conversations, not about us, and a question panel of your own writes the same key and
+lights up the same rows without either plugin knowing the other exists. Three things follow.
+
+*It outranks working.* Anything drawing a conversation has to check this before `active_turn`, or the
+spinner wins and the mark is never seen — which is the whole bug.
+
+*It moves, and `unread` does not.* `Status.Pending`, the palette's group for waiting on something
+outside the program, which is what the footer's `Question.Waiting` already links to. ADR 0042 argues
+a mark for news must be still, because news does not stop being true if you ignore it; this is the
+other case. A question is a *block* — nothing in that conversation goes on until you answer — and it
+ends the moment you do.
+
+*It is on disk and the queue is not.* `vars.json` is written through, and the asks live in memory, so
+a workspace that stopped with a question on screen would come back claiming one is still open. The
+panel therefore announces once at startup, when the queue is empty, and that write is what clears it.
+
 **Layout is in columns and marks are in bytes**, and confusing the two is not theoretical: the first
 build padded rows with `byteLength`, so `❯` — one column, three bytes — made every row with the
 cursor on it two columns short, and the shortcut column zig-zagged. The screenshot showed it

--- a/docs/adr/0043-a-setting-you-cannot-send.md
+++ b/docs/adr/0043-a-setting-you-cannot-send.md
@@ -36,9 +36,15 @@ So they travel in the message, and the plumbing is generic:
 * A select declares `prompt_injected_values`; **the value id is the word**. Nothing between the
   catalogue and the driver holds a table of magic strings.
 * A boolean declares `prompt_injected_word`, for the switches that are a yes/no rather than a rung.
-  Orchestration is not a point on a depth ladder: you can want a fleet of sub-agents on a shallow
-  turn, and asking for one by moving a slider marked "how hard should it think" is a control that
-  does two things and says one.
+  The mechanism stays; nothing on `claude-cli` uses it any more. `ultracode` shipped as one of these
+  on the reasoning that orchestration is not a point on a depth ladder — you can want a fleet of
+  sub-agents on a shallow turn, and asking for one by moving a slider marked "how hard should it
+  think" is a control that does two things and says one. True of the mechanism, wrong about the
+  choice. Nobody sets a reasoning level and then separately decides how hard the harness should
+  work: they pick one thing off one scale and get on with it, and a switch under the ladder drawn
+  `off / on` is a second question about the same decision. It is a rung now, past the top, beside
+  `ultrathink`. The cost is that the two are mutually exclusive, because one message carries one of
+  these words — "ultracode at max effort" was expressible and almost nobody meant it.
 * `neosh_provider::injection` takes the words out of the selection and puts them in the message.
 
 Three properties fall out of doing it in the agent rather than in a driver:

--- a/docs/adr/0044-what-the-plan-has-left.md
+++ b/docs/adr/0044-what-the-plan-has-left.md
@@ -104,6 +104,41 @@ kept, sampled, broadcast and drawn exactly like a built-in one — gated on havi
 driver that serves the instance, because a figure anybody could spoof is not one to draw as fact next
 to a decision about spending an afternoon.
 
+## A measurement without a name is not information
+
+The strip shipped as three bars, three percentages and three countdowns, and every one of them was
+correct. It was still not readable, for two reasons that are the same reason.
+
+It never said **whose** allowance it was. `QuotaSnapshot::instance` is a configuration key, and the
+strip drew none of it — so on a machine with a Claude plan and a Codex one it was two stacks of
+identical bars with nothing between them, and on a machine with one it answered "how much is left"
+without ever saying *of what*. The account row fixes it with the [`Brand`] the model picker already
+draws: same mark at the same three fidelities, same brand colour, same display name. The point is
+not decoration. It is that the thing you chose in `^P` and the thing being spent here are visibly
+one thing, and nothing had ever said so.
+
+And it never said **which way round** any of it went. A bar that fills as an allowance is spent
+reads as "how much is left" to about half of everyone; a bare `3h` beside a percentage is as easily
+"running for" as "back in". So one row per account is a sentence — `78% left · back in 3h` — about
+the window the vendor marked `active`, with `▸` on the row it belongs to so the sentence never has
+to name it twice. The panel does the same job with a column legend (`limit / used / last 7 days /
+refills`) and two lines saying what a rolling allowance is, because a percentage of something opaque
+is exactly the number people otherwise plan around as though it were money.
+
+Two smaller things follow from the same rule. A label is shortened by giving up its separator, then
+by abbreviating its *base*, and only then by clipping its scope — `Weekly · Opus 5` clipped from the
+right became `Weekly ·…`, which loses the only characters that distinguish a per-model cap from the
+plain weekly one and leaves two rows with the same name and different numbers. And a countdown
+counts in days once there are days: `elapsed` measures a turn, which never runs for a week, so a
+weekly window came back as `resets in 164h 34m` — a number you have to do arithmetic on to find out
+means Tuesday.
+
+The way in is on the heading. `sidebar.section` grew an optional `hint`, drawn dim at the right of
+the title, because a summary with no way out of it is one you read and then have to go and find the
+rest of by guessing — and `^L` pressed from the composer is a different affordance from a row you
+have to focus the sidebar and arrive at. It is on the contribution point rather than special-cased
+for this plugin, so the git panel or anybody else's section can say the same thing.
+
 ## Consequences
 
 - Two numbers now exist that neosh cannot verify and did not compute. Both carry their age, and the

--- a/docs/adr/0047-a-panel-that-has-the-keyboard.md
+++ b/docs/adr/0047-a-panel-that-has-the-keyboard.md
@@ -1,0 +1,77 @@
+# 0047 — A panel that has the keyboard
+
+## What happened
+
+`^E` opens the model's option sheet. Pressing `^N` over it opened a new conversation *behind* it and
+left the sheet on screen. `^T` opened the project panel underneath and moved focus into it, with the
+sheet still drawn on top and still holding the focus stack's opinion about where keys go. `^G`, `^L`,
+`^J`, `^D`, `^O`, `^B` and `^F` all did their own version of the same thing. The model picker leaked
+identically; so did every widget in `plugins/api/src/ui.ts`.
+
+None of this was an oversight in any one panel. It is what the routing rule says: `active_scopes`
+resolves window, then buffer, then kind, then **global**, and global is always on the end.
+
+## Why "bind over the keys you care about" was never going to work
+
+That was the existing answer, and it is written down in `bindWidgetKeys`: a widget claims its
+navigation keys window-scoped, so `<C-n>` means "next" in a picker rather than "new conversation".
+It is correct and it is still there. It solves a different problem.
+
+A widget can enumerate the keys it *wants*. It cannot enumerate the keys it merely does not want to
+happen, because that list is every key the program binds now plus every key it binds next year plus
+every key a plugin the author has never heard of binds at load time. A panel that is on screen for
+two seconds cannot be asked that question.
+
+The question it *can* answer is "does anything else reach me". For a control sheet you are in the
+middle of using, a picker you are filtering, or a confirmation you are answering, the answer is no.
+
+## The decision
+
+`FloatConfig::modal`. While a modal float has focus, `KeymapScope::Global` is not in the scope chain.
+
+Three consequences, and each is load-bearing:
+
+**Nearer scopes still resolve.** Window, buffer and kind bindings are unaffected, which is what keeps
+a modal exactly as extensible as any other panel: a third party binds against the buffer **kind** and
+that binding is nearer than a global one, which is the ordering `KeymapScope` already promised. ADR
+0040's rule survives intact — every key in a modal panel is still an ordinary binding pointed at a
+named command, `F1` still lists it, `init.ts` can still move it.
+
+**A key nothing claimed is swallowed.** `unclaimed` stops at a modal instead of emitting
+`UnhandledKey`. Otherwise the host puts characters into the composer behind the float and reads
+`<Esc>` as "interrupt the turn" — typing into a field you cannot see, which is worse than a key that
+does nothing. A `KeymapCapture` on the modal's own window still receives them, so a filter box inside
+a modal works exactly as before; modality is about what happens *after* the panel has declined a key.
+
+**The escape hatches survive.** `ui.modal_escape_keys` — `<C-q>` and `<C-r>` — resolve globally
+anyway, and are consulted only once the panel's own scopes have declined the key, so a modal that
+binds `<C-r>` for something of its own keeps it. This is what makes the whole thing safe: a panel
+that failed to bind a way out would otherwise be a terminal somebody has to kill, and "the panel is
+buggy" must never be the same event as "the program is gone".
+
+It is an option and not a constant because these are keys, and every key here is the user's. **Absent
+is not empty**: an undeclared option falls back to the built-in pair, because the one thing standing
+between a broken panel and a lost terminal must not be contingent on somebody having remembered to
+declare a default. An explicitly empty list is honoured, because that is a person saying so.
+
+## What is modal, and what deliberately is not
+
+Modal: the `^E` option sheet, and the four float widgets in `@neosh/api/ui` — `picker`, `confirm`,
+`prompt`, `railPicker`. Between them that is the model picker, `^N`, the archive, the palette, every
+confirmation, and anything a plugin builds on the same helpers.
+
+Not modal: hints, hover cards and anything else non-focusable, which never intercepted keys in the
+first place; and the docked panels, which are places you *are* rather than things you are in the
+middle of. `modal` defaults off, so a float that says nothing behaves exactly as it always did.
+
+The question panel is not modal either, and that is the interesting exclusion. A question for a
+conversation you are not looking at waits, the footer says how many are asking, and `^T` is how you
+go and answer it — a modal question panel would take away the key whose whole job is getting to the
+other question. Answering is not the same shape of activity as filtering a list.
+
+## The cost
+
+`^E` no longer toggles itself shut from outside, because the global `^E` does not arrive. So the
+panel binds `<C-e>` to close, the way `^S` leaves reading the transcript. Any modal that borrows a
+global key to open itself now owes the same binding — which is a real obligation, and cheaper than
+the alternative, where the key that opened a panel opens a second one behind it.

--- a/plugins/api/src/generated/ApiCall.ts
+++ b/plugins/api/src/generated/ApiCall.ts
@@ -88,7 +88,7 @@ export type ApiCall =
   | { "call": "win_get_cursor"; win: WindowId }
   | { "call": "win_set_cursor"; win: WindowId; row: number; col: number }
   | { "call": "win_get_viewport"; win: WindowId }
-  | { "call": "win_scroll_to"; win: WindowId; top_line: number }
+  | { "call": "win_scroll_to"; win: WindowId; top_line: number | null }
   | { "call": "win_list" }
   | {
     "call": "win_motion";

--- a/plugins/api/src/generated/FloatConfig.ts
+++ b/plugins/api/src/generated/FloatConfig.ts
@@ -31,4 +31,33 @@ export type FloatConfig = {
    * Whether the float can take focus at all. `false` for passive hints and hover cards.
    */
   focusable: boolean;
+  /**
+   * While this float has focus, global bindings stop resolving.
+   *
+   * # Why this is not "bind over the keys you care about"
+   *
+   * That is what every panel here did, and it only ever worked for the keys the panel itself
+   * used. A widget shadows `<C-n>` because *it* wants `<C-n>` for "next" — so `<C-t>`, `<C-g>`,
+   * `<C-l>` and the rest still fell through to the workspace, and pressing one over an open
+   * picker opened a second panel behind the first and left focus somewhere neither of them
+   * expected. A control that is on screen for two seconds cannot be asked to enumerate every
+   * key the program will ever bind; the question it can answer is "does anything else reach me",
+   * and the answer for a panel you are answering a question with is no.
+   *
+   * Window, buffer and kind scopes still resolve, so a modal is exactly as extensible as any
+   * other panel: a third party binds against its **kind** and that binding is nearer than a
+   * global one, which is the ordering [`KeymapScope`](crate::KeymapScope) already promises.
+   *
+   * # The escape hatches survive
+   *
+   * `ui.modal_escape_keys` — `<C-q>` and `<C-r>` by default — resolve globally anyway. A modal
+   * that failed to bind a way out would otherwise be a terminal you have to kill, and "the
+   * panel is buggy" must never be the same event as "the program is gone". It is an option
+   * rather than a constant because which keys those are is the user's, like every other key
+   * here.
+   *
+   * A key nothing claimed is *swallowed* rather than reported unhandled: a modal that let
+   * characters through to the composer would be typing into a field you cannot see.
+   */
+  modal: boolean;
 };

--- a/plugins/api/src/generated/UiEvent.ts
+++ b/plugins/api/src/generated/UiEvent.ts
@@ -35,7 +35,7 @@ export type UiEvent =
   | { "type": "window_buffer"; win: WindowId; buf: BufferId }
   | { "type": "window_closed"; win: WindowId }
   | { "type": "cursor_moved"; win: WindowId; row: number; col: number }
-  | { "type": "scroll_to"; win: WindowId; top_line: number }
+  | { "type": "scroll_to"; win: WindowId; top_line: number | null }
   | { "type": "highlight_defined"; name: string; def: HighlightDef }
   | { "type": "surface_claimed"; surface: SurfaceId; win: WindowId; rect: Rect }
   | { "type": "surface_cells"; surface: SurfaceId; cells: Array<SurfaceCell> }

--- a/plugins/api/src/index.ts
+++ b/plugins/api/src/index.ts
@@ -352,6 +352,20 @@ export interface FloatOptions {
   title?: string;
   closeOnBlur?: boolean;
   focusable?: boolean;
+  /**
+   * Take the keyboard while this float has focus.
+   *
+   * Global bindings stop resolving: `^N`, `^T`, `^G` and the rest do nothing until it closes,
+   * instead of opening a second panel behind the first. Your own bindings still work — window,
+   * buffer and kind scopes are all nearer than global — and so does anything in
+   * `ui.modal_escape_keys` (`^Q` and `^R` by default), so a panel that forgets to bind a way out
+   * is never a terminal somebody has to kill. A key nothing claimed is swallowed rather than
+   * falling through to the composer.
+   *
+   * For a panel you are meant to answer before doing anything else: a question, a confirmation, a
+   * control sheet. Not for a hint or a hover card.
+   */
+  modal?: boolean;
 }
 
 export interface Neosh {
@@ -493,7 +507,14 @@ export interface WindowApi {
   /** `col` is a UTF-8 byte offset, not a character or display column. */
   cursor(win: WindowId): Promise<{ row: number; col: number }>;
   setCursor(win: WindowId, row: number, col: number): Promise<void>;
-  scrollTo(win: WindowId, topLine: number): Promise<void>;
+  /**
+   * Put a buffer row at the top of a window, or hand the scroll position back.
+   *
+   * `null` is *unscrolled*, which is where a window starts and is not the same place as row `0`:
+   * a window that follows its content — the transcript — shows its last screenful unscrolled and
+   * its first row at `0`. Anything else shows the same thing either way.
+   */
+  scrollTo(win: WindowId, topLine: number | null): Promise<void>;
   /**
    * How big this window actually is, in cells.
    *
@@ -1433,6 +1454,7 @@ function floatConfig(o: FloatOptions = {}): FloatConfig {
     title: o.title ?? null,
     close_on_blur: o.closeOnBlur ?? false,
     focusable: o.focusable ?? true,
+    modal: o.modal ?? false,
   };
 }
 

--- a/plugins/api/src/ui.ts
+++ b/plugins/api/src/ui.ts
@@ -469,8 +469,9 @@ const BLANK_MARKER = "  ";
  * A filterable list in a float. Resolves to the chosen value, or `null` if dismissed.
  *
  * Keys: printable characters filter, `<BS>` deletes, `↑`/`↓` and `<C-p>`/`<C-n>` move, `<CR>`
- * accepts, `<Esc>` dismisses. Everything else falls through to your existing bindings, so `<C-q>`
- * still quits while a picker is open.
+ * accepts, `<Esc>` dismisses. The float is **modal**, so nothing else reaches the workspace while
+ * it is up — `^N` over an open picker used to start a new conversation behind it — bar the keys in
+ * `ui.modal_escape_keys`, which is `<C-q>` and `<C-r>` unless you have said otherwise.
  *
  * Only one picker may be open per plugin at a time; opening a second dismisses the first, because
  * two modal lists competing for the keyboard is never what was meant.
@@ -506,6 +507,13 @@ export async function picker<T>(
     border: "rounded",
     focusable: true,
     closeOnBlur: true,
+    // Modal: nothing global resolves while this is up. Shadowing the keys a widget wants — which
+    // is what `bindWidgetKeys` does and still does — only ever covered the keys it uses; `^T`,
+    // `^G`, `^L` and the rest fell straight through and opened a second panel behind this one,
+    // with focus somewhere neither of them expected. `^Q` and `^R` still work, so a widget that
+    // fails to bind a way out is never a terminal somebody has to kill: see
+    // `ui.modal_escape_keys`.
+    modal: true,
     z: 200,
   });
 
@@ -591,20 +599,65 @@ export async function picker<T>(
     if (opts.title) lines.push(opts.title);
     if (filtering) lines.push(`> ${query}`);
 
-    const window = visible.slice(top, top + height);
-    if (window.length === 0) {
-      lines.push(`  ${opts.placeholder ?? "no matches"}`);
-    }
+    // The width the float was asked for *is* the width of its text: a border is drawn outside it,
+    // which is why `columnWidth` subtracts one from each side before opening a panel as wide as the
+    // dock. Measuring against anything else puts the last visible character on both lines — the
+    // continuation says `/ finds` under a row that already ended in `/`.
+    const inner = Math.max(8, width);
+    let window = visible.slice(top, top + height);
     // One gutter for the whole list, or none at all. Giving it only to the rows that asked for an
     // icon would step every other label one column left, which reads as a list that cannot decide
     // where its left margin is.
     const gutter = window.some((r) => r.item.icon) ? 2 : 0;
     const iconFor = (item: PickerItem<T>) =>
       gutter === 0 ? "" : item.icon ? `${item.icon} ` : "  ";
+    const textOf = (row: typeof window[number], on: boolean) =>
+      `${on ? "❯ " : "  "}${iconFor(row.item)}${row.item.label}${row.item.detail ? `  ${row.item.detail}` : ""}`;
+
+    // The row under the cursor says all of itself. A picker is a list of things you are choosing
+    // between, and two rows whose difference is past the right edge are two rows you cannot choose
+    // between — which is exactly what a long model id, a path, or a description does here. The
+    // rest goes underneath, only while the cursor is on it, so the list is still a list.
+    const on = visible[cursor];
+    /** The cursor row's first line, which is re-broken at a word when the row has to continue. */
+    let firstLine = on ? textOf(on, true) : "";
+    let rest: string[] = [];
+    if (on && columnsOf(firstLine) > inner) {
+      const head = `❯ ${iconFor(on.item)}${on.item.label}`;
+      const detail = on.item.detail ? `  ${on.item.detail}` : "";
+      // Only the detail is re-broken. The label is what the filter matched and what the match
+      // highlight is measured against, so it stays exactly where it was written; a row whose label
+      // alone overflows falls back to continuing from wherever the edge cut it.
+      if (detail !== "" && columnsOf(head) + 8 < inner) {
+        const [take, remainder] = takeWords(detail, inner - columnsOf(head));
+        firstLine = `${head}${take}`;
+        rest = remainder.trim() === "" ? [] : wrapToWidth(remainder.trim(), inner - 4);
+      } else {
+        rest = overflowOf(clipToWidth(firstLine, inner), firstLine, inner - 4);
+      }
+    }
+    // The unfolded row pays for its own continuation out of the list's rows rather than out of the
+    // float's height: the window was sized for `height` lines and growing past it would push the
+    // key strip off the bottom, which is the row that says how to get out.
+    if (rest.length > 0) {
+      const room = Math.max(1, height - rest.length);
+      if (cursor < top) top = cursor;
+      if (cursor >= top + room) top = cursor - room + 1;
+      window = visible.slice(top, top + room);
+    }
+
+    if (window.length === 0) {
+      lines.push(`  ${opts.placeholder ?? "no matches"}`);
+    }
+    /** Which of `lines` each visible row starts on, relative to the first list row. */
+    const lineFor: number[] = [];
+    const firstListLine = lines.length;
     for (const row of window) {
-      const mark = row.index === visible[cursor]?.index ? "❯ " : "  ";
-      const detail = row.item.detail ? `  ${row.item.detail}` : "";
-      lines.push(`${mark}${iconFor(row.item)}${row.item.label}${detail}`);
+      const isCursor = row.index === visible[cursor]?.index;
+      lineFor.push(lines.length - firstListLine);
+      lines.push(isCursor ? firstLine : textOf(row, false));
+      if (!isCursor) continue;
+      for (const line of rest) lines.push(`    ${line}`);
     }
     // Pushed onto the last row rather than floated: the float is sized for it, and a strip that
     // moved up as the list shortened would be a strip you have to look for.
@@ -614,7 +667,10 @@ export async function picker<T>(
     // float sized for exactly `height`, where it was silently clipped — leaving the empty state,
     // the one state where you most want to be told what the keys do, as the only one with no keys
     // on it.
-    const listRows = Math.max(1, window.length);
+    // Lines, not rows: the row under the cursor is more than one of them when it has unfolded, and
+    // counting rows here would leave the strip that many lines low — off the bottom of a float
+    // sized for exactly `height`.
+    const listRows = Math.max(1, lines.length - firstListLine);
     const hintLine = hints === "" ? -1 : lines.length + Math.max(0, height - listRows);
     if (hintLine >= 0) {
       while (lines.length < hintLine) lines.push("");
@@ -634,11 +690,16 @@ export async function picker<T>(
     const listTop = (opts.title ? 1 : 0) + (filtering ? 1 : 0);
     for (let i = 0; i < window.length; i++) {
       const row = window[i]!;
-      const line = listTop + i;
+      const line = listTop + (lineFor[i] ?? i);
       const isCursor = row.index === visible[cursor]?.index;
       const eol = byteLength(lines[line] ?? "");
       if (isCursor) {
         mark(line, 0, { hlGroup: "Picker.Selected", endCol: eol });
+        // The band covers the continuation too, so an unfolded row reads as one row that is
+        // several lines tall rather than as a selected row with loose text under it.
+        for (let k = 1; k <= rest.length; k++) {
+          mark(line + k, 0, { hlGroup: "Picker.Selected", endCol: byteLength(lines[line + k] ?? "") });
+        }
       }
       const icon = iconFor(row.item);
       const marker = byteLength(isCursor ? CURSOR_MARKER : BLANK_MARKER);
@@ -682,7 +743,7 @@ export async function picker<T>(
     // it marks the row instead.
     await neosh.win.setCursor(
       win,
-      filtering ? (opts.title ? 1 : 0) : listTop + (cursor - top),
+      filtering ? (opts.title ? 1 : 0) : listTop + (lineFor[cursor - top] ?? cursor - top),
       filtering ? byteLength(`> ${query}`) : 0,
     );
   };
@@ -930,6 +991,13 @@ export async function confirm(
     border: "rounded",
     focusable: true,
     closeOnBlur: true,
+    // Modal: nothing global resolves while this is up. Shadowing the keys a widget wants — which
+    // is what `bindWidgetKeys` does and still does — only ever covered the keys it uses; `^T`,
+    // `^G`, `^L` and the rest fell straight through and opened a second panel behind this one,
+    // with focus somewhere neither of them expected. `^Q` and `^R` still work, so a widget that
+    // fails to bind a way out is never a terminal somebody has to kill: see
+    // `ui.modal_escape_keys`.
+    modal: true,
     // Above a picker: this is asked *from* one often enough that being drawn under it would make
     // the workspace look wedged.
     z: 260,
@@ -1101,6 +1169,127 @@ function clipTo(text: string, width: number): string {
   return chars.length <= width ? text : `${chars.slice(0, Math.max(1, width - 1)).join("")}…`;
 }
 
+// ---------------------------------------------------------------------------
+// Showing the rest of a row
+// ---------------------------------------------------------------------------
+
+/**
+ * Break `text` into lines of at most `columns` **display columns**, splitting words that are wider
+ * than the column rather than letting them overflow it.
+ *
+ * The difference from {@link wrapText} is the whole reason both exist. That one counts code points
+ * and leaves a long word long, because it feeds a float that is sized with a column to spare and
+ * the frontend clips the overhang. This one feeds a *column of a row* — a description beside a
+ * label, a continuation under a title — where an overhanging word does not get clipped, it pushes
+ * whatever is to its right off the edge and takes the alignment of every row below it with it. A
+ * URL, a path or a `--flag=value` is routinely wider than the column it lands in, so this is the
+ * common case and not the exotic one.
+ *
+ * Measured with {@link width}, which is the op the renderer itself uses — so a CJK label and an
+ * ASCII one wrap at the same visual place.
+ */
+export function wrapToWidth(text: string, columns: number): string[] {
+  const limit = Math.max(1, Math.floor(columns));
+  const out: string[] = [];
+  for (const paragraph of text.split("\n")) {
+    let line = "";
+    for (const word of paragraph.split(/\s+/).filter((w) => w !== "")) {
+      const next = line === "" ? word : `${line} ${word}`;
+      if (width(next) <= limit) {
+        line = next;
+        continue;
+      }
+      if (line !== "") {
+        out.push(line);
+        line = "";
+      }
+      // A word that cannot fit a line of its own is cut across as many as it needs. Cutting is
+      // right here and wrong in prose: this is an identifier, not a sentence, and the alternative
+      // is not a nicer break but a row that is silently wider than its column.
+      let rest = word;
+      while (width(rest) > limit) {
+        const head = clipToWidth(rest, limit);
+        if (head === "") break;
+        out.push(head);
+        rest = rest.slice(head.length);
+      }
+      line = rest;
+    }
+    out.push(line);
+  }
+  return out.length > 0 ? out : [""];
+}
+
+/**
+ * The part of `full` that `shown` did not get to say, as lines of `columns` columns.
+ *
+ * `shown` is the row as it was actually written — clipped, and ending in an ellipsis if it was.
+ * The ellipsis is dropped before comparing, so what comes back starts exactly where the visible
+ * text stopped, and the two read as one sentence broken across a line.
+ *
+ * Empty when nothing was lost, which is the common case and has to cost nothing: a list of short
+ * rows must not grow a blank line under the cursor.
+ */
+export function overflowOf(shown: string, full: string, columns: number): string[] {
+  if (full === "" || columns < 1) return [];
+  // Everything before the ellipsis is what actually reached the screen. What comes *after* it is
+  // decoration that survived the clip — an unread dot, a count, a state glyph pinned to the end of
+  // the row — and it is not part of the text, so it is neither compared against `full` nor said
+  // again underneath.
+  const cut = shown.lastIndexOf("…");
+  const visible = cut >= 0 ? shown.slice(0, cut) : shown;
+  // Nothing was lost. The common case, and it has to cost nothing: a list of short rows must not
+  // grow a blank line under the cursor.
+  if (visible.startsWith(full)) return [];
+  // A `full` that is not a continuation of what is on screen means the caller built the two
+  // differently rather than by clipping one from the other. The whole of it is then the honest
+  // thing to show, because there is no prefix to trust.
+  const rest = full.startsWith(visible) ? full.slice(visible.length) : full;
+  if (rest.trim() === "") return [];
+  return wrapToWidth(rest.replace(/^\s+/, ""), columns);
+}
+
+/**
+ * As much of `text` as fits `columns` **without breaking a word**, and the rest of it.
+ *
+ * What a row's first line needs. {@link overflowOf} continues from wherever the clip landed, which
+ * is right when the clip is somebody else's — the row is already drawn and ends in an ellipsis that
+ * says so. When the row is *ours* to lay out, breaking `work` into `wor` and `k` is a choice, and a
+ * bad one: the eye stops at the ragged edge and the reader spends a beat rejoining a word instead of
+ * reading the sentence.
+ *
+ * A single word wider than the column is cut anyway. There is nothing else to do with it, and the
+ * alternative — a first line left empty — is worse.
+ */
+export function takeWords(text: string, columns: number): [string, string] {
+  const limit = Math.max(1, Math.floor(columns));
+  if (width(text) <= limit) return [text, ""];
+  // Split keeping the separators, so what is left over is the exact remainder of the original
+  // rather than a rejoin of it: two spaces after a full stop stay two spaces.
+  const parts = text.split(/(\s+)/);
+  let head = "";
+  for (const part of parts) {
+    const next = head + part;
+    if (width(next.trimEnd()) > limit) break;
+    head = next;
+  }
+  if (head.trim() === "") head = clipToWidth(text, limit);
+  return [head.trimEnd(), text.slice(head.length)];
+}
+
+/**
+ * {@link width}, under a name nothing shadows.
+ *
+ * `picker` binds `width` to its own float's column count, which is a number — so calling the
+ * measuring function inside it is a type error at best and a silent wrong answer at worst.
+ */
+const columnsOf = width;
+
+/** How many columns of leading space `text` has. */
+function leading(text: string): number {
+  return text.length - text.replace(/^ +/, "").length;
+}
+
 /**
  * Type a directory path, with completion as you go.
  *
@@ -1155,6 +1344,13 @@ export async function prompt(
     border: "rounded",
     focusable: true,
     closeOnBlur: true,
+    // Modal: nothing global resolves while this is up. Shadowing the keys a widget wants — which
+    // is what `bindWidgetKeys` does and still does — only ever covered the keys it uses; `^T`,
+    // `^G`, `^L` and the rest fell straight through and opened a second panel behind this one,
+    // with focus somewhere neither of them expected. `^Q` and `^R` still work, so a widget that
+    // fails to bind a way out is never a terminal somebody has to kill: see
+    // `ui.modal_escape_keys`.
+    modal: true,
     z: 200,
   });
 
@@ -1225,14 +1421,18 @@ export async function prompt(
 /**
  * Route every widget key to the widget's own handler while its window is focused.
  *
- * A raw capture only receives what *no binding claimed*, which is the right default — it is what
- * stops a modal swallowing `<C-q>`. But it also means `<C-n>` never reaches a picker, because
- * `<C-n>` is bound globally to "new conversation": you would be typing a filter and suddenly find
- * yourself in a new conversation with the picker gone.
+ * A raw capture only receives what *no binding claimed*. That used to be the whole story, and it
+ * meant `<C-n>` never reached a picker: `<C-n>` is bound globally to "new conversation", so you
+ * would be typing a filter and suddenly find yourself in a new conversation with the picker gone.
  *
  * Window-scoped bindings outrank global ones and are dropped with the window, so a widget owns its
  * keys for exactly as long as it is on screen and not one keystroke longer. Modes are enumerated
  * because a binding is per mode and a picker can be opened from any of them.
+ *
+ * These floats are also `modal`, which is the other half and the half this could not be: a widget
+ * can name the keys it *wants* and never the ones it merely does not want to happen. Both are
+ * needed — modality stops `<C-t>` opening a panel behind the picker, and these bindings are what
+ * point `<C-n>` at "next" rather than at nothing.
  */
 async function bindWidgetKeys(
   neosh: Neosh,
@@ -1493,6 +1693,36 @@ export function money(usd: number): string {
  */
 export interface ListRow<T = unknown> {
   text: string;
+  /**
+   * The whole of what this row says, when `text` is a clipped version of it.
+   *
+   * A panel is a column of fixed width and a conversation title is not, so rows get cut — and a row
+   * cut at the edge is a row you cannot read, which in a list of conversations means you cannot
+   * tell two of them apart. Set this to the row as it *would* have been written with unlimited
+   * room, and the list shows the rest of it on continuation lines whenever the cursor is on that
+   * row, folding back to one line the moment the cursor leaves.
+   *
+   * The cursor is what asks. Only one row can be under it, so only one row is ever more than a line
+   * tall, and the column stays scannable — which is the thing a list is for and the thing that
+   * wrapping everything all the time takes away.
+   *
+   * Include the same prefix `text` has: the marker, the glyph, the indent. What comes back is the
+   * difference between the two, so `text: "  ▸ some long ti…"` with `full: "  ▸ some long title"`
+   * continues with `tle` and not with the glyph again. Leave out anything the clip *kept* — a
+   * trailing unread dot, a count — since that is already on screen and saying it twice under the
+   * row is how a marker stops meaning anything. Nothing happens without
+   * {@link CursoredListOptions.width}, because nothing here can measure a column it was not told
+   * about.
+   */
+  full?: string;
+  /**
+   * The column continuation lines line up under. Defaults to the row's own indent plus two.
+   *
+   * Set it where the default would be wrong — a row whose text starts with a marker and a glyph
+   * has its *content* several columns in from its indent, and continuations that ignore that read
+   * as a second row rather than as the rest of this one.
+   */
+  indent?: number;
   /** Highlight group for the whole row. Link to one the theme defines. */
   hl?: string;
   /**
@@ -1513,6 +1743,15 @@ export interface CursoredListOptions {
   cursorHl?: string;
   /** Called after every move, with the row landed on. */
   onMove?(index: number): void;
+  /**
+   * How many columns the panel has, asked at render time.
+   *
+   * Asked rather than passed once, because a panel is resized and a width captured at construction
+   * is a width that goes stale on the first drag. Without it {@link ListRow.full} does nothing:
+   * a plugin cannot measure the dock it was given, and guessing is how a continuation line ends up
+   * wrapping one column past the edge for the rest of the session.
+   */
+  width?(): number;
 }
 
 /**
@@ -1612,10 +1851,19 @@ export class CursoredList<T = unknown> {
    */
   async render(opts: { showCursor?: boolean; win?: WindowId } = {}): Promise<void> {
     const cursorHl = this.opts.cursorHl ?? "Sidebar.Selected";
-    const drawn: DrawnRow[] = this.rows.map((row, i) => {
+    const columns = this.opts.width?.() ?? 0;
+    const drawn: DrawnRow[] = [];
+    /** Which buffer line each row starts on. Not the row's index once anything has unfolded. */
+    const lineOf: number[] = [];
+    /** How tall the cursor's row turned out, so scrolling can keep all of it on screen. */
+    let block = 1;
+
+    this.rows.forEach((row, i) => {
+      lineOf[i] = drawn.length;
       const eol = byteLength(row.text);
+      const onCursor = opts.showCursor !== false && i === this.cursor;
       const marks: DrawnMark[] = [];
-      if (opts.showCursor !== false && i === this.cursor && eol > 0) {
+      if (onCursor && eol > 0) {
         marks.push({ col: 0, opts: { hlGroup: cursorHl, endCol: eol, priority: 200 } });
       }
       if (row.hl && eol > 0) {
@@ -1639,7 +1887,23 @@ export class CursoredList<T = unknown> {
           },
         });
       }
-      return { text: row.text, marks };
+      drawn.push({ text: row.text, marks });
+
+      // The rest of a row that did not fit, under the row and only while the cursor is on it.
+      if (!onCursor || row.full === undefined || columns < 1) return;
+      const indent = Math.max(0, Math.min(row.indent ?? leading(row.text) + 2, columns - 8));
+      const rest = overflowOf(row.text, row.full, columns - indent);
+      block = 1 + rest.length;
+      for (const line of rest) {
+        const text = `${" ".repeat(indent)}${line}`;
+        const end = byteLength(text);
+        const cont: DrawnMark[] = [];
+        // The band runs the whole block. A continuation drawn on the terminal background reads as
+        // a separate row that happens to be indented, which is the one thing it must not be.
+        cont.push({ col: 0, opts: { hlGroup: cursorHl, endCol: end, priority: 200 } });
+        if (row.hl) cont.push({ col: 0, opts: { hlGroup: row.hl, endCol: end } });
+        drawn.push({ text, marks: cont });
+      }
     });
 
     // One call, not one per mark. A panel that wrote its text, cleared its namespace and then set
@@ -1648,14 +1912,20 @@ export class CursoredList<T = unknown> {
     // full of running agents was flashing.
     await this.neosh.buf.render(this.buf, this.ns, 0, -1, drawn);
 
-    // Keep the cursor on screen without recentring on every keystroke.
+    // Keep the cursor on screen without recentring on every keystroke. In buffer lines, not row
+    // indices: an unfolded row is several lines tall and the two stopped agreeing the moment one
+    // was — which would scroll to the wrong place by however many rows above it had ever unfolded.
     if (opts.win !== undefined && opts.showCursor !== false) {
       const v = await this.neosh.win.viewport(opts.win).catch(() => null);
       if (v && v.height > 0) {
+        const at = lineOf[this.cursor] ?? this.cursor;
+        // The whole of the row, not only the line it starts on: scrolling until the *first* line
+        // is visible leaves the continuation you unfolded it for below the bottom edge.
+        const end = at + Math.min(block, v.height) - 1;
         const top = v.top_line;
-        if (this.cursor < top) await this.neosh.win.scrollTo(opts.win, this.cursor);
-        else if (this.cursor >= top + v.height) {
-          await this.neosh.win.scrollTo(opts.win, this.cursor - v.height + 1);
+        if (at < top) await this.neosh.win.scrollTo(opts.win, at);
+        else if (end >= top + v.height) {
+          await this.neosh.win.scrollTo(opts.win, end - v.height + 1);
         }
       }
     }
@@ -1794,6 +2064,13 @@ export async function railPicker<G, T>(
     border: "rounded",
     focusable: true,
     closeOnBlur: true,
+    // Modal: nothing global resolves while this is up. Shadowing the keys a widget wants — which
+    // is what `bindWidgetKeys` does and still does — only ever covered the keys it uses; `^T`,
+    // `^G`, `^L` and the rest fell straight through and opened a second panel behind this one,
+    // with focus somewhere neither of them expected. `^Q` and `^R` still work, so a widget that
+    // fails to bind a way out is never a terminal somebody has to kill: see
+    // `ui.modal_escape_keys`.
+    modal: true,
     z: 200,
   });
 
@@ -1934,13 +2211,26 @@ export async function railPicker<G, T>(
     return { text, marks };
   };
 
-  const paneCell = (row: PaneRow | undefined, on: boolean): { text: string; marks: Mark[] } => {
+  /**
+   * One row of the list, and — when the cursor is on it — the rest of what it had to say.
+   *
+   * `more` is what makes the three columns bearable. A model row is a name, a rung and a sentence
+   * about it inside 45% of half a float, so the sentence is the first thing cut and the sentence is
+   * the whole reason a catalogue of forty models is choosable at all. It goes under the row rather
+   * than beside it, because the columns are what let you read *down* the list and widening one for
+   * the row you are on would move the other two every time you pressed a key.
+   */
+  const paneCell = (
+    row: PaneRow | undefined,
+    on: boolean,
+  ): { text: string; marks: Mark[]; more: string[] } => {
     const marks: Mark[] = [];
-    if (!row) return { text: "", marks };
+    const more: string[] = [];
+    if (!row) return { text: "", marks, more };
     if (row.kind === "section") {
       const text = `   ${open.has(row.name) || query !== "" ? "▾" : "▸"} ${row.count} ${row.name}`;
       marks.push({ from: 0, to: byteLength(text), hl: on ? "Picker.Selected" : "Comment" });
-      return { text, marks };
+      return { text, marks, more };
     }
     const { item } = row;
     const badge = item.badge?.text ?? "";
@@ -1950,10 +2240,18 @@ export async function railPicker<G, T>(
     const badgeWidth = badge === "" ? 0 : 10;
     const labelWidth = Math.max(10, Math.floor((paneWidth - 3 - badgeWidth) * 0.45));
     const head = on ? " ❯ " : "   ";
-    const label = padToWidth(clipToWidth(item.label, labelWidth), labelWidth);
-    const badgeCell = badgeWidth === 0 ? "" : padToWidth(clipToWidth(badge, badgeWidth), badgeWidth);
     const room = paneWidth - width(head) - labelWidth - badgeWidth;
-    const text = `${head}${label}${badgeCell}${clipToWidth(detail, Math.max(0, room))}`;
+    // On the cursor's row the columns are broken at words and continued underneath; everywhere else
+    // they are clipped, because a list of forty models is read by running an eye down it.
+    const [labelHead, labelRest] = on
+      ? takeWords(item.label, labelWidth)
+      : [clipToWidth(item.label, labelWidth), ""];
+    const [detailHead, detailRest] = on
+      ? takeWords(detail, Math.max(0, room))
+      : [clipToWidth(detail, Math.max(0, room)), ""];
+    const label = padToWidth(labelHead, labelWidth);
+    const badgeCell = badgeWidth === 0 ? "" : padToWidth(clipToWidth(badge, badgeWidth), badgeWidth);
+    const text = `${head}${label}${badgeCell}${detailHead}`;
 
     const labelAt = byteLength(head);
     const offsets = byteOffsets(item.label);
@@ -1967,13 +2265,30 @@ export async function railPicker<G, T>(
       const at = labelAt + byteLength(label);
       marks.push({ from: at, to: at + byteLength(badgeCell), hl: item.badge?.hl ?? "Comment" });
     }
-    if (detail !== "") {
+    if (detailHead !== "") {
       const at = labelAt + byteLength(label) + byteLength(badgeCell);
       marks.push({ from: at, to: byteLength(text), hl: "Picker.Detail" });
     }
     if (item.disabled) marks.push({ from: 0, to: byteLength(text), hl: "Comment" });
     if (on) marks.push({ from: 0, to: byteLength(text), hl: "Picker.Selected", priority: 1 });
-    return { text, marks };
+
+    if (on) {
+      // The name first, if the name itself did not fit — an id is what you are choosing by, and
+      // half of one is not a thing you can choose by.
+      const nameCol = width(head);
+      if (labelRest.trim() !== "") {
+        for (const line of wrapToWidth(labelRest.trim(), Math.max(8, paneWidth - nameCol - 2))) {
+          more.push(`${" ".repeat(nameCol)}${line}`);
+        }
+      }
+      const detailCol = nameCol + labelWidth + badgeWidth;
+      if (detailRest.trim() !== "") {
+        for (const line of wrapToWidth(detailRest.trim(), Math.max(8, paneWidth - detailCol - 1))) {
+          more.push(`${" ".repeat(detailCol)}${line}`);
+        }
+      }
+    }
+    return { text, marks, more };
   };
 
   interface Mark {
@@ -1988,8 +2303,13 @@ export async function railPicker<G, T>(
     // from under the provider you are looking at.
     if (railAt < railTop) railTop = railAt;
     if (railAt >= railTop + height) railTop = railAt - height + 1;
+    // The unfolded row is paid for out of the list rather than out of the float: growing the float
+    // instead would move the key strip under the reader's eyes on every keystroke, and the strip
+    // is the row that says how to get out.
+    const unfolded = focus === "pane" ? paneCell(rows[cursor], true).more.length : 0;
+    const room = Math.max(1, height - unfolded);
     if (cursor < paneTop) paneTop = cursor;
-    if (cursor >= paneTop + height) paneTop = cursor - height + 1;
+    if (cursor >= paneTop + room) paneTop = cursor - room + 1;
 
     const lines: string[] = [];
     const marks: { line: number; mark: Mark }[] = [];
@@ -2017,11 +2337,32 @@ export async function railPicker<G, T>(
     const empty = rows.length === 0
       ? `   ${query === "" ? (opts.placeholder ?? "nothing here") : "no matches"}`
       : null;
+
+    // The two columns are filled independently and then zipped, because they no longer advance
+    // together: the pane's cursor row is several lines tall when it has unfolded, and the rail
+    // beside it must keep listing providers one per line rather than skipping the ones the
+    // unfolded row happened to sit across.
+    const paneLines: { text: string; marks: Mark[] }[] = [];
+    if (empty !== null) {
+      paneLines.push({ text: empty, marks: [{ from: 0, to: byteLength(empty), hl: "Comment" }] });
+    } else {
+      for (let i = paneTop; i < rows.length && paneLines.length < height; i++) {
+        const on = focus === "pane" && i === cursor;
+        const cell = paneCell(rows[i], on);
+        paneLines.push({ text: cell.text, marks: cell.marks });
+        if (!on) continue;
+        for (const text of cell.more) {
+          paneLines.push({
+            text,
+            marks: [{ from: 0, to: byteLength(text), hl: "Picker.Selected", priority: 1 }],
+          });
+        }
+      }
+    }
+
     for (let i = 0; i < height; i++) {
       const left = railCell(railRows[railTop + i], focus === "rail" && railTop + i === railAt);
-      const right = empty !== null && i === 0
-        ? { text: empty, marks: [{ from: 0, to: byteLength(empty), hl: "Comment" }] }
-        : paneCell(rows[paneTop + i], focus === "pane" && paneTop + i === cursor);
+      const right = paneLines[i] ?? { text: "", marks: [] as Mark[] };
       const line = lines.length;
       lines.push(`${left.text}${RULE_V}${right.text}`);
       for (const m of left.marks) marks.push({ line, mark: m });

--- a/plugins/builtin/model/options.ts
+++ b/plugins/builtin/model/options.ts
@@ -32,6 +32,7 @@
 
 import type {
   Disposable,
+  FloatOptions,
   ModelEntry,
   ModelSelection,
   Neosh,
@@ -75,6 +76,10 @@ interface Sheet {
   title: string;
   /** Inside the border. What the description line has to fit in. */
   inner: number;
+  /** What the float was opened with, so `configure` can change one field without losing the rest. */
+  config: FloatOptions;
+  /** Whether anything spoken is in effect, so the border is only redone when the answer changes. */
+  beyond: boolean;
   close(): Promise<void>;
 }
 
@@ -168,10 +173,16 @@ function step(at: number, of: number): string {
  * past the top of it does not compress: five rungs stay five rungs, and the word on the end is
  * drawn as the thing off the scale that it is.
  */
-function groupFor(row: Row, at: number, live: boolean): string {
+function groupFor(row: Row, at: number, live: boolean, focused: boolean): string {
   if (!live) return "Option.Unset";
   const choice = row.choices[at]!;
   if (choice.spoken) return "Option.Beyond";
+  // The row the keys are on says so, and says it where you are looking: at the value they would
+  // move. A ladder with one rung lit reads identically whether or not `←→` do anything to it —
+  // which is how a live control came to look like a summary, and why `↵` on it felt like a key
+  // that does nothing. The ramp is still on every other row, where it is a statement about the
+  // setting rather than about the cursor.
+  if (focused) return "Option.Cursor";
   // A switch is the ends of the scale and nothing in between, said explicitly rather than left to
   // the ramp: a spoken switch has one ordinary value and one word, and a ladder of length one puts
   // its only rung in the middle — so `off` on the switch beside it came out brighter than `off` on
@@ -186,10 +197,24 @@ interface Painted {
   text: string;
   /** `[start, end]` byte offsets, one per choice. */
   spans: [number, number][];
+  /** The two chevrons, same shape, so the caller can colour them by whether they can move. */
+  rails: [[number, number], [number, number]];
 }
 
+/**
+ * A row, with the rail that says it is one.
+ *
+ * The chevrons are the whole reason this function changed. Every row here is a horizontal control
+ * and nothing on screen said so: `↵` was the only key that visibly did anything, it means "done",
+ * and a panel whose one working key closes it is a panel that does nothing. `‹` and `›` are on
+ * every row — the shape is learnt once — and they light on the row the keys act on, dimming at
+ * whichever end you have reached, so where you are on the ladder is readable without counting.
+ */
 function paint(row: Row, labelWidth: number, mark: string, glyph: string): Painted {
   let text = `${mark}${padToWidth(row.label, labelWidth)}  `;
+  const leftStart = byteLength(text);
+  text += "‹";
+  const left: [number, number] = [leftStart, byteLength(text)];
   const spans: [number, number][] = [];
   for (const choice of row.choices) {
     const label = choice.spoken ? `${glyph}${choice.label}` : choice.label;
@@ -197,7 +222,9 @@ function paint(row: Row, labelWidth: number, mark: string, glyph: string): Paint
     text += ` ${label} `;
     spans.push([start, byteLength(text)]);
   }
-  return { text, spans };
+  const rightStart = byteLength(text);
+  text += "›";
+  return { text, spans, rails: [left, [rightStart, byteLength(text)]] };
 }
 
 async function draw(neosh: Neosh, s: Sheet, hints: string): Promise<void> {
@@ -220,6 +247,21 @@ async function draw(neosh: Neosh, s: Sheet, hints: string): Promise<void> {
   const lines = [...painted.map((p) => p.text), "", `  ${said}`, ` ${hints}`];
   await neosh.buf.setLines(s.buf, 0, -1, lines);
 
+  // The whole surface says when the next turn is not an ordinary one. A word in the message is
+  // invisible everywhere else — it never reaches the transcript, and the panel it was chosen in
+  // will have been shut for an hour by the time it matters — so while one is in effect the border
+  // carries the same rainbow the value does. Reconfigured only when the answer *changes*: this is
+  // a round trip, and one per keystroke on a control that already makes several is how a panel
+  // starts lagging behind the keys being pressed. Clock-driven rather than a one-shot, so it is
+  // safe against a redraw that mints every mark again (see ADR 0045).
+  const beyond = s.rows.some((r) => r.choices[r.at]?.spoken);
+  if (beyond !== s.beyond) {
+    s.beyond = beyond;
+    await neosh.float
+      .configure(s.win, { ...s.config, borderHl: beyond ? "Option.Beyond" : undefined })
+      .catch(() => {});
+  }
+
   // Cleared before anything is drawn, every frame. A mark clamps rather than dies when the line
   // under it is replaced, so a row rewritten on every keypress otherwise accumulates them and ends
   // up painted by the narrowest one from three keystrokes ago.
@@ -241,14 +283,27 @@ async function draw(neosh: Neosh, s: Sheet, hints: string): Promise<void> {
       // covering a character and stops, so two of them here would draw one and silently drop the
       // other. `Option.Step*` carries the band as well as the step for exactly that reason.
       await neosh.ns.mark(s.ns, s.buf, i, start, {
-        hlGroup: groupFor(row, c, live),
+        hlGroup: groupFor(row, c, live, i === s.cursor),
+        endCol: end,
+      });
+    }
+    // Lit on the row the keys act on, and only at the end there is somewhere to go. A chevron that
+    // stayed bright at `max` would promise a level that is not there.
+    const ends = [row.at > 0, row.at < row.choices.length - 1];
+    for (let r = 0; r < 2; r++) {
+      const [start, end] = p.rails[r]!;
+      await neosh.ns.mark(s.ns, s.buf, i, start, {
+        hlGroup: i === s.cursor && ends[r] ? "Option.RailLive" : "Option.Rail",
         endCol: end,
       });
     }
   }
   const detail = s.rows.length + 1;
   await neosh.ns.mark(s.ns, s.buf, detail, 0, {
-    hlGroup: "Picker.Detail",
+    // What a spoken level says about itself is said in the register it belongs to. The sentence
+    // under a rainbow value is the one explaining why it is not a level, and drawing it in the
+    // same grey as "how much reasoning the model spends" buries the difference.
+    hlGroup: here?.choices[here.at]?.spoken ? "Option.Beyond" : "Picker.Detail",
     endCol: byteLength(lines[detail] ?? ""),
   });
   await neosh.ns.mark(s.ns, s.buf, detail + 1, 0, {
@@ -283,9 +338,15 @@ async function apply(
   await refresh();
 }
 
-/** The keys, as words, read off what is actually bound rather than written out here. */
+/**
+ * The keys, as words.
+ *
+ * `←→` first, because it is the key that *does* the thing and it used to be third — behind `↵`,
+ * which closes. Read in order, the old line taught you that the way to use this panel was to
+ * dismiss it.
+ */
 function hintsFor(): string {
-  return "↵ done   ←→ change   ↑↓ knob   ⇥ cycle   esc close";
+  return "←→ change   ↑↓ knob   ⇥ cycle   ↵ done   esc close";
 }
 
 export async function installOptions(
@@ -348,16 +409,26 @@ export async function installOptions(
     await apply(neosh, s, refresh);
   };
 
-  // No `^N`/`^P` here, unlike the list widgets. Those two are the most valuable keys in the
-  // program — new conversation, and the model picker — and this panel is on screen for a couple of
-  // seconds at a time. A binding that shadows one of them for the duration is a key that sometimes
-  // does something else, which is the property a keyboard interface can least afford.
+  // No `^N`/`^P` here, and none needed: the float is **modal**, so nothing global resolves while
+  // it is up. This used to be a list of keys deliberately left unbound so that `^N` and `^P` kept
+  // working — which was the wrong half of the problem. Shadowing a key is how a panel keeps the
+  // one key it needs; it does nothing about the dozen it does not, and `^T`, `^G`, `^L` and the
+  // rest all fell through and opened something behind this. A control you are in the middle of
+  // using owns the keyboard until you leave it.
   await verb(`${NS}.next`, ["j", "<Down>"], "Next knob", (s) => move(s, 1));
   await verb(`${NS}.prev`, ["k", "<Up>"], "Previous knob", (s) => move(s, -1));
   await verb(`${NS}.higher`, ["l", "<Right>"], "More", (s) => shift(s, 1, false));
   await verb(`${NS}.lower`, ["h", "<Left>"], "Less", (s) => shift(s, -1, false));
   await verb(`${NS}.cycle`, ["<Tab>", "<Space>"], "The next value along", (s) => shift(s, 1, true));
-  await verb(`${NS}.close`, ["<Esc>", "q", "<C-c>"], "Back to the composer", (s) => s.close());
+  // `^E` closes it too, the way `^S` leaves reading the transcript. A key that opens a surface and
+  // cannot shut it is one you have to remember a second key for — and with the panel modal, the
+  // global `^E` no longer arrives to do it.
+  await verb(
+    `${NS}.close`,
+    ["<Esc>", "q", "<C-c>", "<C-e>"],
+    "Back to the composer",
+    (s) => s.close(),
+  );
   // Nothing left to apply — every change is already in effect — so what this adds is where the
   // acknowledgement *goes*: the panel shuts and the strip it moved to flashes, which is the answer
   // to "fine, but where does that live now". Deliberately not a flash inside the panel: anything
@@ -409,11 +480,15 @@ export async function openOptions(neosh: Neosh): Promise<void> {
   // a page, and a float that spans the terminal reads as something you have to finish reading.
   const labelWidth = Math.max(...rows.map((r) => width(r.label)));
   const widest = Math.max(
-    ...rows.map((r) => r.choices.reduce((n, c) => n + width(c.label) + (c.spoken ? 5 : 2) + 1, 0)),
+    // `+ 2` for the rail: `‹` and `›` are part of the row, and a ladder measured without them is
+    // one whose last chevron falls off the right-hand edge on the widest row.
+    ...rows.map((r) =>
+      r.choices.reduce((n, c) => n + width(c.label) + (c.spoken ? 5 : 2) + 1, 0) + 2
+    ),
     width(hintsFor()),
   );
   const inner = Math.min(96, labelWidth + widest + 8);
-  const win = await neosh.float.open(buf, {
+  const config: FloatOptions = {
     anchor: { kind: "screen" },
     width: { kind: "max", n: inner },
     height: { kind: "fixed", n: rows.length + 3 },
@@ -421,8 +496,15 @@ export async function openOptions(neosh: Neosh): Promise<void> {
     title: ` ${model?.display_name ?? current.model} `,
     focusable: true,
     closeOnBlur: true,
+    // Nothing else reaches the keyboard while this is up. It is a control sheet you are in the
+    // middle of using: `^N` over it opened a new conversation *behind* it, `^T` opened the project
+    // panel and left focus somewhere neither of them expected, and the panel stayed on screen
+    // through both. `^Q` and `^R` still work — see `ui.modal_escape_keys` — so this can never be
+    // a terminal somebody has to kill.
+    modal: true,
     z: 200,
-  });
+  };
+  const win = await neosh.float.open(buf, config);
   await neosh.focus.push(win);
 
   const s: Sheet = {
@@ -434,6 +516,10 @@ export async function openOptions(neosh: Neosh): Promise<void> {
     selection: current,
     title: model?.display_name ?? String(current.model),
     inner,
+    config,
+    // What the border currently says, not what the rows currently are — so the first `draw` finds
+    // them different and lights it, which is what opening straight onto `ultracode` needs.
+    beyond: false,
     close: async () => {
       if (sheet !== s) return;
       sheet = null;

--- a/plugins/builtin/questions/main.ts
+++ b/plugins/builtin/questions/main.ts
@@ -69,8 +69,37 @@ const KIND = "neosh.question";
 /** The most options a digit can reach. Ten would be `0`, which reads as "none of them". */
 const SHORTCUTS = 9;
 
+/**
+ * Which conversations have stopped and are waiting on an answer, in a workspace var.
+ *
+ * Written here because this is the only thing that knows, and shared because it is not about this
+ * plugin: "somebody is waiting on you in *that* conversation" is a fact about the conversation, and
+ * every list of conversations wants it. The footer can only ever say *how many* — it is one line and
+ * it is shared — so without this the answer to "which one" is opening conversations until you find
+ * it, which is the same hunt `SessionInfo::unread` exists to end.
+ *
+ * A conversation that is asking looks exactly like one that is thinking: the turn is still in
+ * flight, blocked on the hook below, so `active_turn` is set and every panel draws a spinner. That
+ * is the bug this fixes, and it is why anything reading this must let it outrank *working*.
+ *
+ * The value is the session ids, newest last. It is on disk with the rest of `vars.json` and the
+ * queue is in memory, so a workspace that stopped with a question on it would come back claiming
+ * one is still open — [`announce`] therefore writes once at activation, when the queue is empty,
+ * and that is what clears it.
+ */
+const VAR_ASKING = "question.asking";
+
 /** How much of the row the label column may take before the description gives up its place. */
 const LABEL_MAX = 28;
+
+/**
+ * The label on the row that takes an answer of your own.
+ *
+ * One word, and a conventional one, because it shares the label column with the options: anything
+ * longer widens that column on every question, including the `Yes`/`No` ones where the whole row is
+ * four characters and the description is what you are reading.
+ */
+const OTHER = "Other";
 
 /**
  * The characters the panel is drawn with, at whatever fidelity the terminal has.
@@ -226,6 +255,28 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
       });
     }
     await elsewhere(neosh, queue, open?.ask ?? null);
+    await announce();
+  };
+
+  /**
+   * Say which conversations are waiting, for anything that draws a list of them.
+   *
+   * `null` to start rather than an empty string, so the first call writes whatever the queue is —
+   * including the empty one, which is how a var left behind by a workspace that stopped mid-question
+   * is cleared. Diffed rather than written every time because a var is a file: `sync` runs on every
+   * conversation switch and most of them change nothing here.
+   */
+  let announced: string | null = null;
+  const announce = async () => {
+    // A question raised by something with no conversation of its own belongs to no row, so it is
+    // the footer's business and not this one's.
+    const ids = [...new Set(queue.map((a) => a.session).filter((s): s is SessionId => Boolean(s)))];
+    const next = ids.join("\n");
+    if (announced === next) return;
+    announced = next;
+    await (ids.length === 0
+      ? neosh.vars.remove({ scope: "global" }, VAR_ASKING)
+      : neosh.vars.set({ scope: "global" }, VAR_ASKING, ids)).catch(() => {});
   };
 
   // First, before anything that awaits. A question arriving while this plugin is still starting up
@@ -309,6 +360,9 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
       void open?.close();
       open = null;
       void neosh.status.clear("question");
+      // And take the mark off the rows. Unloading this plugin unblocks every turn it was holding,
+      // so a conversation still flagged as asking would be one nothing is going to ask again.
+      void neosh.vars.remove({ scope: "global" }, VAR_ASKING).catch(() => {});
     },
   });
 }
@@ -388,6 +442,15 @@ async function draw(neosh: Neosh, ask: Ask, seed: string, done: () => void): Pro
 
   /** What is in the composer, which is the answer nobody listed. */
   let typed = "";
+  /**
+   * Whether the panel is being written into rather than chosen from.
+   *
+   * Explicit rather than `typed !== ""`, and the difference is the row at the foot of the list. You
+   * get here by landing on that row and pressing `↵`, which has to show you an empty field to type
+   * into — derived from the text, the field would not appear until after the first character, so
+   * the key would look like it did nothing and the thing it opened would look like a typo.
+   */
+  let writing = false;
   let closed = false;
 
   const q = () => ask.questions[ask.at]!;
@@ -396,7 +459,7 @@ async function draw(neosh: Neosh, ask: Ask, seed: string, done: () => void): Pro
 
   const render = async () => {
     if (closed) return;
-    const rows = compose(ask, typed, width, glyphs);
+    const rows = compose(ask, typed, writing, width, glyphs);
     await neosh.buf.render(buf, ns, 0, -1, rows.rows).catch(() => {});
     // The caret goes where you are acting: on the row under the cursor, and at the end of what you
     // have typed once you are typing. Without it the terminal's caret parks in the corner of a
@@ -448,6 +511,7 @@ async function draw(neosh: Neosh, ask: Ask, seed: string, done: () => void): Pro
       typed = "";
       await neosh.agent.setDraft("").catch(() => {});
     }
+    writing = false;
 
     // The first one still unanswered, which is not always the next one along: `⇧⇥` goes back to
     // change an earlier answer, and finishing that one should return you to where you were rather
@@ -467,18 +531,56 @@ async function draw(neosh: Neosh, ask: Ask, seed: string, done: () => void): Pro
     await render();
   };
 
+  /**
+   * Move the cursor, over the options *and* the row that lets you write your own.
+   *
+   * `+ 1` because that row is real: it takes the cursor, it wraps round to the first option, and it
+   * is reachable with the same key as everything else. A row you can see and cannot arrive at is
+   * worse than no row.
+   */
   const move = async (delta: number) => {
-    const n = q().options.length;
-    if (n === 0) return;
+    const n = q().options.length + 1;
+    // Moving off the field is how you go back to the options without erasing what you wrote — it
+    // is still there when you come back to the row.
+    if (writing) writing = false;
     ask.cursor = (ask.cursor + delta + n) % n;
     await render();
   };
 
-  /** Take an option, by index. Single-select answers with it; multi-select toggles it. */
+  /** Start writing an answer of your own, with the cursor parked on the row that is the field. */
+  const write = async () => {
+    ask.cursor = q().options.length;
+    writing = true;
+    await render();
+  };
+
+  /**
+   * Stop writing, and go back to choosing.
+   *
+   * What was typed stays typed. Backspacing past the first character is how you change your mind
+   * about writing at all, and one that threw the sentence away would make `⌫` a key you have to be
+   * careful with — on a panel whose entire job is to be answered quickly.
+   */
+  const unwrite = async () => {
+    writing = false;
+    await render();
+  };
+
+  /**
+   * Take an option, by index. Single-select answers with it; multi-select toggles it.
+   *
+   * The index one past the last option is the row that lets you write your own, which is a row and
+   * so answers to every key the rows answer to.
+   */
   const take = async (index: number) => {
     const question = q();
+    if (index === question.options.length) {
+      await write();
+      return;
+    }
     const option = question.options[index];
     if (!option) return;
+    writing = false;
     // Typing wins over the rows while there is anything typed — but reaching for a row is a plain
     // statement that the rows are the answer after all, so it clears what was typed rather than
     // being ignored underneath it.
@@ -512,6 +614,16 @@ async function draw(neosh: Neosh, ask: Ask, seed: string, done: () => void): Pro
   };
 
   await cmd("question.accept", "Answer this question and go on to the next", async () => {
+    if (writing) {
+      if (typed.trim()) {
+        await advance();
+        return;
+      }
+      // An empty field and `↵`. Saying so beats sending nothing: an answer of "" is one the agent
+      // reads as an answer, and a key that silently does nothing is one you press again harder.
+      neosh.notify("type an answer, or ⌫ back to the options", "info");
+      return;
+    }
     if (typed.trim()) {
       await advance();
       return;
@@ -543,6 +655,10 @@ async function draw(neosh: Neosh, ask: Ask, seed: string, done: () => void): Pro
     const picked = draftOf(q()).picked[0];
     ask.cursor = Math.max(0, q().options.findIndex((o) => o.label === picked));
     const was = draftOf(q()).typed;
+    // Back onto a question you answered in your own words puts you back in the field with those
+    // words in it, rather than on a list of options you had already decided against.
+    writing = was !== "";
+    if (writing) ask.cursor = q().options.length;
     if (was !== typed) await retype(was);
     else await render();
   });
@@ -580,7 +696,10 @@ async function draw(neosh: Neosh, ask: Ask, seed: string, done: () => void): Pro
       if (!key || closed) return;
       const code = key.key.code;
       if (code.kind === "backspace") {
-        if (typed) await retype(typed.slice(0, -1));
+        // Back off the end of an empty field and you are choosing again. The one key that leaves
+        // the field, and the one people already reach for.
+        if (!typed) await unwrite();
+        else await retype(typed.slice(0, -1));
         return;
       }
       if (code.kind !== "char" || key.key.mods.alt) return;
@@ -590,9 +709,19 @@ async function draw(neosh: Neosh, ask: Ask, seed: string, done: () => void): Pro
         return;
       }
       const c = code.c;
-      if (!typed && c >= "1" && c <= "9") {
-        await take(Number(c) - 1);
+      // Digits are shortcuts until something is being written, and characters afterwards — which
+      // the panel says out loud by taking the numbers off the rows. `0` is the row at the foot:
+      // on a numbered list it already reads as *none of them*, which is what that row is.
+      if (!writing && c >= "0" && c <= "9") {
+        await take(c === "0" ? q().options.length : Number(c) - 1);
         return;
+      }
+      // The first character of an answer is also the thing that starts one. Typing has always been
+      // how you say something the options do not, and it stays that way — the row at the foot is
+      // how you *find out* that it is, not a gate in front of it.
+      if (!writing) {
+        ask.cursor = q().options.length;
+        writing = true;
       }
       await retype(typed + c);
     }, { desc: "question: a character of your own answer" }),
@@ -615,6 +744,8 @@ async function draw(neosh: Neosh, ask: Ask, seed: string, done: () => void): Pro
   // away: the panel appeared over a field somebody was using, and what they had written is very
   // often the answer — it is the sentence they were about to send.
   typed = seed;
+  writing = seed.trim() !== "";
+  if (writing) ask.cursor = q().options.length;
   await render();
 
   return { ask, close };
@@ -675,11 +806,14 @@ function mark(col: number, end: number, hl: string, priority?: number): DrawnMar
 function compose(
   ask: Ask,
   typed: string,
+  writing: boolean,
   width: number,
   g: Glyphs,
 ): { rows: DrawnRow[]; caret: number; caretCol: number } {
   const question = ask.questions[ask.at]!;
-  const custom = typed.trim().length > 0;
+  const custom = writing;
+  /** The row after the last option: the answer nobody listed. */
+  const customAt = question.options.length;
   const picked = new Set(ask.drafts.get(question.question)?.picked ?? []);
   const rows: DrawnRow[] = [];
   /** The left margin, shared by every row so the panel has one edge rather than several. */
@@ -714,9 +848,12 @@ function compose(
   // One gutter for the whole list — the marker, a space, the box, a space — so the labels line up
   // whether or not the cursor is on the row.
   const gutter = cols(g.cursor) + 1 + cols(on) + 1;
+  // The row at the foot is one of the rows, so its label is one of the labels the column has to
+  // fit. Left out, a question whose options are `Yes` and `No` gives the column three columns and
+  // `Other` arrives clipped — a row offering to take your answer, unable to say so.
   const labelWidth = Math.min(
     LABEL_MAX,
-    question.options.reduce((w, o) => Math.max(w, cols(o.label)), 0),
+    question.options.reduce((w, o) => Math.max(w, cols(o.label)), cols(OTHER)),
   );
   const shortcuts = !custom && question.options.length > 1;
   const badgeWidth = shortcuts ? cols(String(Math.min(SHORTCUTS, question.options.length))) : 0;
@@ -724,61 +861,131 @@ function compose(
   let caret = rows.length;
   let caretCol = 0;
   question.options.forEach((option, i) => {
-    const here = i === ask.cursor;
+    const here = !custom && i === ask.cursor;
     if (here) caret = rows.length;
     const taken = !custom && picked.has(option.label);
     const lead = pad(`${here ? g.cursor : g.blank} ${taken ? on : off} `, gutter);
-    const label = pad(clip(option.label, labelWidth), labelWidth);
     const badge = shortcuts && i < SHORTCUTS ? String(i + 1) : "";
     // What is left for the description, once the row has paid for its gutter, its label column and
     // the shortcut hanging off the right edge.
     const forDetail = room - gutter - labelWidth - 2 - (badgeWidth ? badgeWidth + 2 : 0);
     const detail = option.description.trim();
-    const shown = detail && forDetail >= 8 ? clip(detail, forDetail) : "";
-    const body = shown ? `${label}  ${shown}` : label.trimEnd();
-    // Right-aligned against the panel's own edge, so the shortcuts read as a column rather than as
-    // punctuation trailing each row by a different amount.
+
+    // The row under the cursor says all of itself, on as many lines as that takes, and folds back
+    // to one the moment the cursor leaves.
+    //
+    // This is the whole point of the panel. An option's description is the *only* thing that says
+    // what taking it would mean — "the primary write database" against "the read replica" — and it
+    // is the first thing a two-column row inside a bordered float runs out of room for. Clipped, an
+    // agent asking which of four things you want is a list of four sentences that all stop at the
+    // same word, and the answer is a guess. It goes under the row rather than in a float over it
+    // because there is nowhere else to put it: this panel is already a float over the composer, and
+    // a second one on top would cover the options it is describing.
+    //
+    // Only the cursor's row, and only ever one of them, so the list is still a list you can read
+    // down. The columns hold their places on the continuation lines — a description that reflowed
+    // under the label would read as a new option.
+    const labelLines = here ? wrapCols(option.label, labelWidth) : [clip(option.label, labelWidth)];
+    const detailLines = detail === "" || forDetail < 8
+      ? []
+      : here
+        ? wrapCols(detail, forDetail)
+        : [clip(detail, forDetail)];
+
+    const lines = Math.max(labelLines.length, detailLines.length, 1);
+    for (let n = 0; n < lines; n++) {
+      const label = pad(labelLines[n] ?? "", labelWidth);
+      const shown = detailLines[n] ?? "";
+      const body = shown ? `${label}  ${shown}` : label.trimEnd();
+      // The gutter is paid for on every line, and drawn on the first: the marker and the box are
+      // what the row *is*, and repeating them down the side would read as one option per line.
+      const run = n === 0 ? lead : " ".repeat(gutter);
+      const tail = n === 0 ? badge : "";
+      // Right-aligned against the panel's own edge, so the shortcuts read as a column rather than
+      // as punctuation trailing each row by a different amount.
+      const filler = tail ? " ".repeat(Math.max(1, room - gutter - cols(body) - cols(tail))) : "";
+      const text = `  ${run}${body}${filler}${tail}`;
+
+      const marks: DrawnMark[] = [];
+      // The band goes on first and everything else is patched over it, so a highlighted row keeps
+      // saying what its parts are instead of becoming one flat colour. See the `line_hl_group`
+      // rule. Every line of an unfolded row wears it, or the rest of the description reads as
+      // something that fell out from under the row rather than as part of it.
+      if (here) marks.push({ col: 0, opts: { lineHlGroup: "Question.Cursor" } });
+      const leadAt = LEFT;
+      if (n === 0) {
+        marks.push(mark(leadAt, leadAt + byteLength(lead), taken ? "Question.Taken" : "Question.Box", 100));
+      }
+      const labelAt = leadAt + byteLength(run);
+      if (label.trimEnd() !== "") {
+        marks.push(mark(
+          labelAt,
+          labelAt + byteLength(label.trimEnd()),
+          custom ? "Question.Muted" : "Question.Option",
+          100,
+        ));
+      }
+      if (shown) {
+        const detailAt = labelAt + byteLength(label) + 2;
+        marks.push(mark(detailAt, detailAt + byteLength(shown), "Question.Detail", 100));
+      }
+      if (tail) {
+        marks.push(mark(byteLength(text) - byteLength(tail), byteLength(text), "Question.Shortcut", 100));
+      }
+      rows.push({ text, marks });
+    }
+  });
+
+  // --- the answer nobody listed ----------------------------------------------
+  //
+  // A row, not a note in the key strip. Typing has always been how you answer a question none of
+  // the options answer, and a capability whose entire advertisement is one phrase in a dim strip at
+  // the bottom is a capability nobody has: there is nothing on screen that looks like a field, so
+  // the panel reads as four options and a dead end. It is the last row because that is where "none
+  // of these" belongs, it takes the cursor like any other row, and `↵` on it starts the answer.
+  //
+  // `0` is its shortcut, which is the digit the option rows deliberately do not use: on a numbered
+  // list `0` already reads as *none of them*, and that is exactly what this row is.
+  {
+    const here = custom || ask.cursor === customAt;
+    const lead = pad(`${here ? g.cursor : g.blank} ${g.pen} `, gutter);
+    const badge = shortcuts ? "0" : "";
+    const forDetail = room - gutter - labelWidth - 2 - (badgeWidth ? badgeWidth + 2 : 0);
+    // Once you are writing, the row *is* the field: what is in it is your answer, and it takes the
+    // whole width because a sentence is not a label.
+    const body = custom
+      ? clip(typed, Math.max(8, room - gutter - 2))
+      : (() => {
+        const label = pad(clip(OTHER, labelWidth), labelWidth);
+        const hint = forDetail >= 8 ? clip("type an answer of your own", forDetail) : "";
+        return hint ? `${label}  ${hint}` : label.trimEnd();
+      })();
     const filler = badge ? " ".repeat(Math.max(1, room - gutter - cols(body) - cols(badge))) : "";
     const text = `  ${lead}${body}${filler}${badge}`;
 
-    const marks: DrawnMark[] = [];
-    // The band goes on first and everything else is patched over it, so a highlighted row keeps
-    // saying what its parts are instead of becoming one flat colour. See the `line_hl_group` rule.
-    if (here) marks.push({ col: 0, opts: { lineHlGroup: "Question.Cursor" } });
-    const leadAt = LEFT;
-    marks.push(mark(leadAt, leadAt + byteLength(lead), taken ? "Question.Taken" : "Question.Box", 100));
-    const labelAt = leadAt + byteLength(lead);
-    marks.push(mark(
-      labelAt,
-      labelAt + byteLength(label.trimEnd()),
-      custom ? "Question.Muted" : "Question.Option",
-      100,
-    ));
-    if (shown) {
-      const detailAt = labelAt + byteLength(label) + 2;
-      marks.push(mark(detailAt, detailAt + byteLength(shown), "Question.Detail", 100));
+    const marks: DrawnMark[] = [
+      mark(LEFT, LEFT + byteLength(lead), custom ? "Question.Taken" : "Question.Box", 100),
+    ];
+    if (here) marks.unshift({ col: 0, opts: { lineHlGroup: "Question.Cursor" } });
+    const bodyAt = LEFT + byteLength(lead);
+    if (custom) {
+      marks.push(mark(bodyAt, byteLength(text), "Question.Custom", 100));
+      // The caret sits at the end of what has been typed, which is the one place on this panel
+      // where a terminal cursor means "the keyboard goes here".
+      caret = rows.length;
+      caretCol = bodyAt + byteLength(body);
+    } else {
+      marks.push(mark(bodyAt, bodyAt + byteLength(clip(OTHER, labelWidth)), "Question.Option", 100));
+      const hintAt = bodyAt + byteLength(pad(clip(OTHER, labelWidth), labelWidth)) + 2;
+      if (byteLength(text) > hintAt) {
+        marks.push(mark(hintAt, byteLength(text), "Question.Detail", 100));
+      }
+      if (here) caret = rows.length;
     }
     if (badge) {
       marks.push(mark(byteLength(text) - byteLength(badge), byteLength(text), "Question.Shortcut", 100));
     }
     rows.push({ text, marks });
-  });
-
-  // --- what you typed instead ------------------------------------------------
-  if (custom) {
-    rows.push({ text: "" });
-    const shown = clip(typed.trim(), Math.max(8, room - cols(g.pen) - 1));
-    const text = `  ${g.pen} ${shown}`;
-    caret = rows.length;
-    caretCol = byteLength(text);
-    rows.push({
-      text,
-      marks: [
-        { col: 0, opts: { lineHlGroup: "Question.Cursor" } },
-        mark(LEFT, LEFT + byteLength(g.pen), "Question.Taken", 100),
-        mark(LEFT + byteLength(`${g.pen} `), byteLength(text), "Question.Custom", 100),
-      ],
-    });
   }
 
   // --- the keys --------------------------------------------------------------
@@ -807,8 +1014,18 @@ function progress(ask: Ask, g: Glyphs): string {
  */
 function hints(question: UserQuestion, ask: Ask, custom: boolean, room: number): string {
   /** `[what it says, how readily it goes]`, lower going last. */
+  const onCustom = ask.cursor === question.options.length;
   const parts: Array<[string, number]> = custom
-    ? [["\u21b5 send this answer", 0], ["\u232b back to the options", 2], ["esc dismiss", 1]]
+    ? [["\u21b5 send this answer", 0], ["\u232b back to the options", 1], ["esc dismiss", 1]]
+    : onCustom
+    // On the row at the foot, the only thing worth saying is what it does. The keys that move
+    // between rows are the ones you just used to get here.
+    ? [
+      ["\u21b5 write your own answer", 0],
+      ["\u2191\u2193 move", 3],
+      ...(ask.at > 0 ? [["\u21e7\u21e5 back", 5] as [string, number]] : []),
+      ["esc dismiss", 1],
+    ]
     : [
       [question.multi_select ? "\u21e5 tick" : "\u21b5 choose", 0],
       ...(question.multi_select ? [["\u21b5 done", 0] as [string, number]] : []),
@@ -816,7 +1033,7 @@ function hints(question: UserQuestion, ask: Ask, custom: boolean, room: number):
       ...(question.options.length > 1
         ? [[`1-${Math.min(SHORTCUTS, question.options.length)} pick`, 4] as [string, number]]
         : []),
-      ["type your own", 2],
+      ["0 write your own", 2],
       ...(ask.at > 0 ? [["\u21e7\u21e5 back", 5] as [string, number]] : []),
       ["esc dismiss", 1],
     ];
@@ -837,6 +1054,41 @@ function clip(text: string, room: number): string {
   const chars = [...text];
   if (chars.length <= room) return text;
   return `${chars.slice(0, Math.max(1, room - 1)).join("")}…`;
+}
+
+/**
+ * Break `text` onto lines of at most `width`, cutting a word that is wider than the column.
+ *
+ * The difference from [`wrap`] is where the result lands. That one fills the panel, which is as
+ * wide as the conversation, so a long word simply runs to the next line. This one fills a *column*
+ * beside another column — and a word wider than it does not overhang harmlessly, it pushes the
+ * description sideways and takes the alignment of every line below it with it. Option labels are
+ * routinely identifiers, paths or flags, which is to say routinely longer than 28 columns.
+ */
+function wrapCols(text: string, width: number): string[] {
+  const limit = Math.max(1, width);
+  const out: string[] = [];
+  let line = "";
+  for (const word of text.trim().split(/\s+/).filter(Boolean)) {
+    const next = line ? `${line} ${word}` : word;
+    if (cols(next) <= limit) {
+      line = next;
+      continue;
+    }
+    if (line) {
+      out.push(line);
+      line = "";
+    }
+    let rest = word;
+    while (cols(rest) > limit) {
+      const chars = [...rest];
+      out.push(chars.slice(0, limit).join(""));
+      rest = chars.slice(limit).join("");
+    }
+    line = rest;
+  }
+  if (line) out.push(line);
+  return out.length > 0 ? out : [""];
 }
 
 /**

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -101,6 +101,15 @@ const POINT_ACTION = "sidebar.action";
 interface SectionItem {
   /** Drawn as a heading with a rule under it, matching `PROJECTS`. Omit for rows with no heading. */
   title?: string;
+  /**
+   * The way in, drawn dim at the right of the heading: `^L`, `^G`.
+   *
+   * A section here is a summary of something that has a real panel behind it, and a summary with no
+   * way out of it is one you read and then have to go and find the rest of by guessing. The heading
+   * is where it goes because that costs no row and is the first thing the eye lands on — a hint on
+   * the last row is one you have already scrolled past by the time you want it.
+   */
+  hint?: string;
   /** Where it goes relative to the project list. Defaults to `below`. */
   at?: "above" | "below";
   rows?: Array<{
@@ -169,14 +178,55 @@ const VAR_FAVORITE = "sidebar.favorite";
 const VAR_RANK = "sidebar.rank";
 const VAR_FOLDED = "sidebar.folded";
 /**
- * The directories this panel knows about, in workspace scope.
+ * The projects, in workspace scope. This list *is* what the panel shows.
  *
- * An index rather than a second source of truth: a project with no conversation in it has nothing
- * to derive its existence from, so pinning one has to be written down somewhere. Kept current from
- * both ends — every conversation's directory goes in, and so does any directory somebody sets a
- * project var on, which is how a project this panel has never seen becomes a row in it.
+ * It used to be an index — a hint, with the real list derived from the conversations that happened
+ * to live somewhere. That is the bug this replaced: deleting the last conversation in a directory
+ * deleted the directory too, so clearing out a project you had spent a month in removed it from the
+ * panel and there was nothing left to start the next conversation from. A project is a place you
+ * work, not a property of the work in it.
+ *
+ * Kept current from three ends — every conversation's directory goes in, so does any directory
+ * somebody sets a project var on, and so does anything added by hand — and taken out of by exactly
+ * one thing, which is asking for it to go. See [`Arrangement.forget`].
  */
 const VAR_KNOWN = "sidebar.projects";
+/**
+ * What a project is called, remembered for when there is nothing in it to ask.
+ *
+ * The name comes from the host, which reads it off the repository — `neosh (feat/thing)` for a
+ * worktree rather than the directory's own `wt-fe3c0d93` — and it arrives stamped on a conversation.
+ * A project with no conversations left has nobody to ask, and falling back to the basename renames
+ * a worktree you have used for a fortnight into something you do not recognise the moment you empty
+ * it. Written when it is known, read when it is not.
+ */
+const VAR_NAME = "sidebar.name";
+/**
+ * The checkout a directory is a linked worktree of, for when there is nothing in it to ask.
+ *
+ * Which tree belongs to which repository is read off a conversation's `repo_root`, so a worktree
+ * you have emptied has nobody to say it — and without this it stops being a worktree the moment it
+ * stops having conversations, jumps out of the repository it belongs to and lands at the top level
+ * as a project of its own. Which is the thing ADR 0046 is about, arrived at from the other
+ * direction: a tree does not become a project by being idle.
+ */
+const VAR_ROOT = "sidebar.root";
+/**
+ * Which conversations have stopped and are waiting on an answer.
+ *
+ * Written by whatever serves `ask_user` — the bundled `questions` plugin, or yours instead of it —
+ * and read here, which is the whole reason it is a var and not that plugin's private state. Nothing
+ * else in this column can be worked out: a conversation blocked on a question still has a turn in
+ * flight, so `active_turn` is set and the row it draws is the spinner, identical to the twenty above
+ * it that are actually thinking. An answer nobody is going to give looks like work in progress until
+ * you happen to open it.
+ *
+ * So it outranks *working* wherever the two meet below, and it wears `Status.Pending` — the
+ * palette's own group for waiting on something outside the program, which is what the footer's
+ * `Question.Waiting` links to, so the two say the same thing in the same colour without this panel
+ * having to know the other one exists.
+ */
+const VAR_ASKING = "question.asking";
 
 export async function activate({ neosh, subscriptions }: PluginContext) {
   await declareOptions(neosh);
@@ -197,12 +247,22 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
       .map((s) => s.cwd),
   );
 
+  // Read once and then kept current from `vars.onChange`, like the arrangement and for the same
+  // reason: a draw runs on a 100 ms tick while a turn is in flight and must not spend a round trip
+  // per frame asking a question whose answer changes twice an hour.
+  let asking = asked(
+    await neosh.vars.get<string[]>({ scope: "global" }, VAR_ASKING).catch(() => null),
+  );
+
   // The kind is what makes this panel something other plugins can act on: it is the scope their
   // keymaps bind at and the handle `win.ofKind` finds it by. One argument, and the difference
   // between a panel you can extend and one you can only replace.
   const buf = await neosh.buf.create({ name: "[sidebar]", scratch: true, kind: KIND });
   const ns = await neosh.ns.create(NS);
-  const list = new CursoredList<Target>(neosh, buf, ns);
+  // The panel's own width, as of the last frame. The list needs it to unfold the row under the
+  // cursor, and reading the option again per render would be a round trip inside a redraw.
+  let panelWidth = 34;
+  const list = new CursoredList<Target>(neosh, buf, ns, { width: () => panelWidth });
   let win: WindowId | null = null;
   let focused = false;
   let capture: Disposable | null = null;
@@ -231,13 +291,15 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
           neosh.opt.get<boolean>("ui.ascii_only"),
           neosh.opt.get<boolean>("sidebar.hints"),
         ]);
+        panelWidth = width ?? 34;
         const built = await collect(neosh, arrangement, {
-          width: width ?? 34,
+          width: panelWidth,
           ascii: ascii ?? false,
           hints: hints ?? true,
           focused,
           selected: list.value,
           actions: actions(),
+          asking,
           // Filled in by `collect`, which is what reads the swarm.
           remote: new Map(),
           hosts: new Map(),
@@ -324,6 +386,12 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
   subscriptions.push(
     neosh.vars.onChange((e) => {
       if (arrangement.observe(e.scope, e.key, e.value)) void draw();
+      // Somebody started waiting on an answer, or stopped. Deleting the var is how "nobody is
+      // asking" arrives, and it comes through here with `value` unset rather than as an empty list.
+      if (e.scope.scope === "global" && e.key === VAR_ASKING) {
+        asking = asked(e.value);
+        void draw();
+      }
     }),
   );
   // Rows somebody contributed came or went. Redrawing on this is what stops a plugin that loads
@@ -484,7 +552,10 @@ class Arrangement {
     this.cache.set(scope.cwd, entry);
     // A project somebody else has just said something about is a project this panel should be
     // showing. Without this, pinning a directory from another plugin sets a var nothing ever reads.
-    if (!this.known.includes(scope.cwd)) {
+    //
+    // A var being *removed* is not somebody saying something about a project — it is the last thing
+    // `forget` does, and treating it as an announcement would put the project straight back.
+    if (value !== null && value !== undefined && !this.known.includes(scope.cwd)) {
       this.known.push(scope.cwd);
       void this.neosh.vars.set({ scope: "global" }, VAR_KNOWN, this.known);
     }
@@ -507,9 +578,55 @@ class Arrangement {
     await this.neosh.vars.set({ scope: "global" }, VAR_KNOWN, this.known);
   }
 
-  /** Pinned directories. Also the seed for projects with no conversations. */
-  pinned(): string[] {
-    return this.known.filter((cwd) => this.isFavorite(cwd));
+  /** Every project, whether or not there is anything going on in it. The panel's list. */
+  all(): string[] {
+    return [...this.known];
+  }
+
+  /** What this project was called the last time anything knew. `null` when nothing ever did. */
+  name(cwd: string): string | null {
+    const v = this.cache.get(cwd)?.[VAR_NAME];
+    return typeof v === "string" && v !== "" ? v : null;
+  }
+
+  /** The checkout this one is a worktree of, if anything ever said so. */
+  root(cwd: string): string | null {
+    const v = this.cache.get(cwd)?.[VAR_ROOT];
+    return typeof v === "string" && v !== "" && v !== cwd ? v : null;
+  }
+
+  /**
+   * Write down what the host calls a project, for when it is empty.
+   *
+   * Called from the draw path with every project that has a conversation to read a name off, so it
+   * has to be free when nothing has changed — which it is: the cache is checked first and the
+   * common case is a comparison per project per frame.
+   */
+  remember(named: Array<{ cwd: string; name: string; root?: string }>): void {
+    for (const { cwd, name, root } of named) {
+      if (name !== "" && this.name(cwd) !== name) void this.set(cwd, VAR_NAME, name);
+      if (root !== undefined && root !== cwd && this.root(cwd) !== root) {
+        void this.set(cwd, VAR_ROOT, root);
+      }
+    }
+  }
+
+  /**
+   * Take a project out of the list.
+   *
+   * The one thing that removes one, and the reason the list can be trusted to survive its
+   * conversations. Only this panel's own vars go: another plugin's note about the directory is that
+   * plugin's to keep, and a directory it still cares about comes back the next time it says so.
+   */
+  async forget(cwd: string): Promise<void> {
+    this.known = this.known.filter((c) => c !== cwd);
+    this.cache.delete(cwd);
+    await this.neosh.vars.set({ scope: "global" }, VAR_KNOWN, this.known);
+    await Promise.all(
+      [VAR_FAVORITE, VAR_RANK, VAR_FOLDED, VAR_NAME, VAR_ROOT].map((key) =>
+        this.neosh.vars.remove(projectScope(cwd), key).catch(() => {})
+      ),
+    );
   }
 
   isFavorite(cwd: string): boolean {
@@ -717,10 +834,23 @@ async function registerCommands(w: Wiring): Promise<void> {
     await setArchived(neosh, target.id, true);
   });
   // Shifted, because this is the one that cannot be undone.
-  await verb(`${NS}.delete`, "X", "Delete this conversation permanently", async (target) => {
-    if (target?.kind !== "session") return;
-    await deleteSession(neosh, target.id);
-  });
+  //
+  // One key, two rows, and the same sentence: take this off the list for good. On a heading that is
+  // the project — which is the verb that had been missing entirely, and the reason the panel used
+  // to remove a project *for* you the moment you deleted the last thing in it.
+  await verb(
+    `${NS}.delete`,
+    "X",
+    "Delete this conversation, or remove this project",
+    async (target) => {
+      if (target?.kind === "project") {
+        await removeProject(neosh, arrangement, target.cwd);
+        return;
+      }
+      if (target?.kind !== "session") return;
+      await deleteSession(neosh, target.id);
+    },
+  );
   await verb(`${NS}.new`, "n", "New conversation in this project", async (target) => {
     // The same question `^N` asks, about the project you are looking at — which is the whole reason
     // the cursor is there. It used to create one outright, and that was the bug: `n` and `^N` were
@@ -823,6 +953,19 @@ async function registerCommands(w: Wiring): Promise<void> {
         neosh.notify(String(e), "warn");
       }
     }, { desc: "Add a project — start a conversation in another directory" }),
+  );
+  w.subscriptions.push(
+    await neosh.cmd.register("project.remove", async (args) => {
+      // The row under the cursor when there is one, so the palette entry does something useful from
+      // inside the panel and a plugin can still name a directory outright.
+      const cwd = args[0]?.trim() || owningProject(list.value);
+      if (!cwd) {
+        neosh.notify("project.remove needs a directory", "warn");
+        return;
+      }
+      await removeProject(neosh, arrangement, cwd);
+      await w.draw();
+    }, { desc: "Take a project off the list" }),
   );
 
   await neosh.keymap.set("chat", "<C-b>", "sidebar.toggle", { desc: "Toggle the sidebar" });
@@ -1288,6 +1431,72 @@ async function deleteSession(neosh: Neosh, session: string): Promise<boolean> {
     neosh.notify(String(e), "warn");
     return false;
   }
+}
+
+/**
+ * Take a project off the list.
+ *
+ * Empty, this asks nothing: no file moves, the row goes, and `o` puts the directory back in one
+ * keystroke — a dialog for that is the kind you learn to clear without reading. With conversations
+ * still in it, removing the project is deleting every one of them, so it asks as the delete it is
+ * and says how many and where they would otherwise go.
+ *
+ * The conversations go first and the project only goes if they all did. The store refuses to delete
+ * the very last conversation in the workspace — there has to be somewhere for the next message to
+ * land — and a project removed anyway would take a row that still had something in it off the list.
+ */
+async function removeProject(
+  neosh: Neosh,
+  arrangement: Arrangement,
+  cwd: string,
+): Promise<void> {
+  const inside = (await neosh.session.list({ includeArchived: true }).catch(() => [] as SessionInfo[]))
+    .filter((s) => s.cwd === cwd);
+  const name = inside[0]?.project || arrangement.name(cwd) || basename(cwd);
+
+  if (inside.length > 0) {
+    const many = inside.length === 1 ? "conversation" : `${inside.length} conversations`;
+    const ok = await confirmDestructive(neosh, `Remove "${clip(name, 40)}" and its ${many}?`, {
+      yes: "Delete",
+      no: "Keep",
+      detail: [
+        atStake(inside),
+        "`x` on a conversation archives it instead, and an archived one is already out of the way.",
+      ],
+    });
+    if (!ok) return;
+    for (const s of inside) {
+      try {
+        await neosh.session.close(s.id);
+      } catch (e) {
+        neosh.notify(String(e), "warn");
+        return;
+      }
+    }
+  }
+
+  await arrangement.forget(cwd);
+  neosh.notify(`removed ${short(cwd)} — \`o\` adds it back`);
+}
+
+/**
+ * How much is about to go, in a sentence.
+ *
+ * What is at stake is the point of the question, and the number that says it is how many of these
+ * you would still have found in the panel: something you archived a month ago going is a different
+ * size of loss from a conversation you were in this morning.
+ */
+function atStake(inside: SessionInfo[]): string {
+  const archived = inside.filter((s) => s.archived).length;
+  if (inside.length === 1) {
+    return archived === 1
+      ? "It is archived, and it goes from disk with the project."
+      : "It goes from disk with the project.";
+  }
+  if (archived === inside.length) return `All ${inside.length} are archived, and all of them go from disk.`;
+  if (archived === 0) return `All ${inside.length} go from disk.`;
+  const live = inside.length - archived;
+  return `${live} of them ${live === 1 ? "is" : "are"} still in your list, and all ${inside.length} go from disk.`;
 }
 
 /**
@@ -1836,10 +2045,11 @@ async function renameSession(neosh: Neosh, session: string): Promise<void> {
 /**
  * Projects, as two ordered groups: pinned, then the rest.
  *
- * A project is a directory some conversation lives in — there is no registry to keep in sync, and
- * opening a conversation in another checkout is what makes a second project appear. Pinned
- * directories are seeded even with nothing in them, so unpinning is the only way a favourite
- * disappears.
+ * A project is a directory you have worked in — added by hand, or arrived at because a conversation
+ * was started there — and it stays one until you remove it. Every known directory is seeded, empty
+ * or not, which is the whole of the fix for a project vanishing when you cleared out its
+ * conversations: the list is written down (see [`VAR_KNOWN`]) rather than inferred from what
+ * happens to be in it, and `X` on the heading is the only thing that shortens it.
  */
 function group(
   sessions: SessionInfo[],
@@ -1847,20 +2057,25 @@ function group(
   keys: Map<string, string>,
 ): Project[][] {
   const by = new Map<string, SessionInfo[]>();
-  for (const cwd of arrangement.pinned()) by.set(cwd, []);
+  for (const cwd of arrangement.all()) by.set(cwd, []);
   for (const s of sessions) {
     const existing = by.get(s.cwd);
     if (existing) existing.push(s);
     else by.set(s.cwd, [s]);
   }
 
-  // Which checkout each directory is a linked worktree of, learned from its conversations. A
-  // pinned directory with nothing in it has nobody to say, and stays top-level until it does.
+  // Which checkout each directory is a linked worktree of, learned from its conversations — and
+  // from what was written down the last time one of them said so, because a project stays on the
+  // list after its conversations have gone and an emptied worktree is still a worktree.
   const rootOf = new Map<string, string>();
   for (const s of sessions) {
     if (s.repo_root && s.repo_root !== s.cwd && !rootOf.has(s.cwd)) {
       rootOf.set(s.cwd, s.repo_root);
     }
+  }
+  for (const cwd of by.keys()) {
+    const remembered = arrangement.root(cwd);
+    if (remembered && !rootOf.has(cwd)) rootOf.set(cwd, remembered);
   }
 
   // `session.list()` is most-recently-used first, so index in it is recency. Anything you have
@@ -1875,8 +2090,9 @@ function group(
     // What the host decided to call it. For a worktree that is the repository and the branch,
     // rather than whatever the directory happens to be named — a row reading `wt-fe3c0d93`
     // tells you nothing about which checkout it is, and reads as somebody else's directory having
-    // wandered into your workspace.
-    name: list[0]?.project || basename(cwd),
+    // wandered into your workspace. With nothing in it there is nobody to ask, so the last answer
+    // is kept: emptying a project must not also rename it.
+    name: list[0]?.project || arrangement.name(cwd) || basename(cwd),
     favorite: arrangement.isFavorite(cwd),
     sessions: list,
     key: keys.get(cwd) ?? `dir:${basename(cwd)}`,
@@ -1940,10 +2156,24 @@ interface DrawOptions {
   selected: Target | undefined;
   /** The verbs other plugins put on our rows, for the hint strip. */
   actions: ActionItem[];
+  /** Which conversations are waiting on an answer from you. See [`VAR_ASKING`]. */
+  asking: Set<string>;
   /** Conversations on other computers, grouped by the project key they share with ours. */
   remote: Map<string, SwarmAgent[]>;
   /** Which other machines have each project, by key. */
   hosts: Map<string, string[]>;
+}
+
+/**
+ * The waiting set, out of whatever was in the var.
+ *
+ * Checked rather than trusted, like every contribution: this is JSON written by a plugin this one
+ * has never heard of, and a panel that throws on it is a panel a third party can take off the screen
+ * by writing a string where a list goes.
+ */
+function asked(value: unknown): Set<string> {
+  if (!Array.isArray(value)) return new Set();
+  return new Set(value.filter((v): v is string => typeof v === "string"));
 }
 
 async function collect(
@@ -1989,6 +2219,14 @@ async function collect(
   // A directory that turned up in the conversation list and we had not seen before. Noted rather
   // than fetched inline: the draw runs on a tick and must not wait on a round trip per project.
   void arrangement.note(all.map((s) => s.cwd));
+  // And what the host calls it, and which checkout a tree hangs off, so the row still says both
+  // once the last conversation in it has gone.
+  arrangement.remember([
+    ...projects.filter((p) => p.sessions.length > 0),
+    ...projects.flatMap((p) =>
+      p.worktrees.filter((t) => t.sessions.length > 0).map((t) => ({ ...t, root: p.cwd }))
+    ),
+  ]);
 
   // Rows other plugins own. Read every frame rather than cached, because a contribution is replaced
   // in place when its author's data changes and re-reading is one call.
@@ -2083,12 +2321,19 @@ function sectionRows(
 
     rows.push(blank());
     if (typeof c.item.title === "string" && c.item.title !== "") {
-      rows.push(...heading(clip(c.item.title, opts.width - 2), opts.width));
+      const hint = typeof c.item.hint === "string" ? c.item.hint : undefined;
+      rows.push(
+        ...heading(clip(c.item.title, opts.width - 2), opts.width, hint),
+      );
     }
     for (const r of contributed) {
       if (typeof r?.text !== "string") continue;
       rows.push({
         text: `   ${clip(r.text, Math.max(4, opts.width - 6))}`,
+        // A third party's row gets the same treatment ours do: we have no idea how long its text
+        // is, and a plugin's row cut at our column is our bug rather than theirs.
+        full: `   ${r.text}`,
+        indent: 3,
         hl: typeof r.hl === "string" ? r.hl : undefined,
         right: typeof r.right?.text === "string"
           ? { text: `${r.right.text} `, hl: r.right.hl }
@@ -2112,9 +2357,16 @@ function sectionRows(
  * weight and the eye has to parse the words to find the structure — which is exactly the work a
  * layout is supposed to have already done.
  */
-function heading(text: string, width: number): ListRow<Target>[] {
+function heading(text: string, width: number, hint?: string): ListRow<Target>[] {
   return [
-    { text: ` ${text}`, hl: "Sidebar.Heading", inert: true },
+    {
+      text: ` ${text}`,
+      hl: "Sidebar.Heading",
+      // Dim, and on the heading rather than beside the title: it is an answer to "and then what",
+      // which is a question you ask after reading the section, not while finding it.
+      right: hint ? { text: `${hint} `, hl: "Sidebar.Dim" } : undefined,
+      inert: true,
+    },
     { text: "─".repeat(Math.max(1, width)), hl: "Separator", inert: true },
   ];
 }
@@ -2137,11 +2389,16 @@ function projectRow(
   const within = [...p.sessions, ...p.worktrees.flatMap((t) => t.sessions)];
   const busy = within.find((s) => s.active_turn);
   const here = p.sessions.some((s) => s.is_active);
+  // Something in here has stopped and is waiting on an answer. It is still a turn in flight, so
+  // `busy` finds it too — this is what decides which of the two the row says. Over `within` for the
+  // reason the count is: a question asked in a scratch tree of this repository is a question in
+  // this repository, and folding is what hid the row that would otherwise say so.
+  const waiting = within.some((s) => opts.asking.has(s.id));
 
   // The count is the useful thing when a project is folded, and the elapsed time is the useful
   // thing when something inside it is working. Never both — there is one column.
   const right = busy
-    ? { text: `${turnFor(busy, now)} `, hl: "Status.Working" }
+    ? { text: `${turnFor(busy, now)} `, hl: waiting ? "Status.Pending" : "Status.Working" }
     : within.length > 0
       ? { text: `${within.length} `, hl: "Sidebar.Dim" }
       : { text: "" };
@@ -2170,10 +2427,18 @@ function projectRow(
   // It sits after the name rather than in the right-hand column: that column is already spoken for
   // by the elapsed time of whatever is running, and a project can perfectly well have one turn
   // still going and another that finished an hour ago.
-  const unseen = folded ? within.filter((s) => !s.active_turn && s.unread).length : 0;
-  const mark = unseen === 0 ? "" : unseen === 1
-    ? opts.ascii ? " !" : " ●"
-    : opts.ascii ? ` !${unseen}` : ` ●${unseen}`;
+  // A question in there outranks it, and for the same reason it does on the conversation's own row:
+  // one of them is news that will keep, and the other is a turn that has stopped until you answer.
+  // Only one mark, because there is one column and two would be a puzzle rather than a summary.
+  const unseen = folded && !waiting
+    ? within.filter((s) => !s.active_turn && s.unread).length
+    : 0;
+  const mark = folded && waiting
+    ? " ?"
+    : unseen === 0 ? "" : unseen === 1
+      ? opts.ascii ? " !" : " ●"
+      : opts.ascii ? ` !${unseen}` : ` ●${unseen}`;
+  const markHl = folded && waiting ? "Status.Pending" : "Status.Unread";
 
   const name = clip(
     p.name,
@@ -2183,10 +2448,16 @@ function projectRow(
   if (p.favorite) spans.push({ from: 1, to: 1 + byteLength(star), hl: "Sidebar.Favorite" });
   if (mark !== "") {
     const from = byteLength(` ${star} ${arrow} ${name}`);
-    spans.push({ from, to: from + byteLength(mark), hl: "Status.Unread" });
+    spans.push({ from, to: from + byteLength(mark), hl: markHl });
   }
   return {
     text: ` ${star} ${arrow} ${name}${mark}`,
+    // A project's name is a directory name, and directory names are long. Clipped it is the same
+    // eight characters as the three others you have open beside it, which is the panel failing at
+    // the one thing it is for. The unread dot is left off deliberately: it survived the clip and
+    // is already on the row.
+    full: ` ${star} ${arrow} ${p.name}`,
+    indent: 5,
     hl: here ? "Directory" : "Sidebar.Dim",
     spans: spans.length > 0 ? spans : undefined,
     right: elsewhere.length > 0
@@ -2250,6 +2521,8 @@ function remoteRow(r: SwarmAgent, opts: DrawOptions, now: number): ListRow<Targe
     const width = Math.max(8, opts.width - 11 - host.length);
     return {
       text: `     ${glyph} ${clip(r.agent.label, width)}`,
+      full: `     ${glyph} ${r.agent.label}`,
+      indent: 7,
       hl: working ? "Status.Monitoring" : "Sidebar.Remote",
       right: { text: `${host} `, hl: "Sidebar.Remote" },
       value: {
@@ -2268,44 +2541,73 @@ function sessionRow(
   opts: DrawOptions,
   depth = 0,
 ): ListRow<Target> {
+  // The agent has stopped and is waiting on you. First, because it is the only state here that a
+  // turn being in flight does not already describe: the turn *is* in flight — blocked on the
+  // question — so without this the row is a spinner, indistinguishable from one that is thinking,
+  // and the way you find it is by opening conversations until one of them asks you something.
+  const asking = opts.asking.has(s.id);
   // Working is the only state that moves, and only where the work is. An idle row's status is
   // deliberately static: twenty animating rows carry no more information than one and cost twenty
   // times the attention.
-  const working = Boolean(s.active_turn);
+  const working = !asking && Boolean(s.active_turn);
   // Finished while you were somewhere else. The one row in this column that is asking for
   // something, so it is the one row that gets the attention colour — and it does not move, because
   // it is not going to stop being true on its own and a mark that pulses forever is a mark you
   // learn to look past. It goes away by being opened. See ADR 0042.
-  const unread = !working && s.unread;
-  const glyph = working
-    ? s.is_active
-      ? spinnerFrame()
-      : opts.ascii ? "*" : "◍"
-    : unread
-      ? opts.ascii ? "!" : "●"
-      : s.is_active
-        ? opts.ascii ? ">" : "▸"
-        : " ";
-  const right = working ? turnFor(s, now) : s.updated_at > 0 ? ago(now / 1000 - s.updated_at) : "";
+  const unread = !working && !asking && s.unread;
+  const glyph = asking
+    // A question mark, in both alphabets. Every other glyph here has an ASCII understudy because
+    // the Unicode one is prettier; this one is already the character that means what it means, and
+    // a shape people have to learn would be worse in either.
+    ? "?"
+    : working
+      ? s.is_active
+        ? spinnerFrame()
+        : opts.ascii ? "*" : "◍"
+      : unread
+        ? opts.ascii ? "!" : "●"
+        : s.is_active
+          ? opts.ascii ? ">" : "▸"
+          : " ";
+  // The clock, and it keeps running while the question sits there: one asked four minutes ago and
+  // one asked while you were reading this row are not the same news. Off the turn rather than off
+  // `working`, because a question can be raised by a plugin with no turn behind it at all — and
+  // then the honest number is when the conversation last moved, not a turn that never started.
+  const right = s.active_turn
+    ? turnFor(s, now)
+    : s.updated_at > 0 ? ago(now / 1000 - s.updated_at) : "";
   // Two more columns per level: a conversation inside a worktree sits inside the worktree's row
   // the way the worktree sits inside its repository's.
   const pad = "     " + "  ".repeat(depth);
   return {
     text: `${pad}${glyph} ${clip(s.label, Math.max(8, opts.width - 9 - 2 * depth - right.length))}`,
-    hl: working
-      ? s.is_active && pulseBright() ? "Status.Working" : "Status.Monitoring"
-      : unread
-        // The whole row, not only the dot: a single coloured character five columns in is findable
-        // if you already know it is there, which is the one thing you cannot assume about the
-        // conversation you have forgotten you started.
-        ? "Status.Unread"
-        : s.is_active
-          ? "Accent"
-          : undefined,
+    // The title is the only thing telling two conversations in one project apart, and a generated
+    // title is a sentence rather than a word — so the column cuts it at about the point where it
+    // was going to say which of them this is.
+    full: `${pad}${glyph} ${s.label}`,
+    indent: 7 + 2 * depth,
+    hl: asking
+      // The palette's group for waiting on something outside the program — which here is a person,
+      // and the reason it is the one row in this column that moves. `Status.Unread` deliberately
+      // does not: that is news, and news does not stop being true if you ignore it. This is a
+      // *block*, it ends the moment you answer, and until then nothing in the workspace goes on.
+      ? "Status.Pending"
+      : working
+        ? s.is_active && pulseBright() ? "Status.Working" : "Status.Monitoring"
+        : unread
+          // The whole row, not only the dot: a single coloured character five columns in is findable
+          // if you already know it is there, which is the one thing you cannot assume about the
+          // conversation you have forgotten you started.
+          ? "Status.Unread"
+          : s.is_active
+            ? "Accent"
+            : undefined,
     // A trailing space so the age does not sit flush against the panel's edge rule.
     right: {
       text: right === "" ? "" : `${right} `,
-      hl: working ? "Status.Working" : unread ? "Status.Unread" : "Sidebar.Dim",
+      hl: asking
+        ? "Status.Pending"
+        : working ? "Status.Working" : unread ? "Status.Unread" : "Sidebar.Dim",
     },
     value: { kind: "session", id: s.id, cwd: s.cwd },
   };
@@ -2339,7 +2641,9 @@ function hints(opts: DrawOptions): ListRow<Target>[] {
     // verb with a row of its own is the one that can afford to give up its place on them.
     ? ["^T projects  ^N new   ^F archive", "^K palette   ^B hide  F1 keys"]
     : kind === "project"
-      ? ["↵ fold   f ★       JK move", "n new    a archive  ? keys"]
+      // `X` is on the strip because a list you cannot shorten is a list that grows forever, and a
+      // project that outlives its conversations — which is the point of it — has to have a way off.
+      ? ["↵ fold   f ★       JK move", "n new    X remove   ? keys"]
       : kind === "session"
         ? ["↵ open   r rename   x archive", "X delete a archive   ? keys"]
         : kind === "browse"

--- a/plugins/builtin/usage/main.ts
+++ b/plugins/builtin/usage/main.ts
@@ -27,6 +27,8 @@
  */
 
 import type {
+  Brand,
+  CredentialInfo,
   ModelEntry,
   Neosh,
   PluginContext,
@@ -116,6 +118,16 @@ async function installStrip({ neosh, subscriptions }: PluginContext) {
   let drawn = "";
   /** Windows already complained about, keyed by instance and window. Cleared when one resets. */
   const warned = new Set<string>();
+  /**
+   * Who each instance is, for the account row.
+   *
+   * Cached because this runs on a tick and the answer changes when somebody signs in, not several
+   * times a second. Refreshed on the events that can change it rather than polled.
+   */
+  let who: CredentialInfo[] = [];
+  const reload = async () => {
+    who = await neosh.agent.credentials().catch(() => [] as CredentialInfo[]);
+  };
 
   const refresh = async () => {
     const on = (await neosh.opt.get<boolean>("usage.sidebar").catch(() => true)) ?? true;
@@ -126,16 +138,23 @@ async function installStrip({ neosh, subscriptions }: PluginContext) {
       }
       return;
     }
-    const [quotas, ascii, width] = await Promise.all([
+    const [quotas, ascii, nerd, width] = await Promise.all([
       neosh.quota.list().catch(() => [] as QuotaSnapshot[]),
       neosh.opt.get<boolean>("ui.ascii_only").catch(() => false),
+      neosh.opt.get<boolean>("ui.nerd_font").catch(() => false),
       // The column this has to fit in. Read rather than assumed: the sidebar clips a contributed
       // row to its own width and then draws `right` over the top of whatever survived, so a row
       // built to a guessed width does not wrap — it collides, and the countdown lands on the last
       // letter of the label.
       neosh.opt.get<number>("sidebar.width").catch(() => 34),
     ]);
-    const item = section(quotas, ascii ?? false, width ?? 34, Date.now() / 1000);
+    // An account we cannot name yet. Reaching a quota for an instance that is not in the credential
+    // list means the list is stale — a provider registered late, or somebody has just signed in —
+    // and drawing `claude-cli` where `Claude` belongs for the rest of the session is the failure
+    // this avoids. Once per staleness, not once per frame: `who` is replaced before the next one.
+    if (quotas.some((q) => !who.some((c) => c.instance === q.instance))) await reload();
+    const glyphs = { ascii: ascii ?? false, nerd: nerd ?? false };
+    const item = section(quotas, who, glyphs, width ?? 34, Date.now() / 1000);
     // Compared as JSON rather than by identity: this runs on a tick, and re-contributing the same
     // rows makes the sidebar rebuild its whole list — cursor, scroll and all — several times a
     // second, for no change anybody can see.
@@ -149,33 +168,87 @@ async function installStrip({ neosh, subscriptions }: PluginContext) {
     await neosh.ext.contribute("sidebar.section", "plan", item, { priority: -10 });
   };
 
+  await reload();
   await refresh();
   subscriptions.push(neosh.quota.onChange((s) => {
     void refresh();
     void announce(neosh, s, warned);
   }));
   subscriptions.push(neosh.opt.onChange((e) => {
-    if (e.name === "usage.sidebar" || e.name === "ui.ascii_only") void refresh();
+    if (
+      e.name === "usage.sidebar" || e.name === "ui.ascii_only" || e.name === "ui.nerd_font" ||
+      e.name === "sidebar.width"
+    ) void refresh();
   }));
+  // A selection change is the cheap signal that the provider list may have moved — signing in is
+  // what puts a name and a mark on an account that had neither, and it is usually followed by
+  // choosing something on it. `refresh` also reloads on its own when a quota turns up for an
+  // instance it cannot name, so a sign-in nobody selected after is caught within a tick either way.
+  subscriptions.push(neosh.agent.onSelectionChange(() => void reload().then(refresh)));
   // A countdown is the only thing here that moves without anything happening, and it moves once a
   // minute. The tick is already running for the working line; `refresh` bails on an unchanged
   // render, so this costs a string compare.
   subscriptions.push(onTick(() => void refresh()));
 }
 
-/** What the sidebar is handed. `null` when there is nothing to say — no rows rather than a heading
- * over an empty block, because a section that is always there and usually empty is a section people
- * stop looking at. */
-function section(quotas: QuotaSnapshot[], ascii: boolean, width: number, now: number) {
-  const rows: Array<{ text: string; hl?: string; right?: { text: string; hl?: string }; command?: string }> = [];
+/** A contributed sidebar row, in the shape `sidebar.section` takes. */
+interface StripRow {
+  text: string;
+  hl?: string;
+  right?: { text: string; hl?: string };
+  command?: string;
+}
+
+/**
+ * What the sidebar is handed.
+ *
+ * `null` when there is nothing to say — no rows rather than a heading over an empty block, because
+ * a section that is always there and usually empty is a section people stop looking at.
+ *
+ * # Shape
+ *
+ * An account, then its limits, then one sentence. The account row is the part that used to be
+ * missing entirely: three bars and no name is a column that answers "how much is left" without
+ * ever saying *of what*, and on a machine with both a Claude plan and a Codex one it was two sets
+ * of identical-looking bars stacked on top of each other. It carries the same mark and the same
+ * brand colour the model picker uses, so the thing you chose in `^P` and the thing being spent
+ * here are visibly one thing.
+ *
+ * The sentence is the other half. A bar that fills as an allowance is *spent* and a countdown with
+ * no verb on it are both readable and neither is unambiguous — `12%` and `3h` do not say which way
+ * round they go. One line in words, about the limit that actually binds, says both: how much is
+ * left, and when it comes back.
+ */
+function section(
+  quotas: QuotaSnapshot[],
+  who: CredentialInfo[],
+  glyphs: { ascii: boolean; nerd: boolean },
+  width: number,
+  now: number,
+) {
+  const rows: StripRow[] = [];
   // What the sidebar leaves for the text (`   ` and its own margin), less the widest countdown and
   // a space to keep it off the label.
-  const room = Math.max(12, width - 6 - 5);
+  const room = Math.max(14, width - 6 - 5);
+
   for (const q of quotas) {
     if (q.windows.length === 0) continue;
-    for (const w of q.windows) {
+    // Air between accounts. Two of them run together into one block of bars otherwise, and the
+    // second account's name reads as another limit belonging to the first.
+    if (rows.length > 0) rows.push({ text: "" });
+    rows.push(accountRow(q, who, glyphs, room));
+    // Widest label first, so every bar in an account starts in the same column — a bar whose left
+    // edge moves from row to row cannot be compared with the one above it, which is the only thing
+    // a stack of bars is for.
+    const labels = q.windows.map((w) => compactLabel(w, room));
+    const labelWidth = Math.min(
+      Math.max(...labels.map(cells)),
+      Math.max(6, room - MARKER - BAR_MIN - PCT - 1),
+    );
+    const bar = Math.max(BAR_MIN, Math.min(10, room - MARKER - labelWidth - PCT - 1));
+    for (const [i, w] of q.windows.entries()) {
       rows.push({
-        text: windowRow(w, ascii, room),
+        text: windowRow(w, labels[i] ?? w.label, labelWidth, bar, glyphs.ascii),
         hl: severityGroup(w),
         right: { text: countdown(w, now), hl: "Sidebar.Dim" },
         // Every row opens the panel, so there is no row here you can land on and press `↵` on to
@@ -183,32 +256,174 @@ function section(quotas: QuotaSnapshot[], ascii: boolean, width: number, now: nu
         command: `${NS}.panel`,
       });
     }
+    const said = plainly(q, now, room);
+    if (said) rows.push({ ...said, command: `${NS}.panel` });
     const credit = creditRow(q);
     if (credit) rows.push({ ...credit, command: `${NS}.panel` });
   }
   if (rows.length === 0) return null;
-  return { title: "PLAN", at: "below" as const, rows };
+  // The way in, on the heading. Every row here opens the panel too, but a key you can press from
+  // the composer without going to the sidebar first is a different affordance from a row you have
+  // to arrive at — and it is the one somebody who has never focused this column will find.
+  return { title: "PLAN", hint: "^L", at: "below" as const, rows };
+}
+
+/**
+ * Whose allowance this is: the provider's mark, its name, and what the plan is called.
+ *
+ * The mark and the colour come from the same [`Brand`] the model picker draws, at whatever fidelity
+ * the terminal has — a Nerd Font glyph, geometry, or a letter under `ui.ascii_only`. Drawing our
+ * own would mean two pictures of Anthropic in one program that disagree.
+ *
+ * The name is the *instance's* display name rather than the vendor's, because that is what the
+ * picker calls it and what a second account of the same vendor would be distinguished by. Falling
+ * back to the instance id is deliberate: `claude-cli` is worse than `Claude` and far better than a
+ * blank row, and it happens only before the credential list has arrived.
+ */
+function accountRow(
+  q: QuotaSnapshot,
+  who: CredentialInfo[],
+  glyphs: { ascii: boolean; nerd: boolean },
+  room: number,
+): StripRow {
+  const cred = who.find((c) => c.instance === q.instance);
+  const name = cred?.display_name || q.instance;
+  const mark = markFor(cred?.brand, glyphs);
+  return {
+    text: `${mark} ${clip(name, Math.max(4, room - 2))}`,
+    // The brand colour on the whole row, not just the mark: a contributed row carries one highlight
+    // group, and of the two ways to spend it, the one that makes the account legible at a glance
+    // beats a coloured glyph beside grey text.
+    hl: cred?.brand?.hl ?? "Sidebar.Heading",
+    right: q.plan ? { text: q.plan, hl: "Sidebar.Dim" } : undefined,
+  };
+}
+
+/** The mark for a provider, at whatever fidelity this terminal has. See the model picker's copy. */
+function markFor(b: Brand | null | undefined, glyphs: { ascii: boolean; nerd: boolean }): string {
+  if (!b) return glyphs.ascii ? "?" : "·";
+  if (glyphs.ascii) return b.ascii;
+  return (glyphs.nerd && b.nerd) || b.mark;
 }
 
 /**
  * How many cells a bar in a narrow column is.
  *
- * Eight, because the useful resolution here is about an eighth: plenty of room, getting full,
+ * Six to ten, because the useful resolution here is about an eighth: plenty of room, getting full,
  * nearly out. The exact figure is the number beside it, and a thirty-cell bar in a column this
  * narrow would leave no room for the label that says which allowance it is.
+ */
+const BAR_MIN = 5;
+/** `▸ `, or the two spaces that keep an unmarked row in the same column as a marked one. */
+const MARKER = 2;
+/** ` 100%` — never given up, at any width. A bar with no number on it is a picture. */
+const PCT = 5;
+
+/**
+ * A limit's name, shortened only as far as it has to be, and never past the part that identifies it.
  *
- * Shared by the plan strip and the context meter, which sit in the same kind of space and would
- * read as two different scales if they disagreed.
+ * The old row put the bar first and clipped whatever was left of the label, which turned
+ * `Weekly · Opus 5` into `Weekly ·…` — every character that distinguishes the per-model cap from
+ * the plain weekly one, gone, leaving two rows with the same name and different numbers. So the
+ * ladder goes the other way: give up the separator, then abbreviate the *base*, and only then clip
+ * — and clip the scope, because `Wk Opus…` still says which two things it is about and
+ * `Weekly ·…` says neither.
+ */
+function compactLabel(w: QuotaWindow, room: number): string {
+  // The space between the label and the bar is part of the row too. Forgetting it is one column of
+  // overflow at exactly the width where the label was already the thing being squeezed.
+  const most = Math.max(6, room - MARKER - BAR_MIN - PCT - 1);
+  if (cells(w.label) <= most) return w.label;
+  const scope = w.scope ?? "";
+  // Not a scoped limit, just a long name from a provider nobody here has heard of.
+  if (scope === "") return clip(w.label, most);
+  const base = w.label.slice(0, w.label.length - scope.length).replace(/[\s·]+$/, "");
+  for (const b of [base, base.replace(/^Weekly$/i, "Wk")]) {
+    if (cells(`${b} ${scope}`) <= most) return `${b} ${scope}`;
+  }
+  const short = base.replace(/^Weekly$/i, "Wk");
+  return clip(`${short} ${scope}`, most);
+}
+
+function windowRow(
+  w: QuotaWindow,
+  label: string,
+  labelWidth: number,
+  bar: number,
+  ascii: boolean,
+): string {
+  // The limit that would actually refuse the next request, marked the way the panel marks it. Two
+  // spaces otherwise, so the labels stay in one column.
+  const marker = w.active ? (ascii ? "> " : "▸ ") : "  ";
+  const pct = `${Math.round(w.used_percent)}%`.padStart(PCT);
+  const name = clip(label, labelWidth);
+  return `${marker}${name}${" ".repeat(Math.max(0, labelWidth - cells(name)))} ${
+    meter(w.used_percent / 100, bar, { ascii })
+  }${pct}`;
+}
+
+/**
+ * How long a string is, counted the way {@link clip} counts it.
+ *
+ * Code points rather than UTF-16 units, so a label and the padding computed for it agree. Not
+ * display width — that question is `neosh-tui`'s and is not answerable here — but the labels this
+ * pads are limit names, and the alternative is a `.length` that disagrees with the clip on the
+ * same string.
+ */
+function cells(s: string): number {
+  return [...s].length;
+}
+
+/**
+ * The one row here that is a sentence.
+ *
+ * Everything above it is a measurement, and a measurement has a direction you have to already know:
+ * a bar that fills as an allowance is spent reads as "how much is left" to about half of everyone,
+ * and a bare `3h` beside it could as easily be how long it has been running. This says which way
+ * round both go, about the window that is actually doing the limiting — which is the only one of
+ * the three that answers "may I start something long".
+ *
+ * It never names the window. The `▸` above already did, and a strip this narrow cannot afford to
+ * say `Weekly · Opus 5` twice.
+ */
+function plainly(q: QuotaSnapshot, now: number, room: number): StripRow | null {
+  const w = q.windows.find((x) => x.active) ?? binding(q.windows);
+  if (!w) return null;
+  const back = typeof w.resets_at === "number" ? countdown(w, now) : "";
+  const left = Math.max(0, 100 - Math.round(w.used_percent));
+  const text = left === 0
+    ? back
+      ? `used up · back in ${back}`
+      : "used up"
+    : back
+      ? `${left}% left · back in ${back}`
+      : `${left}% left`;
+  return {
+    text: clip(text, room),
+    // Dim rather than graded: this is the explanation of the rows above, and an explanation that
+    // shouts is one more red thing to work out the meaning of. The row it explains carries the
+    // grade.
+    hl: w.severity === "exhausted" ? "Diagnostic.Error" : "Sidebar.Dim",
+  };
+}
+
+/** The fullest window, for a provider that did not say which of its limits binds. */
+function binding(windows: QuotaWindow[]): QuotaWindow | undefined {
+  return windows.reduce<QuotaWindow | undefined>(
+    (best, w) => (!best || w.used_percent > best.used_percent ? w : best),
+    undefined,
+  );
+}
+
+/**
+ * How many cells the context meter in the footer is.
+ *
+ * Eight, because the useful resolution there is about an eighth: plenty of room, getting full,
+ * nearly out. The exact figure is the number beside it. The plan strip sizes its own bars from the
+ * column it was given (see [`BAR_MIN`]) rather than sharing this, because the footer's width is the
+ * terminal's and the sidebar's is a setting.
  */
 const CELLS = 8;
-
-function windowRow(w: QuotaWindow, ascii: boolean, room: number): string {
-  const pct = Math.round(w.used_percent);
-  const head = `${meter(w.used_percent / 100, CELLS, { ascii })} ${String(pct).padStart(3)}% `;
-  // The bar and the number are never given up; the label is. A row that dropped a digit off `100%`
-  // to keep the word `Fable` would be losing the only part of it that is a measurement.
-  return head + clip(w.label, Math.max(3, room - CELLS - 6));
-}
 
 /**
  * The group a row wears.
@@ -335,6 +550,14 @@ interface View {
   asked: boolean;
   /** What the scan could not read, drawn as a caveat rather than swallowed. */
   note: string | null;
+  /**
+   * Who each instance is, so a gauge can be headed by a provider rather than by an id.
+   *
+   * `claude-cli` is a configuration key. It was what this panel drew, and on a machine with two
+   * accounts it made the one thing the reader needs to tell them apart — which vendor, which plan —
+   * the one thing neither block said.
+   */
+  who: CredentialInfo[];
 }
 
 const WINDOWS = [1, 7, 30, 90];
@@ -353,6 +576,7 @@ async function installPanel({ neosh, subscriptions }: PluginContext) {
     loading: false,
     asked: false,
     note: null,
+    who: [],
   };
 
   const load = async () => {
@@ -361,14 +585,16 @@ async function installPanel({ neosh, subscriptions }: PluginContext) {
     const until = Math.floor(Date.now() / 1000);
     const since = until - view.days * 86_400;
     const resolution: UsageResolution = view.days <= 1 ? "hour" : "day";
-    const [history, quotas, samples] = await Promise.all([
+    const [history, quotas, samples, who] = await Promise.all([
       neosh.quota.usage({ since, until, resolution }).catch(() => null),
       neosh.quota.list().catch(() => [] as QuotaSnapshot[]),
       // The sparklines want the reset period, not the chart's span: a weekly window drawn over
       // ninety days is a flat line with four cliffs in it, which says nothing about this week.
       neosh.quota.history({ since: until - 7 * 86_400, until }).catch(() => []),
+      neosh.agent.credentials().catch(() => [] as CredentialInfo[]),
     ]);
     view.history = history;
+    view.who = who;
     // Merged, never assigned. This read started seconds ago — the transcript scan is the slow part
     // — and a snapshot that arrived by event in the meantime is newer than anything in it. Assigned,
     // a poll landing during the scan was drawn for an instant and then replaced by the empty list
@@ -384,8 +610,12 @@ async function installPanel({ neosh, subscriptions }: PluginContext) {
   const draw = async () => {
     if (buf === null || ns === null || list === null) return;
     const cols = Math.max(40, await panelWidth(neosh, win));
-    const ascii = (await neosh.opt.get<boolean>("ui.ascii_only").catch(() => false)) ?? false;
-    const rows = await body(neosh, view, cols, ascii);
+    const [ascii, nerd] = await Promise.all([
+      neosh.opt.get<boolean>("ui.ascii_only").catch(() => false),
+      neosh.opt.get<boolean>("ui.nerd_font").catch(() => false),
+    ]);
+    const glyphs = { ascii: ascii ?? false, nerd: nerd ?? false };
+    const rows = await body(neosh, view, cols, glyphs);
     list.setRows(rows);
     await list.render({ win: win ?? undefined });
   };
@@ -566,8 +796,9 @@ async function body(
   neosh: Neosh,
   view: View,
   cols: number,
-  ascii: boolean,
+  glyphs: { ascii: boolean; nerd: boolean },
 ): Promise<ListRow<null>[]> {
+  const { ascii } = glyphs;
   const rows: ListRow<null>[] = [];
   const rule = () => rows.push({ text: "─".repeat(cols), hl: "Separator", inert: true });
   const blank = () => rows.push({ text: "", inert: true });
@@ -580,8 +811,28 @@ async function body(
     });
 
   const now = Date.now() / 1000;
-  head("YOUR PLAN", view.quotas.length ? `${NS}.panel.refresh · r` : undefined);
+  // `r refresh`, not `usage.panel.refresh · r`. A command name in a heading is the program telling
+  // you what it calls something rather than what you can do with it.
+  head("YOUR PLAN", view.quotas.length ? "r refresh" : undefined);
   rule();
+  if (view.quotas.length > 0) {
+    // What these numbers *are*, which no amount of care with the bars can say on its own. A rolling
+    // allowance is not a balance and not a token count: it refills on a clock, the vendor decides
+    // how big it is and will not itemise it, and a turn you ran in the vendor's own CLI spent it
+    // too. Everything below is a percentage of something opaque, and saying so once is what stops
+    // people planning around it as though it were money.
+    rows.push({
+      text: "   Rolling allowances your plan enforces. They refill on a clock, and the vendor",
+      hl: "Comment",
+      inert: true,
+    });
+    rows.push({
+      text: "   never says how big they are — so these are percentages, never token counts.",
+      hl: "Comment",
+      inert: true,
+    });
+    blank();
+  }
   if (view.quotas.length === 0) {
     // Two different situations, and only one of them is about to change on its own. A workspace
     // that has never been told is waiting for a turn; one that asked and got nowhere is waiting
@@ -603,7 +854,7 @@ async function body(
     });
   }
   for (const q of view.quotas) {
-    rows.push(...gaugeBlock(q, view.samples, cols, ascii, now));
+    rows.push(...gaugeBlock(q, view.who, view.samples, cols, glyphs, now));
   }
 
   blank();
@@ -662,16 +913,25 @@ function hints(): string {
  */
 function gaugeBlock(
   q: QuotaSnapshot,
+  who: CredentialInfo[],
   samples: View["samples"],
   cols: number,
-  ascii: boolean,
+  glyphs: { ascii: boolean; nerd: boolean },
   now: number,
 ): ListRow<null>[] {
+  const { ascii } = glyphs;
   const rows: ListRow<null>[] = [];
   const age = now - q.observed_at;
+  // The provider, drawn the way the model picker draws it: same mark, same brand colour, same name.
+  // This row used to be the instance id, which is a configuration key — and on a machine with a
+  // Claude plan and a Codex one it made the single thing that tells the two blocks apart the one
+  // thing neither of them said.
+  const cred = who.find((c) => c.instance === q.instance);
   rows.push({
-    text: `   ${q.instance}${q.plan ? `  ${q.plan}` : ""}`,
-    hl: "Sidebar.Heading",
+    text: `   ${markFor(cred?.brand, glyphs)} ${cred?.display_name || q.instance}${
+      q.plan ? `  ${q.plan}` : ""
+    }`,
+    hl: cred?.brand?.hl ?? "Sidebar.Heading",
     // How old the number is, always. A percentage with no age on it is one people trust for longer
     // than they should — and at rest, with polling off, "an hour ago" is the whole answer.
     right: { text: `${freshness(age, q.source)} `, hl: "Comment" },
@@ -687,6 +947,20 @@ function gaugeBlock(
   // the word `resets`.
   const FIXED = 5 + labelWidth + 2 + 6 + 2 + SPARK + 2 + 18;
   const barWidth = Math.max(8, Math.min(40, cols - FIXED));
+
+  // What each column is, once, over the columns themselves.
+  //
+  // Every part of the row below is a measurement with a direction you have to already know: a bar
+  // that fills as an allowance is *spent*, a sparkline that is not labelled could be any span, and
+  // a bare `3h` is as easily "running for" as "back in". Naming them costs one dim row per account
+  // and is the difference between a display you read and one you interpret.
+  rows.push({
+    text: `     ${"limit".padEnd(labelWidth)}  ${"used".padEnd(barWidth)}      ${
+      "last 7 days".padEnd(SPARK)
+    }  refills`,
+    hl: "Comment",
+    inert: true,
+  });
 
   for (const w of q.windows) {
     const pct = Math.round(w.used_percent);
@@ -739,6 +1013,14 @@ function resetsWord(w: QuotaWindow, now: number): string {
   if (typeof w.resets_at !== "number") return "";
   const left = w.resets_at - now;
   if (left <= 0) return "resetting";
+  // Days, once there are any. `elapsed` counts a turn, which never runs for a week, so it tops out
+  // at hours — and a weekly allowance came back as `resets in 164h 34m`, a number you have to do
+  // arithmetic on to find out it means Tuesday.
+  if (left >= 86_400) {
+    const days = Math.floor(left / 86_400);
+    const hours = Math.floor((left % 86_400) / 3600);
+    return `resets in ${days}d${hours > 0 ? ` ${hours}h` : ""}`;
+  }
   return `resets in ${elapsed(left * 1000).replace(/ \d+s$/, "")}`;
 }
 


### PR DESCRIPTION
Two panels' worth of work that had piled up in the tree, plus the merge with `feat/worktrees-in-the-project`.

## A float can be modal — ADR 0047

`active_scopes` resolves window, buffer, kind, then **global**, and global is always on the end — so
`^N` over the option sheet opened a conversation *behind* it, `^T` opened the project panel
underneath and moved focus into it, and `^G`/`^L`/`^J`/`^D`/`^O`/`^B`/`^F` each had their own
version of that. Shadowing the keys a widget wanted only ever covered the keys it knew about.

`FloatConfig::modal` stops global bindings resolving while the float has focus. Window, buffer and
kind scopes still do, so a modal is exactly as extensible as any other panel; `ui.modal_escape_keys`
(`^Q`, `^R`) always resolve, because a buggy panel must never be a lost terminal; and a key nothing
claimed is swallowed rather than typed into a composer you cannot see.

The question panel, the usage panel and the option sheet take it up, along with the keys that go
with being modal, and `plugins/api/src/ui.ts` and the catalogue grew what the three of them needed.

## A project outlives the conversations in it — ADR 0039

The sidebar had no list of projects; it had a list of conversations grouped by directory, with
pinned directories seeded in as a special case. So deleting the last conversation in a directory
deleted the directory too: you cleared out a month of finished threads and the repository left the
panel with them.

The list is written down (`sidebar.projects`) rather than inferred. `sidebar.name` keeps what the
host called a project for when there is nothing in it to ask. `X` on a heading takes a project off
the list and is the only thing that does — empty it asks nothing (`o` puts it back), and with
conversations still in it, it is a delete of every one of them and asks like one.

## Where the two branches met

`#21` nests a worktree under its repository, grouping on `SessionInfo::repo_root` — which a
conversation carries. A project that outlives its conversations therefore had an emptied worktree
jumping out of its repository to the top level. `sidebar.root` is written down while something still
knows it, so a tree you have emptied stays its branch under its repository. A question waiting
anywhere inside a repository now marks the repository's row, on the same argument the folded count
is already aggregated on.

## Verification

Per crate, all green: `neosh-core` (103), `neosh-proto` (176 + `export_bindings`, no generated
drift), `neosh-tui` (100), `neosh` `builtin_plugins` (135), `questions` (15), `reading` (24),
`workspace` (12); `tsc --noEmit` over `plugins/api` and `plugins/builtin`.

New tests cover the modal routing (`crates/neosh-core/tests/key_capture.rs`), a project surviving
its conversations and a restart, `X` removing one, and an emptied worktree staying inside its
repository — the last one verified to fail without the fix.