### PR TITLE
fix(questions): a field that shows what you are typing, and keeps it

### DIFF
--- a/crates/neosh/tests/questions.rs
+++ b/crates/neosh/tests/questions.rs
@@ -283,6 +283,28 @@ impl Session {
             .collect()
     }
 
+    /// The rows drawn into the question panel, and nothing drawn anywhere else.
+    ///
+    /// The composer holds the same sentence — the panel mirrors what you type into it, because the
+    /// composer is the field this screen actually has — so a test about what *the panel* shows has
+    /// to say which buffer it means, or it passes on the composer's copy of the text and never
+    /// looks at the row it was written about.
+    fn panel(&self) -> Vec<String> {
+        let bufs: Vec<Value> = self
+            .events
+            .iter()
+            .filter(|e| e["type"] == "buffer_opened" && e["name"].as_str() == Some("[question]"))
+            .map(|e| e["buf"].clone())
+            .collect();
+        self.events
+            .iter()
+            .filter(|e| e["type"] == "buffer_lines" && bufs.contains(&e["buf"]))
+            .filter_map(|e| e["lines"].as_array())
+            .flatten()
+            .filter_map(|l| l["text"].as_str().map(str::to_string))
+            .collect()
+    }
+
     fn saw(&self, needle: &str) -> bool {
         self.texts().iter().any(|l| l.contains(needle))
     }
