### PR TITLE
A default binding is a key every terminal sends

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ per decision, and records the *reasoning*, not the choice.
   (`ext.contribute`/`ext.list`), which is how rows and verbs arrive from plugins we have never heard
   of; and **shared vars** (`vars`, scoped to the workspace, a conversation or a project) for anything
   about a thing rather than about us — `state` stays private and a favourite is not private. Every
-  key in a panel is an ordinary binding pointed at a named command, so `F1` lists it and `init.ts`
+  key in a panel is an ordinary binding pointed at a named command, so `^Z` lists it and `init.ts`
   can move it; a `switch` on `KeyContext` inside a plugin is the thing this replaced. Keep the
   capture, but only as a sink for keys nothing claimed. See ADR 0040.
 - **A panel you are in the middle of using has the keyboard.** `FloatConfig::modal` takes
@@ -78,6 +78,16 @@ per decision, and records the *reasoning*, not the choice.
   default. A modal that borrows a global key to open itself owes a binding to close itself, which is
   why `^E` shuts the sheet from inside. Answering a question is not this: `^T` is how you reach a
   question waiting in another conversation. See ADR 0047.
+- **A default binding is a key every terminal sends.** Not "a key most people can press once they
+  have found the setting": `F1` is brightness on a Mac out of the box, `⌥V` is `√`, and a key
+  neosh never receives is a key no amount of rebinding will fix. That leaves Ctrl-with-a-letter,
+  `⇧⇥`, `⏎`, `⌫` and `Esc` — and Ctrl with *punctuation* is not in the list, because a plain
+  terminal cannot tell `Ctrl+/` from `Ctrl+7`. Arrows, `PgUp`, `Home` and `End` are bound wherever
+  they mean something and are **never the only way** to do anything, which is also why the first
+  key in a `ui.keys.*` list is the chord: the first one is what a hint row prints, and a legend is
+  a promise about a keyboard. A capability that runs out of chords loses its key and keeps its
+  command — `^K` runs it by name and `init.ts` can bind it — because inventing a prefix layer for
+  one verb costs every user a concept to save one of them a keystroke. See ADR 0048.
 - **Pairing is a decision each machine makes, and neither of them restarts.** A node presents its
   identity to anyone who connects — as an SSH server presents a host key — so adding a computer is
   typing an address and being shown a name and a fingerprint that came from the far end. The other
@@ -349,8 +359,13 @@ the plugin tree is embedded with `include_dir!` and cargo will not notice otherw
 # Keys
 
 Everything here is an ordinary binding in the same table your `init.ts` writes to, bound to a
-*command name* rather than a callback. Setting the same key replaces it. `F1` lists the live
+*command name* rather than a callback. Setting the same key replaces it. `^Z` lists the live
 registry — this table is what ships.
+
+Every key here is one **every terminal sends on every platform**: Ctrl-with-a-letter, `⇧⇥`, `⏎`,
+`⌫`, `Esc`. Nothing needs `fn`, nothing needs Option-as-Alt, and nothing is reachable only by an
+arrow — arrows and `PgUp`/`Home`/`End` are bound wherever they mean something, and are never the
+only way to do anything. See ADR 0048.
 
 ## Chat
 
@@ -360,10 +375,9 @@ registry — this table is what ships.
 | `⇧⏎` | Newline, so a pasted snippet stays one message |
 | `^Y` | Take the last thing you queued back into the composer, to change it or drop it. Readline's yank: `^U`/`^W` kill, `^Y` brings it back |
 | `^V` | Attach the image on the clipboard. A key rather than a paste, because a terminal's paste can only ever hand over text |
-| `⌥V` | Take the last attached image back off |
+| `⌫` | On an empty composer, take the last attached image back off |
 | `^P` | Pick a model. Mid-turn too — the running agent is told, and thinks the rest with it |
-| `^E` | Everything this model can be told, on one panel: effort, thinking, fast mode, context, and whatever a driver invented. `←→` along a row, `↑↓` between them, and it applies as you move. Nothing else reaches the keyboard while it is open; `^E` again closes it |
-| `⌥↑` `⌥↓` | One rung up or down the capability ladder, same provider |
+| `^E` | Everything this model can be told, on one panel: effort, thinking, fast mode, context, and whatever a driver invented. `h`/`l` along a row, `j`/`k` between them, arrows too, and it applies as you move. Nothing else reaches the keyboard while it is open; `^E` again closes it |
 | `⇧⇥` | Permission mode — full access to start with, then ask, allow-listed, deny. Belongs to this conversation, saved with it, and takes effect on the turn that is running |
 | `^T` | Projects and conversations. Switching is never refused — turns keep running where they are |
 | `^J` | The computers in this workspace. Add one by its address, allow one that is asking, or open what it is running |
@@ -383,7 +397,7 @@ registry — this table is what ships.
 | `PgUp` `PgDn` `^End` | Scroll, and back to the newest message |
 | `^R` | Reload configuration |
 | `^Q` | Close this terminal. Whatever is running keeps running, and so does every other terminal open on this workspace — `neosh` puts you back |
-| `F1` | Every binding, live |
+| `^Z` | Every binding, live |
 | `Esc` | Interrupt the turn in this conversation. The agent is asked to stop, so the conversation survives it |
 
 Dragging an image onto the terminal pastes its path, and a pasted path to an image is attached
@@ -391,7 +405,9 @@ rather than typed out. What is attached sits above the field until the message g
 
 Composer editing is a text field: `←`/`→` by character and `^←`/`^→` by word, `Home`/`End` and
 `^Home`/`^End` for the ends, shift with any of them to select, `^W` and `^U` to delete a word or
-back to the start of the line.
+back to the start of the line. The capability ladder — `model.upgrade`, `model.downgrade` — has no
+default key: it had `⌥↑`/`⌥↓`, which is not a key every terminal sends, and `^K` runs both by
+name.
 
 ## Reading the transcript — `^S`
 
@@ -440,7 +456,7 @@ Two corollaries, both of which were bugs:
 What an agent gets when it asks *you* something. One question at a time, `⇧⇥` to go back and change
 an earlier answer, and **typing is answering** — it goes into the composer, where you can see and
 edit it, and the numbered shortcuts disappear to say a digit is now a character. Every key here is
-an ordinary binding against the `neosh.question` buffer kind, so `F1` lists it and `init.ts` can
+an ordinary binding against the `neosh.question` buffer kind, so `^Z` lists it and `init.ts` can
 move it.
 
 | Key | Does |
@@ -448,7 +464,7 @@ move it.
 | `↵` | Take the option under the cursor, and go on to the next question. On one that takes several, confirm what is ticked. With something typed, send that instead |
 | `1`–`9` | Take that option, while nothing has been typed |
 | `⇥` | Tick or untick the option under the cursor, on a question that takes more than one |
-| `↑` `↓`, `^P` `^N` | Move |
+| `^P` `^N`, `↑` `↓` | Move |
 | `⇧⇥` | Back to the previous question |
 | type | Your own answer, for when none of them is it. `⌫` back to the options, `^W` a word, `^U` all of it |
 | `Esc` | Dismiss. The agent is told nobody answered — which is a thing it can act on, not an error |