@@ -623,4 +645,73 @@ fn backspacing_off_an_empty_answer_goes_back_to_the_options() {
     s.wait_for("1-2 pick");
     s.key("1");
     s.wait_for(r#""answers":["Tabs"]"#);
+}
+
+/// An answer longer than the row is wide is still an answer you can read back.
+///
+/// The row that takes an answer of your own was drawn with the same `clip` as an option's label:
+/// past the width of the panel it became the first sixty characters and an ellipsis, and stayed
+/// that way however much more was typed. The caret stopped moving, every word after it went
+/// somewhere invisible, and the only way to find out what you had written was to send it — on the
+/// one row of this panel whose entire job is to show you what you are writing.
+#[test]
+fn an_answer_longer_than_the_row_is_shown_whole() {
+    let mut s = open_with("longanswer", "t.ask.one", "Tabs or spaces?");
+    let answer = "spaces everywhere except in the makefiles, where a tab is the syntax and a space \
+                  is a build that fails, and this is the zzz-end-of-it";
+    for c in answer.chars() {
+        s.key(&c.to_string());
+    }
+    assert!(
+        s.pump(|x| x.panel().iter().any(|l| l.contains("zzz-end-of-it"))),
+        "the end of what is being typed is on the panel\n{}",
+        s.transcript()
+    );
+    // And nothing of it was thrown away to make it fit: the field wraps, it does not clip.
+    assert!(
+        !s.panel().iter().any(|l| l.contains("makefiles") && l.contains('\u{2026}')),
+        "the field wraps rather than ending in an ellipsis\n{}",
+        s.transcript()
+    );
+    s.special("enter");
+    s.wait_for(&format!("\"answers\":[\"{answer}\"]"));
+}
+
+/// What you were half-way through writing survives looking at another conversation.
+///
+/// Which question you are on and which row the cursor is on already did — they live on the ask,
+/// which outlives the panel — but what was in the field lived in the panel, and the panel is closed
+/// and built again from nothing every time the screen moves to another conversation. Go and check
+/// something in the conversation next door and the sentence you were writing was gone, with no key
+/// having been pressed that could have deleted it.
+#[test]
+fn what_you_were_writing_survives_looking_at_another_conversation() {
+    let sb = Sandbox::new("keeps-writing");
+    sb.install_asker(ASKER);
+    let mut s = sb.start();
+    s.wait_for("asker ready");
+    s.command("t.ask.one");
+    s.wait_for("Tabs or spaces?");
+    for c in "half a thought".chars() {
+        s.key(&c.to_string());
+    }
+    s.wait_for("\u{270e} half a thought");
+
+    s.command("t.switch");
+    s.wait_for("conversation is asking");
+    s.drain_for(Duration::from_millis(400));
+
+    // Counted with the panel gone, so what is waited for below is the panel *coming back* rather
+    // than the last of the redraws it made on its way out.
+    let written = s.count("\u{270e} half a thought");
+    s.command("t.switch");
+    assert!(
+        s.pump(move |x| x.count("\u{270e} half a thought") > written),
+        "coming back puts you back in the sentence\n{}",
+        s.transcript()
+    );
+    // And it is still the answer, not merely still on screen.
+    s.special("enter");
+    s.wait_for("\"answers\":[\"half a thought\"]");
+    assert!(s.saw(r#""custom":true"#), "and it is marked as typed\n{}", s.transcript());
 }

--- a/docs/adr/0043-a-question-is-not-a-permission.md
+++ b/docs/adr/0043-a-question-is-not-a-permission.md
@@ -122,6 +122,25 @@ visible and editable, and the panel echoes it on a `✎` row. A digit is a short
 been typed and a character once something has, and the panel says which by wearing the numbers or
 not — the badges disappearing is the notice that the keyboard's meaning changed.
 
+**A field is a field, and the row is one.** The `✎` row was drawn with the same `clip` as an
+option's label, so an answer wider than the panel became its first sixty characters and an ellipsis
+— and stayed that way however much more was typed. The caret stopped, the words went somewhere
+invisible, and the only way to read back what you had written was to send it: the one row on this
+panel whose entire job is to show you what you are writing was the one row that would not. So it
+wraps, onto as many lines as the sentence takes, and past six it keeps the *end* — the end is where
+the caret is, and a field that scrolled the other way would show you everything except the word you
+are typing. The wrap keeps every character it was given, spaces included, because a line that
+rewrites what you typed is one the caret can no longer be placed on honestly.
+
+**What you are writing belongs to the question, not to the panel.** Which question you are on and
+which row the cursor is on live on the ask, which outlives the panel; what was in the field lived in
+the panel, and the panel is closed and built again from nothing every time the screen moves to
+another conversation. Go and check something next door — which is very often exactly what the
+question sent you to do — and the sentence was gone, with no key having been pressed that could have
+deleted it. It is kept on the ask, and restored into the composer as well as onto the row, because
+switching conversations empties the composer and an answer on the panel that is not in the field
+below it is two answers that disagree.
+
 **Every key is a named command** bound against the `neosh.question` buffer kind, so `F1` lists them
 and `init.ts` can move them. Only printable characters come through the raw capture, and only
 because they are text rather than verbs.

--- a/plugins/builtin/questions/main.ts
+++ b/plugins/builtin/questions/main.ts
@@ -102,6 +102,18 @@ const LABEL_MAX = 28;
 const OTHER = "Other";
 
 /**
+ * How many lines of the answer you are writing the panel will show at once.
+ *
+ * A field, not a paragraph: what is being typed goes on as many lines as it takes and the panel
+ * follows the *end* of it, because the end is where the caret is and the caret is what you are
+ * looking at. Unbounded, a long answer would grow the float until it had eaten the conversation it
+ * is a question about; clipped to one line — which is what this was — everything past the width of
+ * the row is an ellipsis, and typing into a field that stopped showing what you were typing is the
+ * one thing a field must never do.
+ */
+const FIELD_LINES = 6;
+
+/**
  * The characters the panel is drawn with, at whatever fidelity the terminal has.
  *
  * A ticked box and an untouched one have to be the same width or the labels beside them step
@@ -181,6 +193,17 @@ type Ask = {
   at: number;
   /** Which option is under the cursor, for the question on screen. */
   cursor: number;
+  /**
+   * What is in the field, and whether the field is open at all.
+   *
+   * On the ask rather than in the panel, because the panel is closed and built again from nothing
+   * every time you look at another conversation — and a sentence somebody is half-way through
+   * writing belongs to the question, not to the float that happened to be drawing it. Separate
+   * from `drafts`, which is what has been *answered*: a half-written sentence is not an answer,
+   * and one filed as though it were would have the panel tick the question off and walk past it.
+   */
+  typing: string;
+  writing: boolean;
   /** Called once, with the answers or `null` for "nobody answered". */
   settle: (answers: QuestionAnswer[] | null) => void;
   settled: boolean;
@@ -295,6 +318,8 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
           drafts: new Map(),
           at: 0,
           cursor: 0,
+          typing: "",
+          writing: false,
           settle: () => {},
           settled: false,
         };
@@ -470,6 +495,11 @@ async function draw(neosh: Neosh, ask: Ask, seed: string, done: () => void): Pro
   const close = async () => {
     if (closed) return;
     closed = true;
+    // Onto the ask, before the panel goes. Looking at another conversation closes this panel and
+    // builds a new one on the way back — the cursor and which question you were on already survive
+    // that, and what you were writing is the one part of it you would notice losing.
+    ask.typing = typed;
+    ask.writing = writing;
     for (const d of disposers) d.dispose();
     await neosh.focus.pop().catch(() => {});
     await neosh.win.close(win).catch(() => {});
@@ -740,12 +770,17 @@ async function draw(neosh: Neosh, ask: Ask, seed: string, done: () => void): Pro
     });
   }
 
-  // Seeded from whatever was already half-typed when the question arrived, rather than thrown
-  // away: the panel appeared over a field somebody was using, and what they had written is very
-  // often the answer — it is the sentence they were about to send.
-  typed = seed;
-  writing = seed.trim() !== "";
+  // What was in the field when this question was last on screen, if it has been: coming back to a
+  // conversation you left mid-sentence puts you back in the sentence. Otherwise, whatever was
+  // already half-typed when the question arrived, rather than thrown away — the panel appeared
+  // over a field somebody was using, and what they had written is very often the answer.
+  typed = ask.typing || seed;
+  writing = ask.writing || typed.trim() !== "";
   if (writing) ask.cursor = q().options.length;
+  // And the composer says the same thing, because switching conversations emptied it. The panel
+  // mirrors the answer into the composer so you can see it in the field this screen actually has;
+  // restoring one without the other is arriving at two answers that disagree.
+  if (typed !== "") await neosh.agent.setDraft(typed).catch(() => {});
   await render();
 
   return { ask, close };
@@ -951,41 +986,59 @@ function compose(
     const lead = pad(`${here ? g.cursor : g.blank} ${g.pen} `, gutter);
     const badge = shortcuts ? "0" : "";
     const forDetail = room - gutter - labelWidth - 2 - (badgeWidth ? badgeWidth + 2 : 0);
-    // Once you are writing, the row *is* the field: what is in it is your answer, and it takes the
-    // whole width because a sentence is not a label.
-    const body = custom
-      ? clip(typed, Math.max(8, room - gutter - 2))
-      : (() => {
-        const label = pad(clip(OTHER, labelWidth), labelWidth);
-        const hint = forDetail >= 8 ? clip("type an answer of your own", forDetail) : "";
-        return hint ? `${label}  ${hint}` : label.trimEnd();
-      })();
-    const filler = badge ? " ".repeat(Math.max(1, room - gutter - cols(body) - cols(badge))) : "";
-    const text = `  ${lead}${body}${filler}${badge}`;
-
-    const marks: DrawnMark[] = [
-      mark(LEFT, LEFT + byteLength(lead), custom ? "Question.Taken" : "Question.Box", 100),
-    ];
-    if (here) marks.unshift({ col: 0, opts: { lineHlGroup: "Question.Cursor" } });
-    const bodyAt = LEFT + byteLength(lead);
     if (custom) {
-      marks.push(mark(bodyAt, byteLength(text), "Question.Custom", 100));
-      // The caret sits at the end of what has been typed, which is the one place on this panel
-      // where a terminal cursor means "the keyboard goes here".
-      caret = rows.length;
-      caretCol = bodyAt + byteLength(body);
+      // Once you are writing, the row *is* the field: what is in it is your answer, it takes the
+      // whole width because a sentence is not a label, and it takes as many lines as the sentence
+      // takes. Clipped to the one row — which is what it did — an answer longer than the panel is
+      // wide became the first sixty characters and an ellipsis, and stayed that way however much
+      // more you typed: the caret stopped moving, the words went nowhere visible, and the only way
+      // to read back what you had written was to send it.
+      //
+      // The *end* is what is kept when there is more of it than [`FIELD_LINES`] can hold, because
+      // the end is where the caret is. A field that scrolled the other way would be one that shows
+      // you everything except the word you are typing.
+      const lines = wrapField(typed, Math.max(8, room - gutter - 2));
+      const shown = lines.slice(Math.max(0, lines.length - FIELD_LINES));
+      shown.forEach((line, n) => {
+        // The gutter is paid for on every line and drawn on the first, as the option rows do it:
+        // repeating the pen down the side would read as one answer per line.
+        const run = n === 0 ? lead : " ".repeat(gutter);
+        const text = `  ${run}${line}`;
+        const marks: DrawnMark[] = [{ col: 0, opts: { lineHlGroup: "Question.Cursor" } }];
+        if (n === 0) marks.push(mark(LEFT, LEFT + byteLength(lead), "Question.Taken", 100));
+        const bodyAt = LEFT + byteLength(run);
+        if (line !== "") marks.push(mark(bodyAt, byteLength(text), "Question.Custom", 100));
+        if (n === shown.length - 1) {
+          // The caret sits at the end of what has been typed, which is the one place on this panel
+          // where a terminal cursor means "the keyboard goes here".
+          caret = rows.length;
+          caretCol = bodyAt + byteLength(line);
+        }
+        rows.push({ text, marks });
+      });
     } else {
+      const label = pad(clip(OTHER, labelWidth), labelWidth);
+      const hint = forDetail >= 8 ? clip("type an answer of your own", forDetail) : "";
+      const body = hint ? `${label}  ${hint}` : label.trimEnd();
+      const filler = badge ? " ".repeat(Math.max(1, room - gutter - cols(body) - cols(badge))) : "";
+      const text = `  ${lead}${body}${filler}${badge}`;
+
+      const marks: DrawnMark[] = [mark(LEFT, LEFT + byteLength(lead), "Question.Box", 100)];
+      if (here) marks.unshift({ col: 0, opts: { lineHlGroup: "Question.Cursor" } });
+      const bodyAt = LEFT + byteLength(lead);
       marks.push(mark(bodyAt, bodyAt + byteLength(clip(OTHER, labelWidth)), "Question.Option", 100));
-      const hintAt = bodyAt + byteLength(pad(clip(OTHER, labelWidth), labelWidth)) + 2;
+      const hintAt = bodyAt + byteLength(label) + 2;
       if (byteLength(text) > hintAt) {
         marks.push(mark(hintAt, byteLength(text), "Question.Detail", 100));
       }
       if (here) caret = rows.length;
+      if (badge) {
+        marks.push(
+          mark(byteLength(text) - byteLength(badge), byteLength(text), "Question.Shortcut", 100),
+        );
+      }
+      rows.push({ text, marks });
     }
-    if (badge) {
-      marks.push(mark(byteLength(text) - byteLength(badge), byteLength(text), "Question.Shortcut", 100));
-    }
-    rows.push({ text, marks });
   }
 
   // --- the keys --------------------------------------------------------------