@@ -480,7 +496,7 @@ says how many are asking, `^T` is where you go, and it opens when you get there.
 | Key | Does |
 |---|---|
 | `↵` | Choose |
-| `↑`/`↓`, `^N`/`^P`, `^J`/`^K` | Move |
+| `^N`/`^P`, `^J`/`^K`, `↑`/`↓` | Move |
 | type | Filter |
 | `⇥` `⇧⇥`, `→` `←` | Between the two panes of the model picker |
 | `Esc`, `^C` | Close |

--- a/crates/neosh-proto/src/api.rs
+++ b/crates/neosh-proto/src/api.rs
@@ -751,7 +751,7 @@ pub enum ApiCall {
     // write and invokes commands it has never heard of, and neither side imports the other.
     //
     // It is deliberately data rather than a callback. A contribution survives being listed by the
-    // palette, described in `F1`, and disabled by the user, none of which is possible for a
+    // palette, described in `^Z`, and disabled by the user, none of which is possible for a
     // function pointer held inside somebody's closure.
     /// Add an item to a point, replacing whatever this plugin had put there under the same `id`.
     ExtContribute {
@@ -1209,7 +1209,7 @@ pub struct AttachmentInfo {
 #[ts(export)]
 pub struct StatusSegment {
     pub text: String,
-    /// The key that changes this, written the way the user would press it — `^P`, `F1`.
+    /// The key that changes this, written the way the user would press it — `^P`, `^Z`.
     ///
     /// Beside what it acts on rather than in a list of its own, because a key is only memorable
     /// once you have seen it next to the thing it does. A separate legend is a second place to

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -1494,6 +1494,26 @@ impl Host {
         Ok(got)
     }
 
+    /// Whether the conversation on screen has an image attached that has not been sent.
+    fn has_attachment(&self) -> bool {
+        self.attached.get(&self.active_session()).is_some_and(|v| !v.is_empty())
+    }
+
+    /// Take the last attached image back off, saying which one went.
+    ///
+    /// Said out loud because the chip it removes may have been the only one on screen: a row that
+    /// silently becomes no row is indistinguishable from a key that did nothing.
+    fn drop_attachment(&mut self) {
+        let here = self.active_session();
+        match self.attached.entry(here).or_default().pop() {
+            None => self.editor_message(MessageLevel::Info, "nothing attached"),
+            Some(a) => {
+                self.editor_message(MessageLevel::Info, format!("took off {}", a.label()));
+                self.refresh_composer();
+            }
+        }
+    }
+
     /// Start a turn in a named conversation, drawing it only if it is the one on screen.
     ///
     /// Named rather than implied, because the caller is not always the keyboard: a turn that ends
@@ -2464,7 +2484,7 @@ impl Host {
             ];
             if i + 1 == attached.len() {
                 v.push(chunk("  ", "Composer.Hint"));
-                v.push(chunk("\u{2325}v", "Composer.HintKey"));
+                v.push(chunk(if ascii { "Bksp" } else { "\u{232b}" }, "Composer.HintKey"));
                 v.push(chunk(" take off", "Composer.Hint"));
             }
             self.composer_mark(0, VirtTextPos::Above, v);
@@ -3067,6 +3087,13 @@ impl Host {
                 self.start_turn(text);
             }
 
+            // Nothing left to erase, and a chip above the field: the next backspace takes that
+            // off. It is how a chip row behaves everywhere else, it needs no modifier anybody's
+            // terminal has an opinion about, and "that was the wrong screenshot" is one key away
+            // from having pasted it.
+            KeyCode::Backspace if self.composer_text().is_empty() && self.has_attachment() => {
+                self.drop_attachment()
+            }
             KeyCode::Backspace if m.ctrl || m.alt => self.compose(TextEdit::DeleteWordBack),
             KeyCode::Backspace => self.compose(TextEdit::DeleteBack),
             KeyCode::Delete if m.ctrl || m.alt => self.compose(TextEdit::DeleteWordForward),
@@ -6408,9 +6435,11 @@ impl Host {
             // `^V` is the one every hand is already on. It stays free for that: nothing else in
             // chat wants it, and the composer has never had a use for it.
             ("<C-v>", "chat.image.paste", "Attach the image on the clipboard"),
-            // Beside it rather than somewhere else, because "that was the wrong screenshot" is
-            // one keystroke away from having taken it.
-            ("<M-v>", "chat.image.drop", "Take the last attached image off"),
+            // Taking one back off is `⌫` on an empty composer, handled below rather than bound
+            // here. It was `⌥V`, which is not a key: a Mac terminal turns Option-v into `√`
+            // unless its owner has been into the settings, and a keyboard whose Alt is a layer
+            // toggle cannot send it at all. `chat.image.drop` is still a command, so `^K` runs it
+            // and `init.ts` can put it back on a chord of your own.
         ] {
             let _ = self.editor.apply(&plugin, ApiCall::KeymapSet {
                 mode: Mode::Chat,
@@ -6631,16 +6660,7 @@ impl Host {
                     self.editor_message(MessageLevel::Warn, e);
                 }
             }
-            "chat.image.drop" => {
-                let here = self.active_session();
-                match self.attached.entry(here).or_default().pop() {
-                    None => self.editor_message(MessageLevel::Info, "nothing attached"),
-                    Some(a) => {
-                        self.editor_message(MessageLevel::Info, format!("took off {}", a.label()));
-                        self.refresh_composer();
-                    }
-                }
-            }
+            "chat.image.drop" => self.drop_attachment(),
             "chat.image.clear" => {
                 let here = self.active_session();
                 let n = self.attached.remove(&here).unwrap_or_default().len();

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -6881,20 +6881,26 @@ impl Host {
                 ),
             },
             // Widget keys. Space-separated lists in Neovim notation, so more than one key can mean
-            // the same thing — `<Down>` and `<C-n>` both move down, and adding a third is a
+            // the same thing — `<C-n>` and `<Down>` both move down, and adding a third is a
             // setting rather than a fork. Declared by the host rather than by whichever plugin
             // happens to open a picker first, because two plugins declaring the same option name
             // is an error and every plugin uses this widget library.
+            //
+            // **The chord comes first, and the arrow second.** The first key in the list is the
+            // one a widget prints on its hint row, and a legend is a promise about a keyboard:
+            // every terminal sends `^N`, while an arrow is a key some keyboards only have on a
+            // layer and some remote sessions mangle. Both work — this is the order they are
+            // *offered* in, not the set.
             OptionSpec {
                 name: "ui.keys.next".into(),
                 ty: OptionType::Str,
-                default: OptionValue::Str("<Down> <C-n> <C-j>".into()),
+                default: OptionValue::Str("<C-n> <Down> <C-j>".into()),
                 description: Some("Move down in a picker or completion list.".into()),
             },
             OptionSpec {
                 name: "ui.keys.prev".into(),
                 ty: OptionType::Str,
-                default: OptionValue::Str("<Up> <C-p> <C-k>".into()),
+                default: OptionValue::Str("<C-p> <Up> <C-k>".into()),
                 description: Some("Move up in a picker or completion list.".into()),
             },
             OptionSpec {

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -2756,13 +2756,13 @@ impl Host {
             rows.push(String::new());
         }
         // The keys worth knowing before the first question — and the one most people never find,
-        // which is that the transcript is a place you can go. The rest of the table is on F1.
+        // which is that the transcript is a place you can go. The rest of the table is on `^Z`.
         let keys: [(&str, &str); 5] = [
             (if ascii { "Enter" } else { "\u{23ce}" }, "send"),
             ("^S", "browse & copy"),
             ("^P", "model"),
             ("^T", "projects"),
-            ("F1", "every key"),
+            ("^Z", "every key"),
         ];
         let mut line = String::from("  ");
         let mut spans = Vec::new();
@@ -2771,7 +2771,7 @@ impl Host {
             // As many as fit, in the order they are worth knowing. A row of hints that wraps is
             // two rows of hints, the second of which starts mid-phrase — and the whole point of
             // this line is to be readable at a glance. `^S` is second because it is the one most
-            // people never find; the ones that get dropped first are the ones `F1` also names.
+            // people never find; the ones that get dropped first are the ones `^Z` also names.
             let would = sep.len() + key.chars().count() + 1 + label.chars().count();
             if i > 0 && line.chars().count() + would > width {
                 break;
@@ -6994,7 +6994,7 @@ impl Host {
                 default: OptionValue::Bool(false),
                 description: Some(
                     "Show a shortcut row under the composer. Off by default: the sidebar's footer \
-                     carries the same keys and `F1` carries all of them, so the row mostly cost \
+                     carries the same keys and `^Z` carries all of them, so the row mostly cost \
                      the transcript a line."
                         .into(),
                 ),

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -1354,9 +1354,9 @@ fn nothing_else_reaches_the_keyboard_while_the_option_sheet_is_open() {
 
 #[test]
 fn a_knob_row_says_it_is_a_control_before_you_press_anything() {
-    // A ladder with one rung lit reads identically whether or not `←→` do anything to it — which is
-    // how a live control came to look like a summary, and why `↵` on it (which means "done") felt
-    // like a key that does nothing at all.
+    // A ladder with one rung lit reads identically whether or not `h`/`l` do anything to it — which
+    // is how a live control came to look like a summary, and why `↵` on it (which means "done")
+    // felt like a key that does nothing at all.
     let sb = Sandbox::new("railsheet");
     let dir = sb.root.join("config/plugins/lab");
     std::fs::create_dir_all(&dir).expect("mkdir");
@@ -5733,7 +5733,7 @@ fn the_usage_panel_opens_with_the_plan_above_the_history() {
 /// The panel's keys are the panel's keys, bound to named commands.
 ///
 /// `t` and `c` are ordinary letters. Bound at buffer-kind scope they only fire here — and because
-/// they point at named commands rather than at a `switch` inside a handler, `F1` lists them and an
+/// they point at named commands rather than at a `switch` inside a handler, `^Z` lists them and an
 /// `init.ts` can move them. See ADR 0040.
 #[test]
 fn the_usage_panel_swaps_metric_on_its_own_key() {

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -3005,6 +3005,26 @@ fn the_key_list_opens_from_the_panel_and_any_key_dismisses_it() {
     assert!(s.pump(|s| s.windows_for(keys).is_empty()), "any key closes it\n{}", s.transcript());
 }
 
+/// The key list is reachable from the composer, and by a chord rather than by `F1`. Apple's top
+/// row is brightness until somebody finds the setting, so the key whose job is teaching every
+/// other key was the one key a new Mac could not press. See ADR 0048.
+#[test]
+fn the_key_list_opens_on_a_chord_from_the_composer() {
+    let sb = Sandbox::new("keylistchord");
+    let mut s = sb.start();
+    s.wait_for("PROJECTS");
+
+    s.ctrl("z");
+    s.wait_for("CHAT");
+    let keys = s.buffer_named("[keys]").expect("key list buffer");
+    assert!(
+        s.pump(|s| s.lines_of(keys).iter().any(|l| l.contains("Command palette"))),
+        "the live registry, not a written-down list\n{:?}",
+        s.lines_of(keys)
+    );
+    assert!(s.pump(|s| s.windows_for(keys).len() == 1), "it is on screen\n{}", s.transcript());
+}
+
 #[test]
 fn escape_leaves_the_thread_list_and_typing_goes_back_to_the_composer() {
     let sb = Sandbox::new("leave");
@@ -3710,7 +3730,7 @@ impl Session {
 #[test]
 fn the_shortcut_row_is_off_because_the_sidebar_already_says_all_of_it() {
     // It read as a good idea and was not. `^T`, `^N` and `^K` are in the sidebar's own footer two
-    // rows below, `F1` is on the row it points at, and what the duplication actually bought was
+    // rows below, `^Z` is on the row it points at, and what the duplication actually bought was
     // one fewer line of transcript and a composer pressed against the status strip.
     let sb = Sandbox::new("nohints");
     let mut s = sb.start();
@@ -3735,7 +3755,7 @@ fn the_shortcut_row_comes_back_if_you_ask_for_it() {
     // Waiting on a plugin's entry, not the host's: the host seeds `⏎ send` before any plugin has
     // loaded, so asserting on that alone would pass before the row was finished.
     assert!(
-        s.pump(|s| s.composer_chrome().iter().any(|t| t.contains("F1 keys"))),
+        s.pump(|s| s.composer_chrome().iter().any(|t| t.contains("^Z keys"))),
         "the way to the keys that did not fit\n{:?}",
         s.composer_chrome()
     );

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -645,7 +645,9 @@ fn the_key_strip_says_the_keys_that_are_actually_bound() {
     s.wait_for("PROJECTS");
     s.ctrl("k");
     assert!(
-        s.pump(|s| s.picker_named("[Go to]").iter().any(|l| l.contains("^y choose"))),
+        // `^Y`, capitalised: nobody presses shift to send it, and the capital is how a terminal
+        // has spelled a chord since curses.
+        s.pump(|s| s.picker_named("[Go to]").iter().any(|l| l.contains("^Y choose"))),
         "the strip follows the setting\n{:?}",
         s.picker_named("[Go to]")
     );

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -1380,7 +1380,8 @@ fn a_knob_row_says_it_is_a_control_before_you_press_anything() {
         s.transcript()
     );
     // And the key that changes something is named before the key that leaves.
-    assert!(s.saw("←→ change"), "the hints lead with the key that does the thing\n{}", s.transcript());
+    // Letters, not arrows: the arrows are bound too, and the row is a promise about a keyboard.
+    assert!(s.saw("h l change"), "the hints lead with the key that does the thing\n{}", s.transcript());
 }
 
 #[test]
@@ -5444,7 +5445,7 @@ fn a_third_party_verb_fires_on_its_key_with_the_row_it_was_pointed_at() {
 /// replace one.
 ///
 /// This is the claim the whole rewrite rests on. Before it, the panel resolved keys in a private
-/// switch statement: `F1` could not list them, `^K` could not run them, and rebinding `x` meant
+/// switch statement: `^Z` could not list them, `^K` could not run them, and rebinding `x` meant
 /// forking the plugin.
 #[test]
 fn the_panels_keys_are_in_the_registry_and_a_user_can_rebind_them() {

--- a/crates/neosh/tests/editing.rs
+++ b/crates/neosh/tests/editing.rs
@@ -691,6 +691,47 @@ fn a_paste_that_is_not_an_image_is_ordinary_text() {
     s.wait_composer(&[sentence.as_str()]);
 }
 
+/// Taking one back off is a key everybody has. It used to be `⌥V`, which is `√` on a Mac whose
+/// terminal has not been told to send Option as Alt — and a key that never arrives is one no
+/// amount of rebinding fixes. Backspace on an *empty* composer is what a chip row does everywhere
+/// else, and it costs the field nothing: there is nothing left to erase. See ADR 0048.
+#[test]
+fn backspace_on_an_empty_composer_takes_the_attachment_off() {
+    let sb = Sandbox::new("attachdrop");
+    let shot = png_at(&sb.root.join("work/shot.png"), 9, 9);
+    let mut s = sb.start();
+    s.ready();
+
+    s.send(&json!({"type": "paste", "text": shot.display().to_string()}));
+    s.type_text("what is this");
+    s.wait_composer(&["what is this"]);
+
+    // While there are words in the field, backspace is backspace. The attachment is not in the
+    // way of typing, which is the whole reason it is a chip and not a token.
+    s.special("backspace", &[]);
+    s.wait_composer(&["what is thi"]);
+
+    s.press(json!({"kind": "char", "c": "u"}), &["ctrl"]);
+    s.wait_composer(&[""]);
+    s.special("backspace", &[]);
+    assert!(
+        s.pump(|s| s.messages().iter().any(|m| m.contains("took off"))),
+        "the chip that went is said out loud — a row that becomes no row looks like a key that \
+         did nothing\n{:?}",
+        s.messages()
+    );
+
+    s.type_text("never mind");
+    s.wait_composer(&["never mind"]);
+    s.special("enter", &[]);
+    assert!(s.pump(|s| s.chat().iter().any(|l| l.contains("never mind"))), "the words were sent");
+    assert!(
+        !s.chat().iter().any(|l| l.contains("[png]")),
+        "and the picture was not\n{:?}",
+        s.chat()
+    );
+}
+
 /// What was attached has to be *in the message*, not only on the screen: the transcript is rebuilt
 /// from the conversation, and a picture that lives in the draft is one that vanishes on the first
 /// switch and was never sent to anything.

--- a/docs/adr/0000-index.md
+++ b/docs/adr/0000-index.md
@@ -53,3 +53,4 @@ implementation — and in two cases (0005, 0008) it did not, which is itself rec
 | [0045](0045-a-card-that-lands-says-so.md) | A card that lands says so | Accepted |
 | [0046](0046-a-worktree-lives-inside-its-project.md) | A worktree lives inside its project | Accepted |
 | [0047](0047-a-panel-that-has-the-keyboard.md) | A panel that has the keyboard | Accepted |
+| [0048](0048-a-key-every-terminal-sends.md) | A default binding is a key every terminal sends | Accepted |

--- a/docs/adr/0048-a-key-every-terminal-sends.md
+++ b/docs/adr/0048-a-key-every-terminal-sends.md
@@ -1,0 +1,97 @@
+# 0048 — A default binding is a key every terminal sends
+
+## What happened
+
+`F1` listed every binding neosh has. On a Mac out of the box it dimmed the screen: Apple's top row
+is brightness and volume until somebody opens *System Settings → Keyboard → Function Keys*, so the
+one key whose entire job was teaching the program the other keys was the one key a new user could
+not press. The documentation's answer was a paragraph explaining where that setting lives.
+
+`⌥↑` and `⌥↓` moved a rung up and down the capability ladder. macOS treats Option as a compose
+key — `⌥p` is `π` — so unless the terminal has been told to send Option as Alt, those two keys are
+`√` and a dead escape sequence. The documentation's answer was a table of five terminals and where
+each of them hides that setting. `⌥V`, which took an attached image back off, was in the same
+position.
+
+Three settings, in two other programs, for three keys. A key the program never receives is a key no
+amount of rebinding will fix, and a default that only works after a trip into somebody else's
+preferences is not a default — it is a bug with instructions attached.
+
+## What a terminal will actually send
+
+The set is smaller than it looks, and it is worth writing down because it is what every future key
+has to come out of:
+
+- **Ctrl with a letter.** Every terminal, every platform, same byte. Minus `^I`, `^M` and `^H`,
+  which *are* Tab, Enter and Backspace and cannot be told apart from them.
+- **`⇧⇥`, `⏎`, `⌫`, `Esc`.** Named keys with their own sequences.
+- **Printable characters**, in a mode that is not a text field.
+
+And what is *not* in it:
+
+- **Function keys**, for the reason above.
+- **Alt/Option**, for the reason above.
+- **Ctrl with punctuation.** In a plain terminal `Ctrl+/` and `Ctrl+7` are the same byte. The Kitty
+  keyboard protocol distinguishes them and neosh asks for it (see `docs/config.md`), but a default
+  cannot be conditional on a negotiation that half of terminals decline.
+- **`⌘`**, which is never sent at all without that protocol.
+
+Arrows, `PageUp`, `PageDown`, `Home` and `End` are a fourth category: real keys, sent reliably, and
+absent from some keyboards or reachable only on a layer. They are fine to *bind* and wrong to
+depend on.
+
+## The decision
+
+**A bundled default is a key from that set. Anything else is a key the user chooses.**
+
+Concretely:
+
+- The key list moved from `F1` to `^Z` — the one chord chat mode had left. Raw mode means it cannot
+  suspend anything, so nothing was displaced.
+- Taking an attached image off moved from `⌥V` to `⌫` **on an empty composer**, which is what a
+  chip row does everywhere else and needs no modifier anybody's terminal has an opinion about.
+- The capability ladder lost its keys and kept its commands. `model.upgrade` and `model.downgrade`
+  are ordinary commands: `^K` runs them by name, one line in `init.ts` binds them.
+- Arrows, `PgUp`, `PgDn`, `Home` and `End` stay bound everywhere they already were, and are never
+  the only way to do anything. Every list moves on `^N`/`^P` as well.
+
+## Why the ladder simply lost its key
+
+There was an obvious alternative: a prefix layer. Free one rarely-used chord — `^O`, say, whose job
+is also a row in the project panel — and spend it on `^O u`, `^O d`, `^O v`, `^O k`. Every homeless
+verb gets a key and there is room for the next one.
+
+It was the wrong trade. A prefix layer is a *concept*, paid for by everybody who ever reads the key
+table, to save two keystrokes for the people who use the ladder — who are already one keystroke
+from `^P`, which shows them the rungs with the current one lit. A capability that runs out of keys
+loses its key and keeps its command. Nothing is unreachable: `^K` finds it by name, `^Z` lists what
+is bound, and `init.ts` is where a key of your own goes.
+
+This is also why nothing ships bound to `<leader>`. In chat mode the leader is a character you are
+trying to type.
+
+## A hint row is a promise about a keyboard
+
+The second half, and the one that was quietly wrong for longer. `ui.keys.next` was
+`"<Down> <C-n> <C-j>"`, and widgets print the *first* key in that list on their hint row — so every
+picker in the program said `↑/↓ move` while `^N`/`^P` worked identically and went unmentioned.
+Somebody reading that row on a keyboard whose arrows are on a layer is being told, by the program,
+that they need a key they have to reach for.
+
+The defaults now lead with the chord: `"<C-n> <Down> <C-j>"`. Same set, different order, and the
+order is the part that gets read. `keyLabel` writes `^N` rather than `^n`, because nobody presses
+shift to send it and the capital is how a terminal program has spelled a chord since curses.
+
+Where a panel binds letters — the option sheet's `h j k l`, the project panel's `j k` — the letters
+are what the row says, for the same reason.
+
+## Consequences
+
+- Anyone who was pressing `F1`, `⌥↑`, `⌥↓` or `⌥V` has to rebind them. They are four lines, and
+  `docs/config.md` has them written out.
+- `^Z` no longer reaches a shell job-control convention some people have in their fingers. In raw
+  mode it never did — `ISIG` is off, so `^Z` was already an ordinary key press that nothing was
+  listening for.
+- One more chord is gone, and chat mode now has none left. The next capability that wants a global
+  key has to take one, replace one, or live on `^K` — which is the constraint working, not the
+  constraint failing.

--- a/docs/config.md
+++ b/docs/config.md
@@ -110,10 +110,10 @@ published `@neosh/api`, so the moment one reaches for something not public, the 
 | `sidebar` | Projects, conversations, changes, model, usage | `<C-b>` hide, `<C-t>` thread list, `<C-n>` new |
 | `model` | Model and reasoning-effort switchers, and the footer | `<C-p>`, `<C-e>` |
 | `git` | Status, branches, commits, diffs, worktrees | `<C-g>`, `<C-d>` |
-| `palette` | Everything by name, with its binding | `<C-k>`, `<F1>` |
+| `palette` | Everything by name, with its binding | `<C-k>`, `<C-z>` |
 | `approvals` | Asks before the agent does something gated | — |
 
-Press `<F1>` for the complete list; it is read from the registry, so it is never out of date.
+Press `<C-z>` for the complete list; it is read from the registry, so it is never out of date.
 
 Turn one off:
 
@@ -315,36 +315,41 @@ mapleader = ","
 timeoutlen = 500   # how long to wait for the rest of a sequence
 ```
 
-`^K` searches every command by name, and `F1` lists every binding — both read the live registry, so
+`^K` searches every command by name, and `^Z` lists every binding — both read the live registry, so
 a plugin loaded five minutes ago is in them without anything having been written down. Every picker
 carries a strip along its foot saying what it answers to, written from the bindings rather than from
 a string, so rebinding `ui.keys.*` changes what the strip says rather than making it a lie.
 
 `AGENTS.md` at the root of the repository has the whole key table in one place.
 
-### Your terminal decides which keys it can send
+### Every default is a key your terminal already sends
 
-A key neosh never receives is a key no amount of rebinding will fix, and two of the defaults are in
-that position on a Mac out of the box. Neither is a neosh setting — both are your terminal's.
+A key neosh never receives is a key no amount of rebinding will fix, so nothing ships bound to one
+that depends on a setting you have to go and find. In practice that rules out three families:
 
-**`F1` needs `fn` on macOS.** Apple's top row controls brightness and volume by default, so `F1`
-dims the screen and `fn`+`F1` is what reaches an application. Either press `fn`+`F1`, or turn on
-*System Settings → Keyboard → Keyboard Shortcuts → Function Keys → Use F1, F2, etc. as standard
-function keys*. Everything `F1` shows is also in `^K`, which needs no such arrangement.
+- **Function keys.** Apple's top row is brightness and volume until somebody turns on *Use F1, F2,
+  etc. as standard function keys*, so `F1` — the key that listed every key — was the one key a new
+  Mac could not press. The key list is `^Z`.
+- **Option / Alt.** macOS treats Option as a compose key: `⌥p` is `π`, not `Alt+p`, unless the
+  terminal has been told otherwise. The model ladder was `⌥↑`/`⌥↓` and now has no default key at
+  all; taking an attached image back off was `⌥V` and is now `⌫` on an empty composer.
+- **Ctrl with punctuation.** In a plain terminal `Ctrl+/` and `Ctrl+7` are the same byte. Neither
+  is a key worth binding — see enhanced keys, below.
 
-**`⌥↑` / `⌥↓` need Option-as-Alt.** macOS treats Option as a compose key — `⌥p` is `π`, not
-`Alt+p` — so a terminal has to be told to send it as a modifier instead:
+What is left is Ctrl-with-a-letter, `⇧⇥`, `⏎`, `⌫` and `Esc`, which every terminal on every
+platform sends the same way, plus the keys a keyboard may or may not have — arrows, `PageUp`,
+`Home`, `End`. Those last ones are bound wherever they make sense and are never the *only* way to
+do anything: every list moves on `^N`/`^P` as well as the arrows, and the hint strip prints the
+chord, because a legend is a promise about a keyboard.
 
-| Terminal | Setting |
-|---|---|
-| Terminal.app | Settings → Profiles → Keyboard → *Use Option as Meta key* |
-| iTerm2 | Settings → Profiles → Keys → Left Option key → *Esc+* |
-| Ghostty | `macos-option-as-alt = left` |
-| Alacritty | `option_as_alt = "Left"` |
-| kitty | `macos_option_as_alt left` |
+If you have the keys, use them, and if you want the ones that were dropped, they are one line each:
 
-Setting the *left* Option key only, where that is offered, keeps the right one for typing `£` and
-`—`.
+```ts
+await neosh.keymap.set("chat", "<F1>", "help.keys");
+await neosh.keymap.set("chat", "<A-Up>", "model.upgrade");
+await neosh.keymap.set("chat", "<A-Down>", "model.downgrade");
+await neosh.keymap.set("chat", "<A-v>", "chat.image.drop");
+```
 
 **Enhanced keys, where the terminal has them.** On startup neosh asks the terminal for the
 [Kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) — supported by kitty,
@@ -492,8 +497,8 @@ More than one key can mean the same thing:
 
 ```toml
 [options]
-"ui.keys.next" = "<Down> <C-n> <C-j>"
-"ui.keys.prev" = "<Up> <C-p> <C-k>"
+"ui.keys.next" = "<C-n> <Down> <C-j>"
+"ui.keys.prev" = "<C-p> <Up> <C-k>"
 "ui.keys.page_down" = "<PageDown>"
 "ui.keys.page_up" = "<PageUp>"
 "ui.keys.first" = "<C-Home>"
@@ -597,7 +602,7 @@ place to look for something that is already on screen. It also means those keys 
 on the shortcut row below — saying it twice costs a row and teaches nothing the first place did not.
 
 There is no shortcut row below by default, for the same reason. It carried `^T`, `^N` and `^K`,
-which are in the sidebar's own footer two rows away, and `F1`, which is on the row it points at.
+which are in the sidebar's own footer two rows away, and `^Z`, which is on the row it points at.
 What the duplication actually bought was one fewer line of transcript and a composer pressed
 against the status strip. `ui.hints = true` brings it back if you want it; the exception is reading
 mode, which draws its own row whatever the setting says, because those keys are live, different,
@@ -986,10 +991,14 @@ because every lineup worth switching between has three: Opus/Sonnet/Haiku, gpt-5
 Pro/Flash/Flash-Lite.
 
 ```
-<A-Up>      model.upgrade      one rung up, same provider
-<A-Down>    model.downgrade    one rung down
-            model.line opus    the current model in a line, wherever it is reachable
+model.upgrade      one rung up, same provider
+model.downgrade    one rung down
+model.line opus    the current model in a line, wherever it is reachable
 ```
+
+None of these has a default key. They had `⌥↑`/`⌥↓`, which is a key only on a terminal that has
+been told to send Option as Alt, and chat mode has no chord left to move them to — so they are
+commands you reach by name from `^K`, or put on a key of your own.
 
 `upgrade`/`downgrade` hold the provider fixed on purpose: "give me something cheaper" is a question
 about the model, and answering it by also changing your billing would answer a question nobody

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -386,7 +386,7 @@ await neosh.keymap.set("chat", "x", "acme.mine", {
 ```
 
 Resolution is window → buffer → kind → global, first match winning. Your binding is an ordinary one:
-`F1` lists it under the panel's section, `^K` runs the command, and the panel's own default loses to
+`^Z` lists it under the panel's section, `^K` runs the command, and the panel's own default loses to
 it because a default that overwrites a choice is not a default.
 
 Publish a kind for anything of yours that is more than a scratch buffer — it is one argument, and it

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,7 +23,7 @@ you out** — it cancels a running turn, then clears a draft, then offers to qui
 The bottom line shows the mode, the selected model, and those keys — if you see it, neosh is running.
 The panel on the left is the `sidebar` plugin; `<C-t>` moves into the thread list, `<C-b>` hides it,
 `<C-p>` picks a model, `<C-e>` its reasoning effort, `<C-g>` git status, `<C-d>` a diff, `<C-k>` the
-command palette, `<F1>` every binding there is.
+command palette, `<C-z>` every binding there is.
 
 ## Checking neosh
 

--- a/plugins/api/src/generated/StatusSegment.ts
+++ b/plugins/api/src/generated/StatusSegment.ts
@@ -7,7 +7,7 @@ import type { StatusAlign } from "./StatusAlign";
 export type StatusSegment = {
   text: string;
   /**
-   * The key that changes this, written the way the user would press it — `^P`, `F1`.
+   * The key that changes this, written the way the user would press it — `^P`, `^Z`.
    *
    * Beside what it acts on rather than in a list of its own, because a key is only memorable
    * once you have seen it next to the thing it does. A separate legend is a second place to

--- a/plugins/api/src/index.ts
+++ b/plugins/api/src/index.ts
@@ -972,7 +972,7 @@ export interface SessionApi {
  * built from what is actually registered right now, so a plugin that is switched off takes its
  * shortcut with it rather than leaving a key advertised that no longer does anything.
  *
- * Write the key the way the user would press it — `^P`, `⇧⏎`, `F1` — not the way a keymap spells
+ * Write the key the way the user would press it — `^P`, `⇧⏎`, `^Z` — not the way a keymap spells
  * it. Hints are dropped from the end when the terminal is too narrow, so put the one you would
  * most want seen at the lowest priority.
  */
@@ -989,7 +989,7 @@ export interface PermissionApi {
 export interface StatusApi {
   /**
    * `keys` is drawn immediately after `text`, dimmed — the key that changes this thing, beside the
-   * thing it changes. Write it the way the user would press it (`^P`, `F1`), not the way a keymap
+   * thing it changes. Write it the way the user would press it (`^P`, `^Z`), not the way a keymap
    * spells it.
    */
   set(
@@ -1102,7 +1102,7 @@ export function sessionScope(session: SessionId): VarScope {
  * it has never heard of, and neither side imports the other.
  *
  * Data rather than a callback on purpose. A contribution can be listed by the palette, described in
- * `F1` and disabled by the user, none of which is possible for a function held inside your closure.
+ * `^Z` and disabled by the user, none of which is possible for a function held inside your closure.
  *
  * Your contributions are withdrawn when your plugin unloads, so `plugins.disabled` takes your rows
  * with it and there is no way to leave a row behind pointing at a command that no longer exists.

--- a/plugins/api/src/ui.ts
+++ b/plugins/api/src/ui.ts
@@ -255,7 +255,13 @@ function keyLabel(keys: Map<WidgetAction, KeySpec[]>, action: WidgetAction): str
     "<CR>": "↵",
     "<Esc>": "esc",
   };
-  return pretty[spec.lhs] ?? spec.lhs.replace(/^<C-(.)>$/, "^$1").replace(/^<|>$/g, "");
+  // `^N`, not `^n`: nobody presses shift to send it, and the capital is how every terminal
+  // program has written a chord since curses. The first key of `ui.keys.*` is the one that
+  // reaches this — which is why the defaults lead with the chord and keep the arrow behind it.
+  return (
+    pretty[spec.lhs] ??
+    spec.lhs.replace(/^<C-(.)>$/, (_, c: string) => `^${c.toUpperCase()}`).replace(/^<|>$/g, "")
+  );
 }
 
 /**

--- a/plugins/builtin/model/main.ts
+++ b/plugins/builtin/model/main.ts
@@ -147,7 +147,7 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
   };
   await footer();
   // The sheet's own keys, bound to this plugin's buffer kind rather than handled privately — so
-  // `F1` lists them and `init.ts` can move any of them. See `options.ts`.
+  // `^Z` lists them and `init.ts` can move any of them. See `options.ts`.
   await installOptions({ neosh, subscriptions }, (flash) => footer(flash));
   subscriptions.push(neosh.session.onChange(() => void footer()));
   subscriptions.push(neosh.agent.onTurnEnd(() => void footer()));

--- a/plugins/builtin/model/main.ts
+++ b/plugins/builtin/model/main.ts
@@ -56,11 +56,17 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
 
   await neosh.keymap.set("chat", "<C-p>", "model.pick", { desc: "Pick a model" });
   await neosh.keymap.set("chat", "<C-e>", "model.options", { desc: "Pick reasoning effort" });
-  // Alt-arrows because they are unclaimed in every mode and mean "along an axis" in most editors.
-  // Rebind like anything else: every one of these is an ordinary command in the same table your
-  // own bindings live in.
-  await neosh.keymap.set("chat", "<A-Up>", "model.upgrade", { desc: "A more capable model" });
-  await neosh.keymap.set("chat", "<A-Down>", "model.downgrade", { desc: "A cheaper model" });
+  // The rungs have no default key. They had `⌥↑` and `⌥↓`, which read well and are not keys a
+  // terminal can be relied on to send: a Mac terminal turns Option-arrow into a word motion or an
+  // escape sequence depending on a setting its owner has probably never opened, and a keyboard
+  // whose arrows live on a layer cannot hold Alt and reach them at all. Chat mode has no chord
+  // left to move them to, and inventing a two-key prefix for two rungs is a worse trade than the
+  // one row of `^P` they are already on.
+  //
+  // They stay ordinary commands, which is the part that matters: `^K` runs them by name, and one
+  // line in `init.ts` puts them on whichever key your keyboard actually has.
+  //
+  //     await neosh.keymap.set("chat", "<A-Up>", "model.upgrade");
 
   // Deliberately *not* on the shortcut row. The key lives beside the model name in the footer,
   // where the thing it changes is already being read — saying it twice costs a row and teaches

--- a/plugins/builtin/model/options.ts
+++ b/plugins/builtin/model/options.ts
@@ -341,12 +341,13 @@ async function apply(
 /**
  * The keys, as words.
  *
- * `←→` first, because it is the key that *does* the thing and it used to be third — behind `↵`,
- * which closes. Read in order, the old line taught you that the way to use this panel was to
- * dismiss it.
+ * The key that *changes something* first: it used to be third, behind `↵`, which closes. Read in
+ * order, the old line taught you that the way to use this panel was to dismiss it.
  */
 function hintsFor(): string {
-  return "←→ change   ↑↓ knob   ⇥ cycle   ↵ done   esc close";
+  // Letters rather than arrows, and not because the arrows do not work — they are bound too. The
+  // row is a promise about a keyboard, and `h j k l` is a promise every keyboard keeps.
+  return "h l change   j k knob   ⇥ cycle   ↵ done   esc close";
 }
 
 export async function installOptions(

--- a/plugins/builtin/model/options.ts
+++ b/plugins/builtin/model/options.ts
@@ -10,13 +10,13 @@
  * fast mode or the context window existed. A setting you cannot see is a setting you do not have.
  *
  * So: every knob at once, one row each, values laid out along the row with the current one lit.
- * `←`/`→` moves along a row, `↑`/`↓` between rows, and what you are looking at *is* the state —
- * there is no "current value" to go and read somewhere else.
+ * `h`/`l` moves along a row and `j`/`k` between them — the arrows do the same — and what you are
+ * looking at *is* the state: there is no "current value" to go and read somewhere else.
  *
  * # Why it is a panel and not a private key handler
  *
  * Because ADR 0040 says so, and the sidebar proved why: every key here is an ordinary binding
- * pointed at a named command, scoped to this buffer's **kind**. `F1` lists them, `^K` runs them,
+ * pointed at a named command, scoped to this buffer's **kind**. `^Z` lists them, `^K` runs them,
  * and `init.ts` can move any of them. A `switch` on the key inside this file is exactly the thing
  * that rule replaced.
  *

--- a/plugins/builtin/palette/main.ts
+++ b/plugins/builtin/palette/main.ts
@@ -31,7 +31,7 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
     }),
   );
   // Registered once rather than per overlay: a command name is global, and re-registering it on
-  // every `<F1>` would leave the previous window's handler shadowed and its float on screen.
+  // every `<C-z>` would leave the previous window's handler shadowed and its float on screen.
   subscriptions.push(
     await neosh.cmd.register("help.keys.key", () => void dismissKeys?.(), {
       desc: "Dismiss the key list",
@@ -39,11 +39,16 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
   );
 
   await neosh.keymap.set("chat", "<C-k>", "commandPalette.toggle", { desc: "Command palette" });
-  await neosh.keymap.set("chat", "<F1>", "help.keys", { desc: "Key bindings" });
+  // `^Z` rather than `<F1>`. A function key is not a key everybody has: Apple's top row is
+  // brightness and volume until somebody goes into the settings, so the key that lists every key
+  // was the one key a new Mac could not press — and a keyboard whose F-row lives on a layer is in
+  // the same position. `^Z` is the one chord chat mode had left, every terminal delivers it
+  // identically, and raw mode means it cannot suspend anything. Rebind it like any other default.
+  await neosh.keymap.set("chat", "<C-z>", "help.keys", { desc: "Key bindings" });
 
   // Last on the row, and the way out of it: whatever else got dropped for width is in here.
   await neosh.hint.set("commands", { keys: "^K", label: "commands", priority: 30 });
-  await neosh.hint.set("keys", { keys: "F1", label: "keys", priority: 31 });
+  await neosh.hint.set("keys", { keys: "^Z", label: "keys", priority: 31 });
 }
 
 async function open(neosh: Neosh): Promise<void> {
@@ -196,7 +201,7 @@ async function showKeys(neosh: Neosh): Promise<void> {
   rows.push({ text: "" });
   rows.push({ text: "  any key closes this", heading: false });
 
-  // A second `<F1>` replaces the first window rather than stacking one behind it.
+  // A second `<C-z>` replaces the first window rather than stacking one behind it.
   await dismissKeys?.();
 
   const buf = await neosh.buf.create({ name: "[keys]", scratch: true });

--- a/plugins/builtin/questions/main.ts
+++ b/plugins/builtin/questions/main.ts
@@ -28,7 +28,7 @@
  * have to notice. While there is something typed the numbered shortcuts go away, which is how the
  * panel says a digit is a character now. See ADR 0037.
  *
- * **Every key is a named command.** `question.accept`, `question.next` — so `F1` lists them and an
+ * **Every key is a named command.** `question.accept`, `question.next` — so `^Z` lists them and an
  * `init.ts` can move them, and a third party can bind their own against the `neosh.question` buffer
  * kind without forking this. Only the printable keys come through the raw capture, and only because
  * they are text rather than verbs. See ADR 0040.

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -2699,7 +2699,7 @@ function hints(opts: DrawOptions): ListRow<Target>[] {
   const lines = !opts.focused
     // `^O` is not here and `+ Add project` is a row you can see: a key strip has two lines, and the
     // verb with a row of its own is the one that can afford to give up its place on them.
-    ? ["^T projects  ^N new   ^F archive", "^K palette   ^B hide  F1 keys"]
+    ? ["^T projects  ^N new   ^F archive", "^K palette   ^B hide  ^Z keys"]
     : kind === "project"
       // `X` is on the strip because a list you cannot shorten is a list that grows forever, and a
       // project that outlives its conversations — which is the point of it — has to have a way off.

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -21,7 +21,7 @@
  * resort rather than the first, and three things are here so that it usually is not necessary:
  *
  * - **Every key in this panel is an ordinary binding**, on the buffer kind `neosh.sidebar`, pointed
- *   at a command with a name. `F1` lists them, the palette runs them, and one line in your
+ *   at a command with a name. `^Z` lists them, the palette runs them, and one line in your
  *   `init.ts` moves any of them. There is no private switch statement any more — there was, and
  *   what it meant was that adding one key to this panel meant forking all twelve hundred lines of
  *   it.
@@ -133,7 +133,7 @@ interface SectionItem {
 interface ActionItem {
   /** Key notation, as `keymap.set` takes it: `d`, `<C-y>`, `gd`. */
   key: string;
-  /** What it does, for the hint strip and for `F1`. */
+  /** What it does, for the hint strip and for `^Z`. */
   label: string;
   command: string;
   /** Which rows it applies to. Defaults to `any`. */
@@ -740,7 +740,7 @@ async function registerCommands(w: Wiring): Promise<void> {
    * Register one verb, and bind it inside this panel.
    *
    * Every key in this list goes through here, which is the point: there is no private key handler
-   * any more, so `F1` lists the panel's keys with the rest, `^K` runs them, and
+   * any more, so `^Z` lists the panel's keys with the rest, `^K` runs them, and
    * `keymap.set("chat", "d", "…", { scope: { kind: "buf_kind", name: "neosh.sidebar" } })` from
    * anybody's `init.ts` replaces one. The scope is the buffer kind rather than the window, because
    * the window is opened and closed as you toggle the panel and a binding on it would go with it.
@@ -1045,7 +1045,7 @@ async function registerCommands(w: Wiring): Promise<void> {
  * conversation. Going through here, the command is invoked with the row as arguments and the
  * contributor never has to know the panel has a cursor at all.
  *
- * They are real bindings all the same. `F1` lists them with the contributed label, `^K` runs the
+ * They are real bindings all the same. `^Z` lists them with the contributed label, `^K` runs the
  * command, and a user who dislikes the key rebinds it exactly as they would one of ours.
  */
 function installActions(
@@ -1943,7 +1943,7 @@ async function openRemote(
 /**
  * The keys inside a remote view.
  *
- * Registered once and bound at buffer-kind scope, so `F1` lists them and `init.ts` can move them —
+ * Registered once and bound at buffer-kind scope, so `^Z` lists them and `init.ts` can move them —
  * the same deal every other panel key gets. Registered lazily rather than at activation because
  * most workspaces never open one.
  */

--- a/plugins/builtin/slash/main.ts
+++ b/plugins/builtin/slash/main.ts
@@ -152,7 +152,7 @@ async function show(neosh: Neosh, query: () => string, done: () => void): Promis
     // the catalogue — and a menu that eats a third of the transcript to say so is one you close
     // before reading.
     height: 8,
-    hints: "↵ run   ↑/↓ move   type to filter   esc keep typing",
+    hints: "↵ run   ^P/^N move   type to filter   esc keep typing",
   });
   done();
 

--- a/plugins/builtin/usage/main.ts
+++ b/plugins/builtin/usage/main.ts
@@ -22,7 +22,7 @@
  *
  * The strip is a `sidebar.section` contribution, so it can be turned off and something else put
  * there. The panel is a buffer with a `kind`, so its keys are bindable and a plugin can add rows to
- * it. Every key is a named command, so `F1` lists them and `init.ts` can move them. Nothing in this
+ * it. Every key is a named command, so `^Z` lists them and `init.ts` can move them. Nothing in this
  * file calls anything a third party could not.
  */
 
@@ -665,7 +665,7 @@ async function installPanel({ neosh, subscriptions }: PluginContext) {
     await neosh.win.close(w).catch(() => {});
   };
 
-  // Every key is a named command, so `F1` lists them and `init.ts` can move them. A `switch` on the
+  // Every key is a named command, so `^Z` lists them and `init.ts` can move them. A `switch` on the
   // key inside a handler is the thing this replaced — see ADR 0040.
   const cmd = async (name: string, desc: string, fn: () => void | Promise<void>) => {
     subscriptions.push(await neosh.cmd.register(`${NS}.${name}`, fn, { desc }));


### PR DESCRIPTION
## A default binding is a key every terminal sends

Three defaults needed a setting in somebody else's program before they arrived at all:

- **`F1`** — Apple's top row is brightness and volume until *Use F1, F2, etc. as standard function keys* is turned on, so the one key whose whole job was teaching the other keys was the one key a new Mac could not press.
- **`⌥↑` / `⌥↓`** (the capability ladder) and **`⌥V`** (drop the last attachment) — macOS treats Option as a compose key, so those were `√`, a word motion or nothing at all depending on a terminal setting their owner has probably never opened.

A key the program never receives is a key no amount of rebinding fixes, so the set a default may come from is now written down in ADR 0048 — and the docs section that explained where five terminals hide those settings is gone, replaced by the rule that made it unnecessary.

### Keys that moved

| Was | Now | |
|---|---|---|
| `F1` every key | `^Z` | the one chord chat mode had left; raw mode means it cannot suspend anything |
| `⌥V` drop the attachment | `⌫` on an empty composer | what a chip row does everywhere else; no modifier anybody's terminal has an opinion about |
| `⌥↑` `⌥↓` model ladder | *no default key* | `model.upgrade`/`model.downgrade` stay commands: `^K` runs them, `init.ts` binds them |

`PgUp`, `PgDn`, `^End`, `Home`/`End` and the arrows stay bound exactly where they were. They are simply never the *only* way to do anything.

Anyone who wants the old spellings gets them back in four lines, written out in `docs/config.md`.

### A hint row is a promise about a keyboard

`ui.keys.next` was `"<Down> <C-n> <C-j>"`, and a widget prints the **first** key of that list — so every picker said `↑/↓ move` while `^N`/`^P` worked identically and went unmentioned. The defaults now lead with the chord; same set, different order. `keyLabel` writes `^N` rather than `^n`. Panels that bind letters say the letters: the option sheet's row is now `h l change   j k knob`.

### Why the ladder simply lost its key

The obvious alternative was a prefix layer — free `^O` and spend it on `^O u` / `^O d` / `^O v` / `^O k`. That is a *concept*, paid for by everybody who reads the key table, to save two keystrokes for the people who are already one key away from `^P`. A capability that runs out of keys loses its key and keeps its command.

### Verification

Driven against the real binary with `scripts/shot.py`, not read off the source:

- `^Z` opens the key list; the welcome row reads `⏎ send   ^S browse & copy   ^P model   ^T projects   ^Z every key`
- the palette strip reads `↵ choose   ^P/^N move   type to filter   esc close`
- a pasted PNG shows `attached png 8×8 · 74 B  ⌫ take off`, and `⌫` on the empty composer answers `took off png 8×8 · 74 B`
- the `^E` sheet reads `h l change   j k knob   ⇥ cycle   ↵ done   esc close`

Suites: `neosh-core` (103), `builtin_plugins` (139), `editing` (23), `questions`, `user_config`, `workspace` — all green. Generated TypeScript regenerated and in sync; `plugins/api` and `plugins/builtin` type-check.

New tests: `the_key_list_opens_on_a_chord_from_the_composer`, and `backspace_on_an_empty_composer_takes_the_attachment_off` — which also asserts the half that would be a bug: while there are words in the field, backspace is backspace.