@@ -1089,6 +1142,43 @@ function wrapCols(text: string, width: number): string[] {
   }
   if (line) out.push(line);
   return out.length > 0 ? out : [""];
+}
+
+/**
+ * Break what is being *typed* onto lines of at most `width`.
+ *
+ * The third of these, and it exists because the other two rewrite what they wrap. [`wrap`] and
+ * [`wrapCols`] split on whitespace and join with single spaces, which is right for a label or a
+ * sentence that arrived finished and wrong for a field: the two spaces somebody typed would come
+ * back as one, a trailing space would vanish the moment it was typed and reappear with the next
+ * word, and the caret — which is placed at the end of the last line — would sit somewhere other
+ * than where the next character is going to land.
+ *
+ * So every character survives, and the space a line breaks at stays on the end of the line it broke
+ * from: the lines joined back together are exactly what was typed. Words are still kept whole where
+ * one fits, and one that does not is cut, because a word wider than the field has to go somewhere.
+ */
+function wrapField(text: string, width: number): string[] {
+  const limit = Math.max(1, width);
+  const out: string[] = [];
+  let rest = text;
+  while (cols(rest) > limit) {
+    const chars = [...rest];
+    // The last space that would still leave something before it — a break at the very front would
+    // push the whole line down and make no progress.
+    let at = -1;
+    for (let i = limit - 1; i > 0; i--) {
+      if (chars[i] === " ") {
+        at = i;
+        break;
+      }
+    }
+    const cut = at > 0 ? at + 1 : limit;
+    out.push(chars.slice(0, cut).join(""));
+    rest = chars.slice(cut).join("");
+  }
+  out.push(rest);
+  return out;
 }
 
 /**


### PR DESCRIPTION
Two bugs on the one row of the question panel whose entire job is to show you what you are writing.

**It was drawn with `clip`.** The `✎` row used the same one-line clip as an option's label, so an answer wider than the panel became its first sixty characters and an ellipsis — and stayed that way however much more you typed. The caret stopped moving, the words went somewhere invisible, and the only way to read back what you had written was to send it. It now wraps onto as many lines as the sentence takes, and past `FIELD_LINES` (6) it keeps the **end**, because the end is where the caret is; a field that scrolled the other way would show you everything except the word you are typing.

`wrapField` is a third wrap rather than a reuse of `wrap` or `wrapCols`: those split on whitespace and rejoin with single spaces, which is right for a sentence that arrived finished and wrong for a field — two typed spaces come back as one, a trailing space vanishes and reappears with the next word, and the caret ends up somewhere other than where the next character lands. This one preserves every character, so the lines joined back together are exactly what was typed.

**What was in it lived in the panel.** Which question you are on and which row the cursor is on already survive a conversation switch — they live on the `Ask` — but `typed`/`writing` were locals in `draw`, and the panel is closed and built again from nothing every time the screen moves. Going next door to check the thing the question sent you to check threw the sentence away, with no key having been pressed that could have deleted it.

They are now `Ask::typing`/`Ask::writing`, stashed in `close()` and restored on reopen, kept apart from `drafts` — which is what has been *answered*, and a half-written sentence filed there would have the panel tick the question off and walk past it. The composer is restored with it, since `enter_session` empties it: an answer on the panel that is not in the field below it is two answers that disagree.

ADR 0043's panel section records both.

## Verification

- `cargo test -p neosh --test questions` — 17 pass, including two new ones: `an_answer_longer_than_the_row_is_shown_whole` and `what_you_were_writing_survives_looking_at_another_conversation`. The first needed a `Session::panel()` helper that filters to the `[question]` buffer — the composer mirrors the same sentence, so a test scanning every row passes on the composer's copy without ever looking at the panel.
- `cargo test -p neosh --test builtin_plugins` — 138 pass.
- Driven under a pty against the real binary with a sandbox asker plugin: a 140-character answer wraps and grows the float, and a 500-character one caps at six lines with its last word still on screen.