### PR TITLE
A list you move in, a plan that is one row, and a card attached to what it did

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,24 @@ per decision, and records the *reasoning*, not the choice.
   default. A modal that borrows a global key to open itself owes a binding to close itself, which is
   why `^E` shuts the sheet from inside. Answering a question is not this: `^T` is how you reach a
   question waiting in another conversation. See ADR 0047.
+- **A list is a place you move in.** Anywhere there is a cursor over rows and no text field — the
+  project panel, the transcript reader — the motions are Vim's and they take a count: `5j` is five
+  rows you can *land on*, `^D`/`^U` are half of the panel's real height, `12G` is a row rather than
+  twelve of anything, and a half-typed count is on screen because a first press with no visible
+  effect is indistinguishable from a key that does nothing. The motion after it spends it and
+  anything else ends it. Not in the core, and not in a picker: the panel keys live in `chat` mode,
+  which is the mode the composer types in, so a digit that became a count globally is a digit you
+  could no longer send. Two more things belong to the same list: the row you are *in* stays
+  unfolded (`ListRow.expand`, and only ever one row — the cursor is what asks, everywhere else),
+  and the foot is held against the bottom edge (`render({ pinned })`, padded in *drawn lines*
+  because an unfolded row is several). A dock resizes in place with `win.resize` — reopening gives
+  the window a new id and drops the keyboard, so a panel resized from inside itself used to throw
+  you back to the composer on every press. And what a foot *says* is on the same budget: the plan
+  strip is the one limit that would refuse the next request, plus anything else already critical,
+  because three bars and a name and a sentence is five rows of a column whose job is your
+  conversations. `⇥` steps it up to every window and then to all of it — contributed as a
+  `sidebar.action` with `on: "custom"`, which is how a plugin puts a key on rows it owns rather
+  than on every row in somebody else's panel. See ADR 0048.
 - **Pairing is a decision each machine makes, and neither of them restarts.** A node presents its
   identity to anyone who connects — as an SSH server presents a host key — so adding a computer is
   typing an address and being shown a name and a fingerprint that came from the far end. The other
@@ -230,8 +248,10 @@ per decision, and records the *reasoning*, not the choice.
   read off the arguments, like the colour. A call nothing here classifies keeps the name its author
   gave it, so a plugin's tool is never renamed. **A command's output folds from the middle**: the
   head is how it started and the tail is what it decided, and it is the second one you were waiting
-  for. And **one row of air between actions**, which is the cheapest structure there is. See ADR
-  0040.
+  for. **A card is attached to what it did**: no blank row above it, and its body under a corner
+  (`└`) at a four-column indent rather than a rule down the whole left side. Air between every two
+  actions and a wall beside every diff were both structure said twice — the header is at column
+  zero, the body is indented, and that is already a list. See ADR 0040 and ADR 0049.
 - **A terminal cannot paste a picture, so pasting one is a key.** Bracketed paste is a text
   protocol: a screenshot arrives as nothing, and a dragged file arrives as its path. `^V` asks the
   system clipboard through whichever of `wl-paste`/`xclip`/`pngpaste`/`osascript`/`powershell` is
@@ -261,6 +281,11 @@ per decision, and records the *reasoning*, not the choice.
   clips or pads every frame to the width of the run underneath, so a spinner can never move the
   column after it. The buffer keeps the glyph that was written — a frame is what a cell looks like,
   not what the line says. See ADR 0045.
+- **Compaction moves the meter, because compaction is what moved the context.** A driver that has
+  once answered "how full is it" turns off the estimate derived from usage, so the next answer only
+  arrives with the next request — and a `Compacted` whose `after` nobody applied left the footer
+  reporting the pre-compaction number for the rest of the conversation, under a card that said
+  `180k → 12k`. See ADR 0049.
 - **What the plan has left cannot be counted, only reported and then kept.** A subscription's
   allowance is opaque and is not a function of anything on this machine — a turn run in `claude`
   directly spent it too. `claude` says so on a `rate_limit_event` line and `codex` on
@@ -373,7 +398,7 @@ registry — this table is what ships.
 | `^B` | Toggle the sidebar |
 | `^K` | Command palette |
 | `/` | Completes a command by name — neosh's, and whatever the agent says it accepts. Keep typing; the composer is still the field, and `↵` sends what you typed when nothing matches |
-| `^L` | What the plan has left, and where the week went. Live gauges per limit, and the last 30 days from the agents' own transcripts |
+| `^L` | What the plan has left, and where the week went. Live gauges per limit, and the last 30 days from the agents' own transcripts. The sidebar keeps one row of it; `⇥` on that row asks for more |
 | `^G` | Git status |
 | `^D` | Show what changed |
 | `^S` | Read the transcript — see below |
@@ -412,11 +437,11 @@ Two corollaries, both of which were bugs:
 
 | Key | Does |
 |---|---|
-| `hjkl`, arrows | Move |
+| `hjkl`, arrows | Move. A count first does it that many times: `5j` |
 | `w` `b` | By word |
 | `0` `$` | Ends of the line |
-| `gg` `G` | Ends of the transcript |
-| `^D` `^U` | Half a screen |
+| `gg` `G` | Ends of the transcript. With a count it is a row: `12G`, `12gg` |
+| `^D` `^U` | Half a screen, or that many of them |
 | `^F` `^B`, `PgUp`/`PgDn` | A screen |
 | `zz` `zt` `zb` | Put the cursor's line in the middle, at the top, at the bottom |
 | `[` `]` | Previous / next **turn** |
@@ -460,7 +485,10 @@ says how many are asking, `^T` is where you go, and it opens when you get there.
 | Key | Does |
 |---|---|
 | `↵` | Open a conversation, fold a project, or add one from the `+` row |
-| `j` `k` | Move |
+| `j` `k` | Move. With a count, that many rows you can land on: `5j` |
+| `^D` `^U` | Half a screen; `PgUp`/`PgDn` for a whole one. Not `^F`/`^B` — those stay the archive and hiding the panel |
+| `gg` `G` | The ends of the list, and `5gg` / `5G` for the fifth row |
+| `>` `<` `=` | Wider, narrower, back to the default. It is the `sidebar.width` setting, so `config.toml` and this key say the same number |
 | `n` | New conversation — the same question `^N` asks, about the project the cursor is on |
 | `o` | Add a project |
 | `f` | Pin a project to the top |
@@ -468,6 +496,7 @@ says how many are asking, `^T` is where you go, and it opens when you get there.
 | `r` | Rename a conversation |
 | `x` `X` | Archive, delete. On a project heading, `X` takes the project off the list — the only thing that does |
 | `a` | The archive. Nothing archived is ever a row in this panel — `↵` restores one, `^U` puts it back without going there, `^X` deletes |
+| `⇥` | On the plan rows: how much of it to show — the limit that binds, every limit, or all of it with the account and the sentence. `usage.sidebar.style` is where it starts, `usage.sidebar` turns it off |
 | `?` | The keys for whatever row you are on |
 | `Esc` | Back to the composer |
 

--- a/crates/neosh-core/src/editor.rs
+++ b/crates/neosh-core/src/editor.rs
@@ -766,6 +766,24 @@ impl Editor {
                 });
                 Ok(ApiOk::Unit)
             }
+            ApiCall::WinResize { win, size } => {
+                let layout = match &self.win(win)?.layout {
+                    WindowLayout::Docked { dock, gravity, wrap, .. } => WindowLayout::Docked {
+                        dock: *dock,
+                        size,
+                        gravity: *gravity,
+                        wrap: *wrap,
+                    },
+                    WindowLayout::Float { .. } => {
+                        return Err(ApiError::InvalidArgument {
+                            message: "win_resize is for docked windows; a float is configured with float_configure".into(),
+                        });
+                    }
+                };
+                self.win_mut(win)?.layout = layout.clone();
+                self.push_ui(UiEvent::WindowConfigured { win, layout });
+                Ok(ApiOk::Unit)
+            }
             ApiCall::WinClose { win } => {
                 self.win(win)?;
                 self.windows.remove(&win);

--- a/crates/neosh-proto/src/api.rs
+++ b/crates/neosh-proto/src/api.rs
@@ -274,6 +274,17 @@ pub enum ApiCall {
     WinClose {
         win: WindowId,
     },
+    /// Change how wide (or tall) a docked window is, without closing it.
+    ///
+    /// Reopening was the only way to resize a dock, and reopening is not the same thing: the window
+    /// id changes, whatever had the keyboard loses it, and a panel resized from inside itself would
+    /// throw you back to the composer on every press. `None` gives the dock back its default
+    /// extent. A float is configured through [`ApiCall::FloatConfigure`] and is refused here — the
+    /// two have nothing in common but the word.
+    WinResize {
+        win: WindowId,
+        size: Option<u16>,
+    },
     WinSetBuf {
         win: WindowId,
         buf: BufferId,

--- a/crates/neosh/src/cards.rs
+++ b/crates/neosh/src/cards.rs
@@ -77,14 +77,15 @@ pub struct Glyphs {
     /// already says. What is news is a call still out and a call that went wrong, so those are the
     /// two that get a mark and finished ones get the blank of the same width.
     pub fail: &'static str,
-    /// The rule down the left of what a tool came back with.
+    /// The corner on the first row of what a tool came back with.
     ///
-    /// A rule and not an elbow. An elbow marks where a body *starts*, which is the one thing a
-    /// body's position under its header already says; it leaves the other forty rows unmarked, so
-    /// a long result has no visible extent and reads as loose text that happens to be indented.
-    /// A rule answers the question that is actually open — how far does this go — and costs three
-    /// columns less, which on a diff is three columns of code.
-    pub rule: &'static str,
+    /// It used to be a rule down the whole left side, on the argument that a long body needs its
+    /// extent marked. What that actually produced was a wall: forty rows each saying the same
+    /// thing, down the side of a diff whose own colours are the thing to read, in a column already
+    /// carrying an indent that says the same. The corner says where a body *starts* — which is the
+    /// one moment the eye needs telling, now that a card no longer has a blank row above it — and
+    /// the indent carries the rest.
+    pub elbow: &'static str,
     /// Unchanged lines a diff is not showing.
     pub fold: &'static str,
     /// The mark on the row that stands in for what is not being shown.
@@ -110,7 +111,7 @@ impl Glyphs {
                 bar: "|",
                 live: ">",
                 fail: "x",
-                rule: "|",
+                elbow: "\\",
                 fold: ":",
                 elision: "...",
                 between: "...",
@@ -126,7 +127,7 @@ impl Glyphs {
                 bar: "\u{258c}",
                 live: "\u{25b8}",
                 fail: "\u{2717}",
-                rule: "\u{2502}",
+                elbow: "\u{2514}",
                 fold: "\u{22ee}",
                 elision: "\u{2026}",
                 between: "\u{22ef}",
@@ -140,17 +141,24 @@ impl Glyphs {
         }
     }
 
-    /// What every row of a card body starts with: two columns of indent, the rule, one space.
+    /// What every row of a card body starts with: four columns of indent.
     ///
-    /// The same on the first row as on the last, which is the whole point of it being a rule.
+    /// Four rather than two because the first row of a body wears a corner in the same space —
+    /// see [`Glyphs::opener`] — and a body whose first line is indented differently from the rest
+    /// of it is a body that reads as two things.
     fn margin(&self) -> String {
-        format!("  {} ", self.rule)
+        "    ".into()
+    }
+
+    /// The first row of a body: the same four columns, with the corner in them.
+    fn opener(&self) -> String {
+        format!("  {} ", self.elbow)
     }
 
     /// The two columns a card's header opens with: a mark, when the state is news, and a space.
     ///
     /// Always two columns wide, so the names line up down the column whatever each card is doing,
-    /// and so the rule under a card sits directly beneath the name it belongs to.
+    /// and so a card's body sits directly beneath the name it belongs to.
     fn mark(&self, state: ToolState) -> (&'static str, &'static str) {
         match state {
             ToolState::Running => (self.live, "Agent.ToolRunning"),
@@ -506,7 +514,7 @@ pub fn exit_code(content: &str) -> Option<i64> {
 /// there is already the claim that the call happened. So the column holds a mark only while the
 /// call is out — where it sweeps, and is then the one moving thing in the transcript — or when the
 /// call failed. Otherwise it is two blanks of the same width, which keeps the names in a column
-/// and puts the body's rule directly under the name it belongs to.
+/// and puts the body's corner directly under the name it belongs to.
 ///
 /// The subject sits after the name with a gap, rather than inside brackets. `Edit(src/main.rs)`
 /// reads as a function call, which is what it is on the wire and not what it is on screen: what
@@ -706,11 +714,11 @@ pub fn group_header(g: &Glyphs, heads: &[Head], root: &std::path::Path, width: u
     Row::new(text, spans)
 }
 
-/// What an opened run shows: one row per call, under the rule.
+/// What an opened run shows: one row per call, under the header.
 ///
 /// ```text
-///   │ Read  crates/neosh/src/host.rs  620 lines
-///   │ Grep  fn header  12 lines
+///   └ Read  crates/neosh/src/host.rs  620 lines
+///     Grep  fn header  12 lines
 /// ```
 ///
 /// The full subject rather than the short name the folded row uses, because "which file" is the
@@ -729,7 +737,7 @@ pub fn group_body(
     }
     let margin = g.margin();
     let room = width.saturating_sub(margin.chars().count()).max(8);
-    heads
+    let mut rows: Vec<Row> = heads
         .iter()
         .map(|h| {
             let (text, spans) = label(h, root, room);
@@ -738,7 +746,9 @@ pub fn group_body(
             all.extend(spans.into_iter().map(|(a, b, hl)| (at + a, at + b, hl)));
             Row::new(format!("{margin}{text}"), all)
         })
-        .collect()
+        .collect();
+    attach(g, &mut rows);
+    rows
 }
 
 /// Whether two calls may share one card: both only looked at something.
@@ -978,23 +988,23 @@ fn clip(text: &str, room: usize) -> String {
 
 /// What goes under a header once the call has come back.
 ///
-/// For an edit that worked, the change itself — a rule down the left, a line number where one is
-/// known, a sign, and the code, syntax-coloured, on a band that says which way it went:
+/// For an edit that worked, the change itself — a corner where it starts, a line number where one
+/// is known, a sign, and the code, syntax-coloured, on a band that says which way it went:
 ///
 /// ```text
-///   │ 142    impl Session {
-///   │ 143  - let x = 1;
-///   │ 143  + let x = 2;
-///   │ ⋮ 4 unchanged
+///   └ 142    impl Session {
+///     143  - let x = 1;
+///     143  + let x = 2;
+///     ⋮ 4 unchanged
 /// ```
 ///
 /// For anything else — and for an edit that failed, whose error is the thing to read — what came
-/// back, under the same rule:
+/// back, at the same indent:
 ///
 /// ```text
-///   │ hello
-///   │ world
-///   │ … +2 more lines (^S ⇥ to expand)
+///   └ hello
+///     world
+///     … +2 more lines (^S ⇥ to expand)
 /// ```
 ///
 /// Folded to `limits` rows unless `expanded`, because the point is to see that something happened
@@ -1010,17 +1020,38 @@ pub fn body(
     expanded: bool,
     width: usize,
 ) -> Vec<Row> {
-    if !result.is_error {
-        let changes = edits_of(input);
-        if !changes.is_empty() {
-            return diff_rows(g, &changes, limits.diff_lines, expanded, width);
-        }
+    let mut rows = if !result.is_error && !edits_of(input).is_empty() {
+        diff_rows(g, &edits_of(input), limits.diff_lines, expanded, width)
+    } else if !result.is_error && !expanded && looks_at_something(input) {
         // Folded to the header alone. The count is already on it, and `⇥` opens this.
-        if !expanded && looks_at_something(input) {
-            return Vec::new();
-        }
+        Vec::new()
+    } else {
+        result_rows(g, result, limits.output_lines, expanded, width)
+    };
+    attach(g, &mut rows);
+    rows
+}
+
+/// Put the corner on the first row of a body.
+///
+/// Done here rather than in each builder because every one of them lays a row out from
+/// [`Glyphs::margin`] and counts its spans from the end of it — so the corner is a swap of the
+/// first four columns and a shift of whatever that row's spans said about them, in one place, and
+/// nothing downstream has to know there are two kinds of margin.
+fn attach(g: &Glyphs, rows: &mut [Row]) {
+    let Some(first) = rows.first_mut() else { return };
+    let (from, to) = (g.margin(), g.opener());
+    if !first.text.starts_with(&from) {
+        return;
     }
-    result_rows(g, result, limits.output_lines, expanded, width)
+    first.text = format!("{to}{}", &first.text[from.len()..]);
+    // Byte offsets, so the two margins being the same *width* is not the same as being the same
+    // length: `└` is three bytes and a space is one.
+    let shift = |x: usize| if x >= from.len() { x + to.len() - from.len() } else { x };
+    for (a, b, _) in &mut first.spans {
+        *a = shift(*a);
+        *b = shift(*b);
+    }
 }
 
 /// The row that stands in for what is not being shown.
@@ -1045,9 +1076,9 @@ fn trailer(g: &Glyphs, margin: &str, rest: usize, what: &str) -> Row {
 /// gets one row, the tail gets the rest, and the count of what fell out sits between them.
 ///
 /// ```text
-///   │    Compiling neosh v0.1.0
-///   │ … +4 lines (^S ⇥ to expand)
-///   │ test result: ok. 12 passed
+///   └    Compiling neosh v0.1.0
+///     … +4 lines (^S ⇥ to expand)
+///     test result: ok. 12 passed
 /// ```
 ///
 /// One row of head rather than half: what the head is *for* is telling you which command's output
@@ -1144,7 +1175,7 @@ fn look(op: diff::Op) -> (&'static str, Option<&'static str>, &'static str, &'st
 
 /// The change itself.
 ///
-/// Three columns and then the code: the rule, the line number if anyone knew it, and the sign. The
+/// Three columns and then the code: the margin, the line number if anyone knew it, and the sign. The
 /// sign stays even though the band already says the same thing, because the band is the first thing
 /// to go — on a sixteen-colour terminal, under `NO_COLOR`, in a screenshot somebody pasted into a
 /// ticket — and a diff whose two halves are told apart by nothing at all is not a diff. It is the
@@ -1267,7 +1298,7 @@ fn paint(change: &Change) -> Option<Vec<neosh_syntax::Spans>> {
 ///
 /// Long lines wrap rather than being cut. A clipped line of prose has lost an adjective; a clipped
 /// line of code has lost the half of it you were about to read, and there is no scrolling sideways
-/// to get it back. The continuation carries the band and the rule and nothing else — no repeated
+/// to get it back. The continuation carries the band and the margin and nothing else — no repeated
 /// sign, no repeated number, because both of those are facts about *a line* and this is still the
 /// same one.
 fn code_rows(
@@ -1341,7 +1372,7 @@ fn shift(spans: &neosh_syntax::Spans, from: usize, to: usize, at: usize) -> Vec<
 /// made here and for the same reason: the frontend owns width, wraps whatever still overflows, and
 /// re-wrapping something already close to right is invisible. Doing it here at all is what buys the
 /// continuation rows their indent — a line the frontend wraps starts again at column zero, under
-/// the rule rather than beside it.
+/// the margin rather than beside it.
 fn split_at_width(text: &str, room: usize) -> Vec<(usize, String)> {
     let chars: Vec<(usize, char)> = text.char_indices().collect();
     if chars.len() <= room {
@@ -1683,8 +1714,8 @@ mod tests {
         // Opened, every call gets its own row with the *whole* subject: the short names on the
         // folded row are the loose answer, and this is where it is exact.
         assert_eq!(texts(&rows), vec![
-            "  \u{2502} Read  deep/down/a.rs  120 lines",
-            "  \u{2502} Searched  fn main  3 lines",
+            "  \u{2514} Read  deep/down/a.rs  120 lines",
+            "    Searched  fn main  3 lines",
         ]);
     }
 
@@ -1766,7 +1797,7 @@ mod tests {
         assert!(t[1].contains("\u{2026} +"), "then what was dropped: {t:?}");
         assert!(t.last().unwrap().ends_with("test result: ok. 12 passed"), "the answer: {t:?}");
         // And no row is spent on a blank line, of which that output has two.
-        assert!(t.iter().all(|r| !r.trim_end().ends_with('\u{2502}')), "{t:?}");
+        assert!(t.iter().all(|r| !r.trim().is_empty()), "{t:?}");
     }
 
     #[test]
@@ -1822,7 +1853,7 @@ mod tests {
         let result = neosh_proto::ToolResult::ok("ok");
         let rows = body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 3 }, false, 80);
         let t = texts(&rows);
-        assert_eq!(t[0], "  \u{2502}   l8", "context first, no gap row at the top: {t:?}");
+        assert_eq!(t[0], "  \u{2514}   l8", "context first, no gap row at the top: {t:?}");
         assert!(t.iter().any(|r| r.ends_with("- l10")), "{t:?}");
         assert!(t.iter().any(|r| r.ends_with("+ L10")), "{t:?}");
         assert!(!t.iter().any(|r| r.contains("unchanged")), "no gap at either end: {t:?}");
@@ -1872,7 +1903,7 @@ mod tests {
         let input = json!({ "file_path": "/work/a.rs", "old_string": "a\nb", "new_string": "a\nc" });
         let result = neosh_proto::ToolResult::ok("ok");
         let rows = body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 3 }, false, 80);
-        assert_eq!(texts(&rows), vec!["  \u{2502}   a", "  \u{2502} - b", "  \u{2502} + c"]);
+        assert_eq!(texts(&rows), vec!["  \u{2514}   a", "    - b", "    + c"]);
     }
 
     #[test]
@@ -1880,7 +1911,7 @@ mod tests {
         let input = json!({ "file_path": "/work/a.rs", "old_string": "a", "new_string": "b" });
         let result = neosh_proto::ToolResult::error("old_string not found");
         let rows = body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 0 }, false, 80);
-        assert_eq!(texts(&rows), vec!["  \u{2502} old_string not found"]);
+        assert_eq!(texts(&rows), vec!["  \u{2514} old_string not found"]);
         assert_eq!(rows[0].spans[0].2, "Agent.ToolError");
     }
 
@@ -1893,9 +1924,9 @@ mod tests {
         // One line of head, then what was dropped, then the end — which for a command is the
         // answer. Folding from the end would keep `one` and `two` and throw away the result.
         assert_eq!(t, vec![
-            "  \u{2502} one",
-            "  \u{2502} \u{2026} +2 lines (^S \u{21e5} to expand)",
-            "  \u{2502} four",
+            "  \u{2514} one",
+            "    \u{2026} +2 lines (^S \u{21e5} to expand)",
+            "    four",
         ]);
         let open = body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 2 }, true, 80);
         assert_eq!(texts(&open).len(), 4);
@@ -1960,7 +1991,7 @@ mod tests {
         });
         let rows =
             body(&g(), &strings, &result, Limits { diff_lines: 12, output_lines: 3 }, false, 80);
-        assert_eq!(texts(&rows), vec!["  \u{2502} -     let x = 1;", "  \u{2502} +     let x = 2;"]);
+        assert_eq!(texts(&rows), vec!["  \u{2514} -     let x = 1;", "    +     let x = 2;"]);
     }
 
     #[test]
@@ -2013,7 +2044,7 @@ mod tests {
         // get by pressing `⇥`.
         let rows = body(&g(), &json!({"file_path": "/work/a.rs"}), &result,
             Limits { diff_lines: 12, output_lines: 3 }, true, 80);
-        assert_eq!(texts(&rows), vec!["  \u{2502}      1    impl Session {"]);
+        assert_eq!(texts(&rows), vec!["  \u{2514}      1    impl Session {"]);
     }
 
     /// A turn that reads six files should read as six rows, not as thirty.
@@ -2042,7 +2073,7 @@ mod tests {
         let input = json!({"path": "/work/gone.rs"});
         let result = neosh_proto::ToolResult::error("no such file");
         let rows = body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 3 }, false, 80);
-        assert_eq!(texts(&rows), vec!["  \u{2502} no such file"]);
+        assert_eq!(texts(&rows), vec!["  \u{2514} no such file"]);
     }
 
     /// A command's output *is* its answer, so it keeps its body — and its header does not repeat
@@ -2062,7 +2093,7 @@ mod tests {
     fn a_limit_of_zero_counts_a_result_and_hides_a_diff() {
         let result = neosh_proto::ToolResult::ok("one\ntwo");
         let rows = body(&g(), &json!({}), &result, Limits { diff_lines: 0, output_lines: 0 }, false, 80);
-        assert_eq!(texts(&rows), vec!["  \u{2502} 2 lines"]);
+        assert_eq!(texts(&rows), vec!["  \u{2514} 2 lines"]);
         let input = json!({ "file_path": "/work/a.rs", "old_string": "a", "new_string": "b" });
         let rows = body(&g(), &input, &result, Limits { diff_lines: 0, output_lines: 3 }, false, 80);
         assert!(rows.is_empty(), "the header already has the stats: {:?}", texts(&rows));
@@ -2160,6 +2191,6 @@ mod tests {
         let g = Glyphs::new(true);
         let result = neosh_proto::ToolResult::ok("one\ntwo");
         let rows = body(&g, &json!({}), &result, Limits { diff_lines: 12, output_lines: 1 }, false, 80);
-        assert_eq!(texts(&rows), vec!["  | ... +1 line (^S Tab to expand)", "  | two"]);
+        assert_eq!(texts(&rows), vec!["  \\ ... +1 line (^S Tab to expand)", "    two"]);
     }
 }

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -264,6 +264,13 @@ pub struct Host {
     /// Cleared by the key that follows, whatever it is, so a mistyped second key ends the sequence
     /// instead of leaving the next unrelated press to be swallowed by it.
     reading_pending: Option<char>,
+    /// A count typed before a motion in the transcript — `5j`, `12G`.
+    ///
+    /// Kept as the digits rather than a number so that it can be shown while it is half typed: a
+    /// count is two keystrokes with nothing between them, and the first one is otherwise a press
+    /// that appears to have done nothing at all. Ended by whatever motion spends it, and by any
+    /// key that is not one.
+    reading_count: String,
     /// Whether the running selection takes whole lines — `V` rather than `v`.
     ///
     /// A flag rather than a second kind of selection, because there is one selection model here and
@@ -711,6 +718,7 @@ impl Host {
             keys_touched: false,
             reading: false,
             reading_pending: None,
+            reading_count: String::new(),
             reading_linewise: false,
             search: None,
             searched: String::new(),
@@ -2616,6 +2624,14 @@ impl Host {
             used += display_width(head);
             out.push(chunk(head, "Status.Pending"));
         }
+        // A count that has been typed and not yet spent. It goes first because it is about the key
+        // you are in the middle of pressing, and without it the digit is a press with no effect —
+        // which is indistinguishable from a key that does nothing.
+        if !self.reading_count.is_empty() {
+            let head = format!("{}  ", self.reading_count);
+            used += display_width(&head);
+            out.push(chunk(head, "Accent"));
+        }
         for (keys, label) in pairs {
             let gap = if out.len() > usize::from(self.reading_pending.is_some()) { 2 } else { 0 };
             let cost = gap + display_width(keys) + 1 + display_width(label);
@@ -3382,6 +3398,7 @@ impl Host {
         }
         self.reading = false;
         self.reading_pending = None;
+        self.reading_count.clear();
         self.reading_linewise = false;
         self.editor.set_mode(self.mode_before_reading);
         self.clear_matches();
@@ -3407,6 +3424,29 @@ impl Host {
         };
         let select = self.chat_anchored() || key.mods.shift;
 
+        // A count, typed before the motion it belongs to. Digits first, because `0` is also a
+        // motion: it is the start of the line when nothing is pending and part of the number when
+        // something is, which is what it means everywhere else these keys come from.
+        if !key.mods.ctrl
+            && !key.mods.alt
+            && self.reading_pending.is_none()
+            && let Some(d) = ch.chars().next().filter(char::is_ascii_digit)
+            && !(d == '0' && self.reading_count.is_empty())
+        {
+            // Three digits is already more rows than any transcript has on screen, and it is what
+            // stops a leant-on key growing a string without end.
+            if self.reading_count.len() < 3 {
+                self.reading_count.push(d);
+            }
+            self.refresh_composer();
+            return;
+        }
+        // Whatever was typed, the motion that follows is the only thing that spends it — so take it
+        // here and let every arm below run with it already gone. A key that is not a motion
+        // therefore ends the count, which is what makes a half-typed one abandonable.
+        let typed = self.take_reading_count();
+        let count = typed.unwrap_or(1);
+
         // Chords first — before the pending pair and before the plain motions, because a chord is
         // a different key and not a modified one. Read after them, `^B` was matched by the `b` arm
         // of the motion table and moved a word left, `^Y` opened a pending yank, and `^E` moved a
@@ -3414,14 +3454,15 @@ impl Host {
         // share. `<C-d>`/`<C-u>` are half a screen because that is what they are everywhere; a full
         // screen with no overlap loses the line you were reading.
         let page = self.chat_height().max(2);
+        let n = count as i64;
         if key.mods.ctrl {
             match ch {
-                "d" => return self.reading_by(page as i64 / 2, select),
-                "u" => return self.reading_by(-(page as i64 / 2), select),
-                "f" => return self.reading_by(page as i64, select),
-                "b" => return self.reading_by(-(page as i64), select),
-                "e" => return self.reading_by(1, select),
-                "y" => return self.reading_by(-1, select),
+                "d" => return self.reading_by(n * page as i64 / 2, select),
+                "u" => return self.reading_by(-(n * page as i64 / 2), select),
+                "f" => return self.reading_by(n * page as i64, select),
+                "b" => return self.reading_by(-(n * page as i64), select),
+                "e" => return self.reading_by(n, select),
+                "y" => return self.reading_by(-n, select),
                 _ => {}
             }
         }
@@ -3438,7 +3479,7 @@ impl Host {
         // mistyped `y` would sit there waiting to eat an unrelated keystroke later.
         if let Some(first) = self.reading_pending.take() {
             self.refresh_composer();
-            self.reading_pair(first, &key, ch);
+            self.reading_pair(first, &key, ch, typed);
             return;
         }
         // `y` is the only one of the three that is two keys in one: an operator when nothing is
@@ -3448,10 +3489,24 @@ impl Host {
         // making, with no message either way to say why.
         if matches!(ch, "g" | "z") || (ch == "y" && !self.chat_anchored()) {
             self.reading_pending = ch.chars().next();
+            // Put the count back for the key that finishes the pair. `5gg` is one motion with a
+            // number in front of it, and the first `g` is not the thing that spends it.
+            if let Some(n) = typed {
+                self.reading_count = n.to_string();
+            }
             self.refresh_composer();
             return;
         }
 
+        // `G` with a count in front of it is a *row* — `12G` — and it is the one motion here where
+        // the number is the destination rather than how many times to go. Before the table, because
+        // afterwards it is a repetition like everything else in it.
+        if ch == "G"
+            && let Some(n) = typed
+        {
+            self.reading_by_row(n, select);
+            return;
+        }
         let motion = match (&key.code, ch) {
             (KeyCode::Left, _) | (_, "h") => Some(CursorMotion::Left),
             (KeyCode::Right, _) | (_, "l") => Some(CursorMotion::Right),
@@ -3465,11 +3520,23 @@ impl Host {
             _ => None,
         };
         if let Some(motion) = motion {
-            let _ = self.editor.apply(&PluginId::from(BUILTIN), ApiCall::WinMotion {
-                win: self.chat_win,
-                motion,
-                select,
-            });
+            // Repeated rather than computed: `5j` is five of what `j` does, including what it does
+            // at the ends and to the column it remembers, and a version of it that worked out a row
+            // number would be a second answer to a question the core already answers. The ends of
+            // the transcript are the exception — there is only one of each, and going there five
+            // times is going there.
+            let times = if matches!(motion, CursorMotion::BufEnd | CursorMotion::BufStart) {
+                1
+            } else {
+                count
+            };
+            for _ in 0..times {
+                let _ = self.editor.apply(&PluginId::from(BUILTIN), ApiCall::WinMotion {
+                    win: self.chat_win,
+                    motion,
+                    select,
+                });
+            }
             self.resnap_linewise();
             self.follow_cursor();
             // The hint row says what the row under the cursor can do, so it moves with it.
@@ -3539,8 +3606,15 @@ impl Host {
     }
 
     /// The second key of a pair: `gg`, `zz`/`zt`/`zb`, and the `y` operator.
-    fn reading_pair(&mut self, first: char, key: &neosh_proto::KeyPress, ch: &str) {
+    ///
+    /// `typed` is the count the *first* key put back for this one — `5gg` is one motion with a
+    /// number in front of it, and the `g` that opened the pair is not what spends it.
+    fn reading_pair(&mut self, first: char, key: &neosh_proto::KeyPress, ch: &str, typed: Option<u32>) {
         match (first, ch) {
+            ('g', "g") if typed.is_some() => {
+                let select = key.mods.shift || self.chat_anchored();
+                self.reading_by_row(typed.unwrap_or(1), select);
+            }
             ('g', "g") => {
                 // Extends whenever a selection is running, exactly as `k` does. Shift alone would
                 // mean `v` then `gg` threw away what you had selected and jumped, which is the one
@@ -3628,6 +3702,21 @@ impl Host {
         self.resnap_linewise();
         self.follow_cursor();
         self.refresh_composer();
+    }
+
+    /// The count typed before a motion, if one was, and forget it.
+    ///
+    /// `None` rather than `1` for "nobody typed one", because the two are different keys: `G` is
+    /// the end of the transcript and `1G` is its first row.
+    fn take_reading_count(&mut self) -> Option<u32> {
+        let typed = std::mem::take(&mut self.reading_count);
+        typed.parse::<u32>().ok().filter(|n| *n > 0)
+    }
+
+    /// Go to a row, counted from one, the way `12G` counts.
+    fn reading_by_row(&mut self, row: u32, select: bool) {
+        let last = self.chat_lines().len().saturating_sub(1) as u32;
+        self.reading_jump((row.saturating_sub(1).min(last), 0), select);
     }
 
     /// Move `delta` rows, clamped to the transcript.
@@ -4303,12 +4392,11 @@ impl Host {
             output: None,
         };
         let card = cards::header(&g, &head, &root, width);
-        // A blank row between one action and the next. Butted together, a header, four rows of
-        // output and the next header are one block of text with no edges in it, and finding where
-        // an action starts means reading for it. A row of air is what turns the transcript into a
-        // list of things that happened — it is the cheapest structure there is, and every program
-        // that reads well spends it.
-        self.chat_gap();
+        // No blank row above it. Air used to go between one action and the next on the argument
+        // that it turns the transcript into a list — but a card is already a header at column zero
+        // with its body indented under a corner, and a run of actions reads as a list without
+        // paying a row for every one of them. Prose still gets its blank, because a paragraph and
+        // a command are different kinds of thing; two commands are not.
         let row = self.chat_push(vec![card.text.clone()]);
         self.chat_row(row, &card);
         self.cards.push(Card::new(leg, row));
@@ -5488,6 +5576,24 @@ impl Host {
                     // The plan was built from calls the driver can no longer see. Keeping it would
                     // be a checklist for work nothing is going to pick up.
                     r.plan.clear();
+                }
+                // What the window holds *now*. Compaction is the one moment the number moves
+                // without a request being made, and the card said `20.3k → 1.6k` while the meter
+                // under it went on reporting the number from before — for the rest of the
+                // conversation, because a driver that has answered "how full is it" once turns the
+                // estimate in `add_usage` off, and the next answer only arrives with the next
+                // request. The driver said `post_tokens`; this is what it is for.
+                if let Some(used) = after {
+                    let window = self
+                        .agent
+                        .sessions()
+                        .get(&session)
+                        .and_then(|s| s.context_window)
+                        .unwrap_or(0);
+                    if let Some(s) = self.agent.sessions().get_mut(&session) {
+                        s.set_context(used, window);
+                    }
+                    self.persist_sessions();
                 }
                 if on_screen {
                     let r = cards::compaction(&self.glyphs(), before, after);
@@ -7711,8 +7817,8 @@ fn transcript(
                         cards[i].legs.push(leg);
                         cards[i].row
                     } else {
-                        // The row of air the live path puts between one action and the next.
-                        gap(&mut lines);
+                        // No gap, exactly as the live path draws it: the two have to produce the
+                        // same rows, or switching away and back re-spaces the conversation.
                         let at = lines.len() as u32;
                         cards.push(Card::new(leg, at));
                         lines.push(String::new());

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -142,15 +142,26 @@ impl Session {
         let before = self.sidebar_rows();
         self.ctrl("n");
         assert!(
-            self.pump(|s| s.sidebar_rows() > before),
+            self.pump(move |s| s.sidebar_rows() > before),
             "a conversation was started\n{:?}",
             self.sidebar_now()
         );
     }
 
     /// How many conversation rows the panel is showing, however they are named.
+    ///
+    /// Counted by the age in the right-hand column rather than by the indent. A row the panel has
+    /// unfolded is several lines, and a line of somebody's title is indented exactly as far as the
+    /// row it belongs to — so the text alone cannot tell a second line of a title from an idle
+    /// conversation. The age can: it is virtual text on the row, and a continuation has none.
+
     fn sidebar_rows(&self) -> usize {
-        self.sidebar_now().iter().filter(|l| l.starts_with("     ") || l.starts_with("       ")).count()
+        let text = self.sidebar_now();
+        let virt = self.sidebar_virt_now();
+        text.iter()
+            .zip(virt.iter())
+            .filter(|(l, v)| l.starts_with("    ") && !v.trim().is_empty())
+            .count()
     }
 
     fn ctrl(&mut self, c: &str) {
@@ -2066,7 +2077,7 @@ fn a_worktree_nests_under_the_repository_it_belongs_to() {
             match (repo, tree) {
                 // Below its repository, indented past the repository's own arrow, and the branch
                 // alone — `work · sideline` is the flat list this replaced.
-                (Some(r), Some(t)) => t > r && rows[t].starts_with("     ") && !rows[t].contains('\u{b7}'),
+                (Some(r), Some(t)) => t > r && rows[t].starts_with("    ") && !rows[t].contains('\u{b7}'),
                 _ => false,
             }
         }),
@@ -2116,7 +2127,7 @@ fn an_emptied_worktree_is_still_inside_its_repository() {
             let repo = rows.iter().position(|l| l.contains("work") && !l.contains("sideline"));
             let tree = rows.iter().position(|l| l.contains("sideline"));
             match (repo, tree) {
-                (Some(r), Some(t)) => t > r && rows[t].starts_with("     "),
+                (Some(r), Some(t)) => t > r && rows[t].starts_with("    "),
                 _ => false,
             }
         }),
@@ -3652,6 +3663,45 @@ export async function activate({ neosh }: PluginContext) {
 }
 "#;
 
+/// A driver that fills its context and then compacts it, reporting both the way `claude` does.
+///
+/// `Activity::Context` is the driver answering "how full is it"; `Activity::Compacted` carries the
+/// count either side of a compaction. The second one is the whole subject of the test: it is the
+/// only moment the number moves without a request being made.
+const COMPACTOR: &str = r#"
+import type { PluginContext } from "@neosh/api";
+const nap = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export async function activate({ neosh }: PluginContext) {
+  await neosh.provider.register("compactor", [{
+    id: "compactor", driver: "compactor", display_name: "Compactor",
+    models: [{ id: "compactor", display_name: "Compactor" }],
+  }], async (_req, emit) => {
+    emit({ type: "message_start", model: "compactor", usage: {} });
+    emit({ type: "activity", activity: { kind: "context", used: 180000, total: 200000 } });
+    await nap(400);
+    emit({ type: "activity", activity: { kind: "compacted", before: 180000, after: 12000 } });
+    emit({ type: "block_start", index: 0, block: { kind: "text" } });
+    emit({ type: "text_delta", index: 0, text: "Carrying on." });
+    emit({ type: "block_stop", index: 0 });
+    emit({ type: "message_delta", stop_reason: { kind: "end_turn" }, usage: {} });
+    emit({ type: "message_stop" });
+  }, { agentLoop: true });
+  neosh.notify("compactor ready");
+}
+"#;
+
+fn install_compactor(sb: &Sandbox) {
+    let dir = sb.root.join("config/plugins/compactor");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    std::fs::write(
+        dir.join("plugin.toml"),
+        "name = \"compactor\"\nversion = \"0.1.0\"\nentry = \"main.ts\"\npermissions = [\"providers\"]\n",
+    )
+    .expect("manifest");
+    std::fs::write(dir.join("main.ts"), COMPACTOR).expect("plugin");
+}
+
 fn install_wide(sb: &Sandbox) {
     let dir = sb.root.join("config/plugins/wide");
     std::fs::create_dir_all(&dir).expect("mkdir");
@@ -4002,6 +4052,45 @@ fn there_is_exactly_one_context_meter() {
     let line = s.status_now().join(" ");
     let bars = line.match_indices('\u{2588}').count();
     assert!(bars > 0 && bars <= 8, "one bar of at most eight cells, not two: {line:?}");
+}
+
+/// Compaction moves the meter, because compaction is what moved the context.
+///
+/// The card said `180k → 12k` and the meter under it went on reporting 180k — for the rest of the
+/// conversation, because a driver that has once answered "how full is it" turns off the estimate
+/// derived from usage, and the next answer only arrives with the next request. The driver said
+/// `after`; that is the number.
+#[test]
+fn compacting_updates_the_context_meter() {
+    let sb = Sandbox::new("compactctx");
+    install_compactor(&sb);
+    sb.write_config("[options]\n\"agent.model\" = \"compactor/compactor\"\n");
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("compactor ready");
+    s.type_text("go");
+    s.enter();
+
+    assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("Compacted the conversation"))),
+        "it compacted, and said so\n{:?}",
+        s.chat_now()
+    );
+    // The card carries both numbers, so the one the meter has to agree with is on screen beside
+    // it. 12k of the 200k window the driver reported is 6%; 180k is 90%, which is what the meter
+    // went on saying.
+    assert!(
+        s.chat_now().iter().any(|l| l.contains("180.0k") && l.contains("12.0k")),
+        "with the count either side of it\n{:?}",
+        s.chat_now()
+    );
+    assert!(
+        s.pump(|s| {
+            let line = s.status_now().join("");
+            line.contains("6% of 200k") && !line.contains("90%")
+        }),
+        "and the meter says what the window holds now\n{:?}",
+        s.status_now()
+    );
 }
 
 /// A strip too narrow for everything drops whole segments, least important first, rather than
@@ -4884,9 +4973,9 @@ fn a_tool_call_says_what_came_back_not_only_that_it_ran() {
         s.chat_now()
     );
     assert!(
-        s.pump(|s| s.chat_now().iter().any(|l| l.contains('\u{2502}')
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains('\u{2514}')
             && l.contains("could not read"))),
-        "and what it came back with, under it\n{:?}",
+        "and what it came back with, under it and joined to it\n{:?}",
         s.chat_now()
     );
 }
@@ -4978,8 +5067,10 @@ fn calls_that_only_looked_at_things_share_one_row_and_open_into_several() {
         !rows.iter().any(|l| l.starts_with('\u{23fa}')),
         "no card carries the old dot\n{rows:?}"
     );
-    // The edit is its own card, right under the run, with its diff.
-    assert!(rows[run + 2].starts_with("  Edited  "), "with a row of air between\n{rows:?}");
+    // The edit is its own card, on the very next row: a card is a header at column zero with its
+    // body indented under a corner, which is what says where one action ends and the next begins —
+    // a blank row between every two of them was a row spent saying it again.
+    assert!(rows[run + 1].starts_with("  Edited  "), "directly under the run\n{rows:?}");
     assert!(rows.iter().any(|l| l.ends_with("- a")), "the edit kept its diff\n{rows:?}");
 
     // Opened, one row per call, with the whole subject and how much came back.
@@ -5356,7 +5447,172 @@ export async function activate({ neosh }: PluginContext) {
     );
 }
 
+/// A count moves that many rows you can land on, and the panel says one is being typed.
+///
+/// The keys are Vim's because this is a cursor over a column in a terminal, and a list of thirty
+/// conversations reached one `j` at a time is a list nobody moves around in. Counted in rows the
+/// cursor can *land* on rather than lines, so the headings and rules it already skips do not
+/// silently eat two of the five. See ADR 0048.
+#[test]
+fn a_count_before_a_motion_moves_that_many_rows() {
+    let sb = Sandbox::new("counts");
+    let mut s = sb.start();
+    s.wait_for("PROJECTS");
+
+    // Three conversations, so there is somewhere to count to. Named by what was typed into them,
+    // which is what a conversation with no title is called in a list.
+    let named = |s: &mut Session, name: &str| {
+        s.type_text(name);
+        s.enter();
+        // Waited for in the *panel*, not in the transcript: the next thing this test does is start
+        // another conversation, and a row still called "New conversation" because the rename has
+        // not arrived yet is a row that makes counting them meaningless.
+        let want = name.to_string();
+        assert!(
+            s.pump(move |s| s.sidebar_now().iter().any(|l| l.contains(&want))),
+            "the panel says what this conversation is about"
+        );
+    };
+    named(&mut s, "alpha");
+    s.new_conversation();
+    named(&mut s, "beta");
+    s.new_conversation();
+    named(&mut s, "gamma");
+
+    // The panel lands on the conversation you are in, and the list is newest first — so counting
+    // down from `gamma` two rows is `alpha`, with `beta` in between.
+    s.enter_panel();
+    assert!(
+        s.pump(|s| s.sidebar_cursor().is_some_and(|l| l.contains("gamma"))),
+        "the cursor starts where you are\n{:?}",
+        s.sidebar_now()
+    );
+
+    // Half of it: a digit on its own moves nothing and says so, because a first press with no
+    // visible effect is indistinguishable from a key that does nothing.
+    s.key("2");
+    assert!(
+        s.pump(|s| s.sidebar_virt_now().iter().any(|v| v.trim() == "2")),
+        "the count being typed is on screen\n{:?}",
+        s.sidebar_virt_now()
+    );
+    assert!(
+        s.sidebar_cursor().is_some_and(|l| l.contains("gamma")),
+        "and nothing has moved yet\n{:?}",
+        s.sidebar_now()
+    );
+
+    s.key("j");
+    assert!(
+        s.pump(|s| s.sidebar_cursor().is_some_and(|l| l.contains("alpha"))),
+        "two rows down, not two lines\n{:?}",
+        s.sidebar_now()
+    );
+    assert!(
+        !s.sidebar_virt_now().iter().any(|v| v.trim() == "2"),
+        "and the count is spent\n{:?}",
+        s.sidebar_virt_now()
+    );
+
+    // `gg` is the top of the list, which is the project heading — the first row anything can land
+    // on. `G` is the far end.
+    s.key("g");
+    s.key("g");
+    assert!(
+        s.pump(|s| s.sidebar_cursor().is_some_and(|l| l.contains("work"))),
+        "gg is the first row you can land on\n{:?}",
+        s.sidebar_now()
+    );
+    s.key("2");
+    s.key("G");
+    assert!(
+        s.pump(|s| s.sidebar_cursor().is_some_and(|l| l.contains("gamma"))),
+        "2G is the second row, not the end\n{:?}",
+        s.sidebar_now()
+    );
+}
+
+/// The column is as wide as you want it, and resizing it does not take the keyboard away.
+///
+/// Reopening the dock was how this used to be done, and it gives the window a new id: the panel
+/// resized from inside itself threw the cursor back to the composer on every press. The width is
+/// the `sidebar.width` setting either way, so a key and a line of `config.toml` say one number.
+#[test]
+fn the_panel_is_resized_in_place_and_keeps_the_cursor() {
+    let sb = Sandbox::new("width");
+    let mut s = sb.start();
+    s.wait_for("PROJECTS");
+    s.enter_panel();
+
+    let rule = |s: &Session| {
+        s.sidebar_now().iter().filter(|l| l.starts_with('\u{2500}')).map(|l| l.chars().count()).max()
+    };
+    let before = rule(&s).expect("the panel has a rule under its heading");
+
+    s.key("3");
+    s.key(">");
+    assert!(
+        s.pump(move |s| rule(s).is_some_and(|w| w > before)),
+        "the column got wider\n{:?}",
+        s.sidebar_now()
+    );
+    // Still in the panel: the hint strip is the panel's own, not the composer's.
+    assert!(
+        s.sidebar_now().iter().any(|l| l.contains("? keys")),
+        "and the panel still has the keyboard\n{:?}",
+        s.sidebar_now()
+    );
+
+    s.key("=");
+    assert!(
+        s.pump(move |s| rule(s) == Some(before)),
+        "and back to the default\n{:?}",
+        s.sidebar_now()
+    );
+}
+
 impl Session {
+    /// The right-hand column of every panel row, as it is *now*.
+    ///
+    /// [`Session::sidebar_virt`] is every one ever drawn, which answers a different question: a
+    /// count that was on screen and has since been spent is in that list for the rest of the
+    /// session, so "it is gone" is not a thing it can be asked.
+    fn sidebar_virt_now(&self) -> Vec<String> {
+        let Some(buf) = self.buffer_named("[sidebar]") else { return Vec::new() };
+        let mut rows: Vec<String> = Vec::new();
+        for e in &self.events {
+            if e["type"] != "buffer_lines" || e["buf"].as_u64() != Some(buf) {
+                continue;
+            }
+            let start = e["start"].as_i64().unwrap_or(0);
+            let old_end = e["old_end"].as_i64().unwrap_or(start);
+            let new: Vec<String> = e["lines"]
+                .as_array()
+                .map(|a| {
+                    a.iter()
+                        .map(|l| {
+                            l["marks"]
+                                .as_array()
+                                .map(|ms| {
+                                    ms.iter()
+                                        .filter_map(|m| m["virt_text"].as_array())
+                                        .flatten()
+                                        .filter_map(|c| c["text"].as_str())
+                                        .collect::<Vec<_>>()
+                                        .join("")
+                                })
+                                .unwrap_or_default()
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            let s = start.clamp(0, rows.len() as i64) as usize;
+            let en = if old_end < 0 { rows.len() } else { (old_end as usize).clamp(s, rows.len()) };
+            rows.splice(s..en, new);
+        }
+        rows
+    }
+
     /// The panel row the cursor is on, read from the highlight rather than from a count.
     ///
     /// A count would be a test that passes for the wrong reason the moment the panel gains a row.
@@ -5392,6 +5648,9 @@ const win = (id: string, label: string, pct: number, active = false) => ({
 export async function activate({ neosh }: PluginContext) {
   await neosh.provider.register("planner", [{
     id: "planner", driver: "planner", display_name: "Planner",
+    // How it is drawn, declared by the plugin exactly as a bundled provider declares it. A group
+    // name, never a colour: the theme owns what `Brand.Anthropic` looks like.
+    brand: { mark: "\u2733", ascii: "A", hl: "Brand.Anthropic" },
     models: [{ id: "planner-1", display_name: "Planner One", context_window: 300000 }],
   }], async (_req, emit) => {
     emit({ type: "message_start", model: "planner-1", usage: {} });
@@ -5444,7 +5703,9 @@ fn install_planner(sb: &Sandbox) {
 fn a_plugins_own_provider_appears_in_the_plan_strip() {
     let sb = Sandbox::new("planstrip");
     install_planner(&sb);
-    sb.write_config("[options]\n\"agent.model\" = \"planner/planner-1\"\n");
+    sb.write_config(
+        "[options]\n\"agent.model\" = \"planner/planner-1\"\n\"usage.sidebar.style\" = \"full\"\n",
+    );
     let mut s = sb.start_letting_config_choose();
     s.wait_for("planner ready");
 
@@ -5476,6 +5737,102 @@ fn a_plugins_own_provider_appears_in_the_plan_strip() {
     );
 }
 
+/// The plan is one row until you ask for more of it.
+///
+/// Three bars, a name and a sentence is five rows of a column whose job is your conversations —
+/// and four of them answer a question you did not ask. The default is the limit that would refuse
+/// the next request, plus anything else already critical; `<Tab>` on the row steps up to every
+/// window and then to the whole block, and `^L` is all of it whichever is showing. See ADR 0048.
+#[test]
+fn the_plan_strip_is_one_row_until_you_ask_for_more() {
+    let sb = Sandbox::new("plandense");
+    install_planner(&sb);
+    sb.write_config("[options]\n\"agent.model\" = \"planner/planner-1\"\n");
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("planner ready");
+    s.send(&command("planner.publish"));
+    s.wait_for("published");
+
+    // `session` is the window the provider marked active, so it is the one that would refuse the
+    // next request — and `weekly` at 40% is not news, so it is not a row.
+    assert!(
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("Session"))),
+        "the limit that binds is on the strip\n{:?}",
+        s.sidebar_now()
+    );
+    let strip = s.sidebar_now().join("\n");
+    assert!(!strip.contains("Weekly"), "and a limit at 40% is not news:\n{strip}");
+    assert!(!strip.contains("% left ·"), "nor is the sentence that explains it:\n{strip}");
+
+    // Onto a plan row and `<Tab>`: every window, contributed as a verb on the rows it belongs to
+    // rather than bound over every conversation in the panel.
+    s.enter_panel();
+    s.key("G");
+    assert!(
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("plan detail"))),
+        "the key is advertised on the rows it applies to\n{:?}",
+        s.sidebar_now()
+    );
+    s.special("tab");
+    assert!(
+        s.pump(|s| s.sidebar_now().join("\n").contains("Weekly")),
+        "every window, one step up\n{:?}",
+        s.sidebar_now()
+    );
+    s.special("tab");
+    assert!(
+        s.pump(|s| s.sidebar_now().join("\n").contains("88% left")),
+        "and the account and the sentence at the top of the ladder\n{:?}",
+        s.sidebar_now()
+    );
+    s.special("tab");
+    assert!(
+        s.pump(|s| !s.sidebar_now().join("\n").contains("Weekly")),
+        "and round to one row again\n{:?}",
+        s.sidebar_now()
+    );
+}
+
+/// The provider's mark keeps the provider's colour, on a row graded by something else.
+///
+/// The bar is coloured by how close the limit is, which is what a bar is for — and the one thing on
+/// the row that says *whose* allowance it is has a colour of its own. Two accounts are then two
+/// rows you tell apart without reading a word. It needs a span rather than a row highlight, so
+/// `sidebar.section` rows carry spans: a contributed row that can only be one colour is a row a
+/// plugin cannot put a mark on.
+#[test]
+fn the_plan_row_keeps_the_providers_own_colour() {
+    let sb = Sandbox::new("planbrand");
+    install_planner(&sb);
+    sb.write_config("[options]\n\"agent.model\" = \"planner/planner-1\"\n");
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("planner ready");
+    s.send(&command("planner.publish"));
+    s.wait_for("published");
+    assert!(
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("Session"))),
+        "the strip is drawn\n{:?}",
+        s.sidebar_now()
+    );
+
+    let buf = s.buffer_named("[sidebar]").expect("the panel buffer");
+    let at = s
+        .sidebar_now()
+        .iter()
+        .position(|l| l.contains("Session"))
+        .expect("the row with the binding limit on it");
+    let groups = s.groups_of(buf);
+    let on_row = groups.get(at).cloned().unwrap_or_default();
+    assert!(
+        on_row.iter().any(|g| g == "Brand.Anthropic"),
+        "the mark carries the provider's group\n{on_row:?}"
+    );
+    assert!(
+        on_row.iter().any(|g| g != "Brand.Anthropic"),
+        "and the rest of the row is graded by how close the limit is\n{on_row:?}"
+    );
+}
+
 /// Whose allowance it is, said on the strip.
 ///
 /// Three bars and no name answers "how much is left" without ever saying *of what* — and on a
@@ -5487,7 +5844,9 @@ fn a_plugins_own_provider_appears_in_the_plan_strip() {
 fn the_plan_strip_says_which_account_it_is_about() {
     let sb = Sandbox::new("planwho");
     install_planner(&sb);
-    sb.write_config("[options]\n\"agent.model\" = \"planner/planner-1\"\n");
+    sb.write_config(
+        "[options]\n\"agent.model\" = \"planner/planner-1\"\n\"usage.sidebar.style\" = \"full\"\n",
+    );
     let mut s = sb.start_letting_config_choose();
     s.wait_for("planner ready");
 
@@ -5529,7 +5888,9 @@ fn the_plan_strip_says_which_account_it_is_about() {
 fn a_mid_turn_report_does_not_erase_the_other_windows() {
     let sb = Sandbox::new("planpatch");
     install_planner(&sb);
-    sb.write_config("[options]\n\"agent.model\" = \"planner/planner-1\"\n");
+    sb.write_config(
+        "[options]\n\"agent.model\" = \"planner/planner-1\"\n\"usage.sidebar.style\" = \"full\"\n",
+    );
     let mut s = sb.start_letting_config_choose();
     s.wait_for("planner ready");
 
@@ -5770,14 +6131,16 @@ export async function activate({ neosh }: PluginContext) {
     );
 }
 
-/// The row under the cursor says all of a title the column had to cut.
+/// The row you are in says all of its title; every other row waits for the cursor.
 ///
 /// A conversation's title is the only thing telling two of them in one project apart, and a
 /// generated title is a sentence rather than a word — so a 34-column panel cuts it at about the
-/// point where it was going to say which of them this is. Arriving on the row is what asks for the
-/// rest; leaving it folds the row back, so the column is still something you read down.
+/// point where it was going to say which of them this is. The conversation you are *in* is not a
+/// row you are considering, it is where you are, so it stays open with nothing on it. Everywhere
+/// else the cursor is what asks, and leaving folds the row back — which is what keeps the column
+/// something you read down.
 #[test]
-fn the_sidebar_row_under_the_cursor_says_all_of_a_title_it_had_to_cut() {
+fn the_row_you_are_in_says_all_of_a_title_the_column_had_to_cut() {
     let sb = Sandbox::new("unfold");
     let mut s = sb.start();
     s.wait_for("PROJECTS");
@@ -5795,23 +6158,35 @@ fn the_sidebar_row_under_the_cursor_says_all_of_a_title_it_had_to_cut() {
         "the title does not fit the column\n{:?}",
         s.sidebar_now()
     );
-    // And the tail of it is nowhere, because nothing has the cursor on it yet.
+    // And open, with the cursor nowhere near it and the panel not even focused: this is the
+    // conversation on screen, and abbreviating the one row you are certain about is the one place
+    // the cursor rule is wrong.
     assert!(
-        !s.sidebar_now().iter().any(|l| l.contains("has to fit inside")),
-        "a row nobody is on stays one row\n{:?}",
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("has to fit inside"))),
+        "the conversation you are in says its whole name\n{:?}",
         s.sidebar_now()
     );
 
-    // Onto the conversation, which is where the cursor already is: the panel keeps it on the
-    // conversation you are in, which is the whole point of anchoring it to a value.
+    // Somewhere else. The row that was open is now an ordinary one, and goes back to a line.
+    s.new_conversation();
+    assert!(
+        s.pump(|s| !s.sidebar_now().iter().any(|l| l.contains("has to fit inside"))),
+        "a row nobody is in or on stays one row\n{:?}",
+        s.sidebar_now()
+    );
+
+    // Onto it with the cursor, and it says the rest of itself again. The panel keeps the cursor on
+    // the conversation you are in, and the list is newest first — so the older one is the row
+    // below where the cursor lands.
     s.enter_panel();
+    s.key("j");
     assert!(
         s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("has to fit inside"))),
         "the row under the cursor says the rest of itself\n{:?}",
         s.sidebar_now()
     );
 
-    // Up onto the project, and it folds away again.
+    // Off it again, and it folds away.
     s.key("k");
     assert!(
         s.pump(|s| !s.sidebar_now().iter().any(|l| l.contains("has to fit inside"))),

--- a/crates/neosh/tests/reading.rs
+++ b/crates/neosh/tests/reading.rs
@@ -255,6 +255,49 @@ impl Session {
 // Getting a piece of the answer out
 // ---------------------------------------------------------------------------
 
+/// A count before a motion, the way it works everywhere these keys come from.
+///
+/// `5j` is five lines and `3G` is the third one — the count is a repetition on a motion and a
+/// destination on `G`, which is the distinction the digits are for. `0` is the start of the line
+/// when nothing has been typed and part of the number when something has. See ADR 0048.
+#[test]
+fn a_count_repeats_a_motion_and_places_a_jump() {
+    let sb = Sandbox::new("counts");
+    let mut s = sb.start();
+    s.answered_and_reading();
+    s.to_top();
+
+    s.ch("5");
+    // A digit on its own moves nothing and says so: the strip is the only thing that can tell you
+    // the first of two keystrokes landed anywhere.
+    assert!(
+        s.pump(|s| s.chat_cursor() == Some(0)),
+        "nothing has moved yet: {:?}",
+        s.chat_cursor()
+    );
+    s.ch("j");
+    assert!(
+        s.pump(|s| s.chat_cursor() == Some(5)),
+        "five lines, not one: {:?}",
+        s.chat_cursor()
+    );
+
+    // And the count is spent — the next `j` is one line, not another five.
+    s.ch("j");
+    assert!(s.pump(|s| s.chat_cursor() == Some(6)), "one line: {:?}", s.chat_cursor());
+
+    // `G` with a number in front of it is a row rather than that many of anything.
+    s.ch("3");
+    s.ch("G");
+    assert!(s.pump(|s| s.chat_cursor() == Some(2)), "the third row: {:?}", s.chat_cursor());
+
+    // And `gg` takes one too.
+    s.ch("4");
+    s.ch("g");
+    s.ch("g");
+    assert!(s.pump(|s| s.chat_cursor() == Some(3)), "the fourth row: {:?}", s.chat_cursor());
+}
+
 /// `yc` takes the code and nothing else: not the language line above it, not the indent the
 /// renderer added, not the sentence after it.
 ///

--- a/docs/adr/0000-index.md
+++ b/docs/adr/0000-index.md
@@ -53,3 +53,5 @@ implementation — and in two cases (0005, 0008) it did not, which is itself rec
 | [0045](0045-a-card-that-lands-says-so.md) | A card that lands says so | Accepted |
 | [0046](0046-a-worktree-lives-inside-its-project.md) | A worktree lives inside its project | Accepted |
 | [0047](0047-a-panel-that-has-the-keyboard.md) | A panel that has the keyboard | Accepted |
+| [0048](0048-a-list-is-a-place-you-move-in.md) | A list is a place you move in | Accepted |
+| [0049](0049-a-card-is-attached-to-what-it-did.md) | A card is attached to what it did | Accepted |

--- a/docs/adr/0048-a-list-is-a-place-you-move-in.md
+++ b/docs/adr/0048-a-list-is-a-place-you-move-in.md
@@ -1,0 +1,107 @@
+# 0048 — A list is a place you move in
+
+## What happened
+
+The sidebar had `j` and `k`. That is the whole of it: no count, no page, no way to the top, and no
+way to make the column wider than whatever `sidebar.width` said when the panel opened. On a list of
+four conversations that is enough. On a list of thirty it is thirty presses, and the keys everybody's
+hands already know — `5j`, `^D`, `gg`, `G` — did nothing at all, which reads as a panel that has not
+been finished rather than one that made a choice.
+
+Two other things came from the same place. A generated title is a sentence, the column is a little
+over thirty cells wide with seven of them spent on an indent, and what a row said was
+`Rework the sidebar so…` — for every row, including the conversation you were sitting in. And the
+plan gauge, contributed at the foot, floated directly under the last project: a strip whose position
+depended on how many projects were unfolded, which means it is somewhere different every time you
+look for it.
+
+## The decision
+
+**Motions are Vim's, counts included, wherever there is a cursor over a list.** That is two places
+and only two: the project panel and the transcript reader. A count is `1`–`9` then a motion; it
+counts *rows you can land on*, so the headings and rules the cursor already skips do not silently eat
+two of the five. `^D`/`^U` are half a screen, measured from the panel's real height rather than a
+guess, and `PgUp`/`PgDn` are a whole one — deliberately not `^F`/`^B`, which are the archive and
+hiding the panel, and a key that means something else only while the cursor happens to be in this
+column is the worst kind of key. `gg` and `G` are the ends, and `5gg`/`5G` are the fifth row,
+because that is the one place a count is a destination rather than a repetition.
+
+**A half-typed count is on screen.** It sits at the right of the key strip in the panel and at the
+head of the hint row in the reader. A count is two keystrokes with nothing in between, and a first
+press with no visible effect is indistinguishable from a key that does nothing — which is exactly
+what teaches somebody the feature is not there.
+
+**A count is spent by the motion after it, and ended by anything else.** Every other verb in the
+panel clears it, so a `5` you thought better of does not turn the next `j` into five. The one
+exception is the first key of a pair: `5gg` is one motion with a number in front of it, so `g` puts
+the count back for the key that finishes it.
+
+**The row you are in stays open.** `ListRow.expand` unfolds a row's full text whether or not the
+cursor is on it, and the sidebar sets it on the active conversation and nothing else. The rule that
+*the cursor is what asks* is what keeps a column scannable, and this is the one row it is wrong for:
+where you are is not a row you are considering. There is only ever one of them, which is what stops
+this becoming "wrap everything".
+
+**The foot is held against the bottom edge.** `render({ pinned })` takes a number of trailing rows
+and pads with blank lines so they end at the bottom of the window — measured in *drawn lines*, not
+rows, because an unfolded row is several lines tall. When the list is longer than the window there is
+nothing to pin against and the rows are simply the end of the list, which is where scrolling finds
+them.
+
+**A dock can be resized without being reopened.** `ApiCall::WinResize` changes a docked window's
+extent in place. Reopening was the previous answer and it is not the same thing: the window id
+changes and the focus stack drops it, so a panel resized from inside itself threw the cursor back to
+the composer on every press. `>` and `<` in the panel move the *setting*, so `config.toml`,
+`init.ts` and the key all say the same number, and a width set in a file resizes the open panel
+rather than closing and reopening it.
+
+**And what the foot *says* is on the same budget.** The plan strip was an account row, a bar per
+limit and a sentence under them: five rows of a column whose job is your conversations, four of
+which answer a question nobody asked. It is now the limit that would refuse the next request, plus
+any other already graded `critical` or `exhausted` — one row for one account, with the brand mark on
+the bar since there is no account row left to carry it. `⇥` on a plan row steps up to every window
+and then to the whole block, `usage.sidebar.style` is where it starts, `usage.sidebar` takes it off
+the column, and `^L` is all of it whichever is showing.
+
+The mark on that row keeps the *provider's* colour while the bar is graded by how close the limit
+is — two accounts are then two rows you tell apart without reading a word — which needed
+`sidebar.section` rows to carry `spans` as well as one highlight group. A contributed row that can
+only be one colour is a row nobody can put a mark on.
+
+That key needed one small thing: `sidebar.action` grew `on: "custom"`. A plugin could already
+contribute *rows* to the column and had nowhere to put a key that belonged to them — `any` binds it
+on every row in the panel and advertises it over conversations it means nothing for.
+
+**And the titles got shorter.** `session.title.prompt` asks for two to five words and at most 32
+characters, and the plugin clamps at a word boundary rather than mid-syllable. A title generated to
+fit a column that cannot show it is a wasted request, and `Fix the authenticati` reads as a broken
+panel rather than a long name.
+
+## What was considered instead
+
+**Counts in the core, so every panel gets them.** The scope rule is what kills it: the panel keys
+live in `chat` mode, which is also the mode the composer types in, and a digit that becomes a count
+globally is a digit you can no longer type into a message. The two surfaces that want counts are the
+two with a cursor and no text field — the sidebar, whose keys are ordinary bindings on a buffer kind,
+and the reader, which has its own key path. Pickers are the third list in the program and they
+deliberately do not want this: typing in a picker filters, so `5` there is the character `5`.
+
+**A wider default sidebar.** It is somebody else's screen. The keys are the answer, and the default
+stays where it was.
+
+**Gravity.** `WindowLayout::Docked` already has `Gravity::End`, which settles short content against
+the bottom — of the whole window, which would put `PROJECTS` down there too. The foot is a *part* of
+one list, so it is the list that has to place it.
+
+## Consequences
+
+- `ListRow.expand` is public API, and a third-party panel built on `CursoredList` gets both it and
+  `pinned` for free.
+- `sidebar.action`'s `on: "custom"` means anybody contributing a section can give its rows verbs,
+  and `sidebar.section` rows take `spans`, so they can carry a mark in its own colour — the two
+  halves of the contribution model that were missing.
+- `win.resize` is public API: any plugin's dock can be resized, by its own keys or by anybody's.
+- The count lives in the panel rather than in the key table, which means a plugin that binds its own
+  verb into the sidebar gets the count cleared for it and does not have to know it exists.
+- `2j` in the sidebar is two conversations, and `2j` in a file tree somebody else writes is whatever
+  they make it. Nothing here reaches into a panel it does not own.

--- a/docs/adr/0049-a-card-is-attached-to-what-it-did.md
+++ b/docs/adr/0049-a-card-is-attached-to-what-it-did.md
@@ -1,0 +1,68 @@
+# 0049 — A card is attached to what it did
+
+## What happened
+
+A tool card was drawn with a blank row above it and a rule down the left of everything under it:
+
+```text
+Let me look at the config and run the tests.
+
+  Read  host.rs, cards.rs
+
+✗ Ran  cargo test -p neosh-core
+  │ no such tool: bash
+
+All green.
+```
+
+Three actions and a sentence cost nine rows, three of which are empty and about forty columns of
+which are a vertical bar repeating a fact the indent already carries. On a diff the bar runs down
+the side of the code it is meant to be showing.
+
+Both were deliberate, and both are written down in ADR 0040 and in `cards.rs`: air is the cheapest
+structure there is, and a rule answers "how far does this go" where an elbow only says "it starts
+here". The arguments are not wrong. They are answers to a question that stopped being open once a
+card became *a header at column zero with its body indented*: the shape says where an action begins
+without spending a row on it, and the extent of a body is legible from the indent because nothing
+else in the transcript is indented that way.
+
+## The decision
+
+**No blank row above a card.** Prose keeps its paragraph break — a sentence and a command are
+different kinds of thing — but two commands are not, and a run of actions reads as a list because it
+*is* one, not because there is air in it.
+
+**A corner rather than a rule.** The first row of a body wears `└` in the same four columns every
+other row of it is indented by; the rest are plain indent. That marks the one moment the eye needs
+telling — where the body starts, which now matters more, because the row above it is another card
+rather than a blank. `⇥` still opens the whole thing, and an opened diff is four columns of code
+wider than it was.
+
+**Compaction moves the meter.** Unrelated to the layout and found in the same place: `Activity::
+Compacted { after }` was drawn as a card and thrown away. A driver that has once answered "how full
+is it" turns off the estimate `Session::add_usage` derives from a request's prompt, so nothing else
+was going to correct it — the footer reported the pre-compaction number for the rest of the
+conversation, directly under a card that said `180k → 12k`. The driver said `post_tokens`; that is
+what it is for.
+
+## What was considered instead
+
+**Keeping the rule and dropping only the air.** The two are the same argument: both spend a
+dimension of the layout on saying where a thing starts and stops, and the header and the indent
+already say it. Half the change would have left the transcript denser and still walled.
+
+**No mark at all under the header**, only the indent. That is the failure the rule was written
+against in the first place, and removing the blank row above makes it worse rather than better: with
+another card on the row above and nothing to say a body has begun, a result reads as loose text that
+happens to be indented. The corner costs one glyph on one row and answers it.
+
+## Consequences
+
+- `Glyphs::rule` is gone; `Glyphs::elbow` replaces it, `Glyphs::margin` is four spaces and
+  `Glyphs::opener` is the corner. A body is laid out from `margin` as before, and `attach` swaps the
+  first row's four columns — one place, so nothing downstream has to know there are two margins.
+- The live path and the replay both draw no gap, which is ADR 0040's other rule: a conversation that
+  changes shape when you switch away and back reads as two programs having written it.
+- Ten card unit tests and two integration tests carried the old layout in their expected values.
+  What they were about — folding from the middle, limits, tabs, a run opening into a row per call —
+  is unchanged.

--- a/plugins/api/src/generated/ApiCall.ts
+++ b/plugins/api/src/generated/ApiCall.ts
@@ -84,6 +84,7 @@ export type ApiCall =
   | { "call": "buf_detach"; buf: BufferId }
   | { "call": "win_open"; buf: BufferId; layout: WindowLayout }
   | { "call": "win_close"; win: WindowId }
+  | { "call": "win_resize"; win: WindowId; size: number | null }
   | { "call": "win_set_buf"; win: WindowId; buf: BufferId }
   | { "call": "win_get_cursor"; win: WindowId }
   | { "call": "win_set_cursor"; win: WindowId; row: number; col: number }

--- a/plugins/api/src/index.ts
+++ b/plugins/api/src/index.ts
@@ -503,6 +503,15 @@ export interface WindowApi {
     opts?: { size?: number; gravity?: Gravity; wrap?: boolean },
   ): Promise<WindowId>;
   close(win: WindowId): Promise<void>;
+  /**
+   * Change how wide (or tall) a docked window is, without closing it.
+   *
+   * Reopening is not the same thing: the window id changes and whatever had the keyboard loses it,
+   * so a panel resized from inside itself would throw the cursor back to the composer on every
+   * press. `null` gives the dock its default extent back. Floats are configured with
+   * {@link FloatApi.configure}, and are refused here.
+   */
+  resize(win: WindowId, size: number | null): Promise<void>;
   setBuf(win: WindowId, buf: BufferId): Promise<void>;
   /** `col` is a UTF-8 byte offset, not a character or display column. */
   cursor(win: WindowId): Promise<{ row: number; col: number }>;
@@ -1806,6 +1815,9 @@ export function __createContext(plugin: string, config: unknown, version: number
       },
       async close(win) {
         await c({ call: "win_close", win });
+      },
+      async resize(win, size) {
+        await c({ call: "win_resize", win, size });
       },
       async setBuf(win, buf) {
         await c({ call: "win_set_buf", win, buf });

--- a/plugins/api/src/ui.ts
+++ b/plugins/api/src/ui.ts
@@ -1716,6 +1716,18 @@ export interface ListRow<T = unknown> {
    */
   full?: string;
   /**
+   * Keep this row unfolded whether or not the cursor is on it.
+   *
+   * The cursor asking is the rule, and this is the one exception worth having: the conversation
+   * you are *in* is not a row you are considering, it is where you are, and a panel that abbreviates
+   * it to `Fix the login re…` until you happen to move the cursor onto it is abbreviating the one
+   * row you already know you want. Needs {@link ListRow.full} and
+   * {@link CursoredListOptions.width}, like every other unfolding here. Use it for a row that is
+   * *current*, never for one that is merely long — every row that opts in is a row the column can
+   * no longer be scanned down.
+   */
+  expand?: boolean;
+  /**
    * The column continuation lines line up under. Defaults to the row's own indent plus two.
    *
    * Set it where the default would be wrong — a row whose text starts with a marker and a glyph
@@ -1821,18 +1833,72 @@ export class CursoredList<T = unknown> {
     }
   }
 
-  /** Move by `delta` selectable rows. Wraps, because a list you cannot get back to the top of is a chore. */
-  move(delta: number): void {
-    if (this.rows.length === 0) return;
+  /**
+   * Move by `delta` selectable rows.
+   *
+   * Wraps by default, because a list you cannot get back to the top of is a chore. A page step
+   * passes `wrap: false`: `^D` at the foot of the list means "there is no more", and one that
+   * silently reappears at the top is a keypress that loses your place in a column you were
+   * reading downwards.
+   *
+   * `delta` counts rows you can land on, not buffer rows — headings, rules and blanks are not
+   * places, so `5j` past two separators moves five conversations rather than three.
+   */
+  move(delta: number, opts: { wrap?: boolean } = {}): void {
+    if (this.rows.length === 0 || delta === 0) return;
+    const wrap = opts.wrap ?? true;
+    const step = delta < 0 ? -1 : 1;
+    let remaining = Math.abs(delta);
     let i = this.cursor;
-    for (let n = 0; n < this.rows.length; n++) {
-      i = (i + delta + this.rows.length) % this.rows.length;
+    let landed = -1;
+    // Bounded by the whole list per row asked for: an all-inert list has nowhere to go, and a
+    // wrapping search for a row that does not exist would otherwise spin.
+    const limit = this.rows.length * Math.abs(delta) + this.rows.length;
+    for (let n = 0; n < limit && remaining > 0; n++) {
+      let next = i + step;
+      if (next < 0 || next >= this.rows.length) {
+        if (!wrap) break;
+        next = (next + this.rows.length) % this.rows.length;
+      }
+      i = next;
       if (!this.rows[i]?.inert) {
+        landed = i;
+        remaining--;
+      }
+    }
+    if (landed < 0) return;
+    this.cursor = landed;
+    this.opts.onMove?.(landed);
+  }
+
+  /**
+   * The first or last row you can land on — `gg` and `G`.
+   *
+   * A separate verb from a large `move`, because "the end" is a place and "a hundred rows down"
+   * is a guess about where the end is.
+   */
+  toEnd(which: "first" | "last"): void {
+    const found = which === "first"
+      ? this.rows.findIndex((r) => !r.inert)
+      : this.rows.reduce((acc, r, i) => (r.inert ? acc : i), -1);
+    if (found < 0) return;
+    this.cursor = found;
+    this.opts.onMove?.(found);
+  }
+
+  /** The n-th row you can land on, 1-based, the way `5G` counts. */
+  nth(n: number): void {
+    let seen = 0;
+    for (const [i, row] of this.rows.entries()) {
+      if (row.inert) continue;
+      seen += 1;
+      if (seen === n) {
         this.cursor = i;
         this.opts.onMove?.(i);
         return;
       }
     }
+    this.toEnd("last");
   }
 
   /** Put the cursor on the first row whose value matches. */
@@ -1848,8 +1914,17 @@ export class CursoredList<T = unknown> {
    *
    * `showCursor` is false when the panel does not have the keyboard: a cursor drawn on an unfocused
    * list claims an attention it does not have, and two visible cursors is worse than none.
+   *
+   * `pinned` is how many rows at the end sit against the *bottom edge* rather than after the
+   * content: a gauge or a key strip is a foot, and a foot that floats halfway up a half-empty
+   * column is chrome that moves every time the list above it grows by one. It costs blank lines
+   * and nothing else — when the list is longer than the window there is no room to pin anything
+   * to, and the rows go back to being the end of the list, which is where scrolling will find
+   * them.
    */
-  async render(opts: { showCursor?: boolean; win?: WindowId } = {}): Promise<void> {
+  async render(
+    opts: { showCursor?: boolean; win?: WindowId; pinned?: number } = {},
+  ): Promise<void> {
     const cursorHl = this.opts.cursorHl ?? "Sidebar.Selected";
     const columns = this.opts.width?.() ?? 0;
     const drawn: DrawnRow[] = [];
@@ -1889,22 +1964,48 @@ export class CursoredList<T = unknown> {
       }
       drawn.push({ text: row.text, marks });
 
-      // The rest of a row that did not fit, under the row and only while the cursor is on it.
-      if (!onCursor || row.full === undefined || columns < 1) return;
+      // The rest of a row that did not fit: under the cursor, or on a row that asked to stay open.
+      if ((!onCursor && !row.expand) || row.full === undefined || columns < 1) return;
       const indent = Math.max(0, Math.min(row.indent ?? leading(row.text) + 2, columns - 8));
       const rest = overflowOf(row.text, row.full, columns - indent);
-      block = 1 + rest.length;
+      // Only the cursor's block is scrolled to. A row that is permanently open is not somewhere
+      // the cursor is, so counting its height here would scroll the panel to a row nobody moved to.
+      if (onCursor) block = 1 + rest.length;
       for (const line of rest) {
         const text = `${" ".repeat(indent)}${line}`;
         const end = byteLength(text);
         const cont: DrawnMark[] = [];
         // The band runs the whole block. A continuation drawn on the terminal background reads as
-        // a separate row that happens to be indented, which is the one thing it must not be.
-        cont.push({ col: 0, opts: { hlGroup: cursorHl, endCol: end, priority: 200 } });
+        // a separate row that happens to be indented, which is the one thing it must not be. Only
+        // where there is a band to run: an always-open row that is not under the cursor gets its
+        // own colour and nothing else, or every one of them would look selected.
+        if (onCursor) cont.push({ col: 0, opts: { hlGroup: cursorHl, endCol: end, priority: 200 } });
         if (row.hl) cont.push({ col: 0, opts: { hlGroup: row.hl, endCol: end } });
         drawn.push({ text, marks: cont });
       }
     });
+
+    // The foot, against the bottom edge. Measured after everything is drawn rather than counted in
+    // rows, because an unfolded row is several lines tall and padding by row count would leave the
+    // strip one line short for every row that happened to be open.
+    const pinned = Math.min(Math.max(0, opts.pinned ?? 0), this.rows.length);
+    // One round trip, used twice — and skipped when neither the foot nor the cursor needs it, since
+    // this runs on a tick while a turn is in flight and an unfocused panel that pins nothing has
+    // nothing to measure.
+    const needed = pinned > 0 || opts.showCursor !== false;
+    const view = opts.win === undefined || !needed
+      ? null
+      : await this.neosh.win.viewport(opts.win).catch(() => null);
+    if (pinned > 0) {
+      const at = lineOf[this.rows.length - pinned] ?? drawn.length;
+      const filler = (view?.height ?? 0) - drawn.length;
+      if (filler > 0) {
+        drawn.splice(at, 0, ...Array.from({ length: filler }, () => ({ text: "", marks: [] })));
+        for (let i = this.rows.length - pinned; i < this.rows.length; i++) {
+          lineOf[i] = (lineOf[i] ?? 0) + filler;
+        }
+      }
+    }
 
     // One call, not one per mark. A panel that wrote its text, cleared its namespace and then set
     // its marks a call at a time was observable halfway through — and a frame landing after the
@@ -1916,7 +2017,7 @@ export class CursoredList<T = unknown> {
     // indices: an unfolded row is several lines tall and the two stopped agreeing the moment one
     // was — which would scroll to the wrong place by however many rows above it had ever unfolded.
     if (opts.win !== undefined && opts.showCursor !== false) {
-      const v = await this.neosh.win.viewport(opts.win).catch(() => null);
+      const v = view;
       if (v && v.height > 0) {
         const at = lineOf[this.cursor] ?? this.cursor;
         // The whole of the row, not only the line it starts on: scrolling until the *first* line

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -115,6 +115,16 @@ interface SectionItem {
   rows?: Array<{
     text: string;
     hl?: string;
+    /**
+     * Highlights for pieces of the row, over the top of `hl`: a brand mark, a matched substring, a
+     * state glyph.
+     *
+     * `from`/`to` are UTF-8 byte offsets into *your* `text` — this panel adds its own indent and
+     * shifts them. One group per row is not enough for a row that is a measurement in one colour
+     * with somebody's mark on the front of it, and the alternative is a plugin drawing its own
+     * window beside ours.
+     */
+    spans?: Array<{ from: number; to: number; hl: string }>;
     right?: { text: string; hl?: string };
     /** Run on `↵`. Without one the row is inert — a label rather than a verb. */
     command?: string;
@@ -136,8 +146,15 @@ interface ActionItem {
   /** What it does, for the hint strip and for `F1`. */
   label: string;
   command: string;
-  /** Which rows it applies to. Defaults to `any`. */
-  on?: "project" | "session" | "any";
+  /**
+   * Which rows it applies to. Defaults to `any`.
+   *
+   * `custom` is a row somebody contributed through `sidebar.section` — usually the contributor's
+   * own. Without it a plugin can put rows in this column and then has nowhere to put a key that
+   * belongs to them: `any` binds the key on every row in the panel and advertises it on all of
+   * them, which is a verb about the plan gauge appearing while the cursor is on a conversation.
+   */
+  on?: "project" | "session" | "custom" | "any";
 }
 
 /** A project as the panel thinks of it: a directory, and what is going on in it. */
@@ -265,6 +282,9 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
   const list = new CursoredList<Target>(neosh, buf, ns, { width: () => panelWidth });
   let win: WindowId | null = null;
   let focused = false;
+  // Typed before a motion and consumed by it. Shared with the key table and with the draw, which
+  // is what puts it on screen while it is half typed.
+  const count = { pending: "" };
   let capture: Disposable | null = null;
   let running = false;
 
@@ -300,13 +320,18 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
           selected: list.value,
           actions: actions(),
           asking,
+          count: count.pending,
           // Filled in by `collect`, which is what reads the swarm.
           remote: new Map(),
           hosts: new Map(),
         });
         running = built.running;
         list.setRows(built.rows, same);
-        await list.render({ showCursor: focused, win: win ?? undefined });
+        await list.render({
+          showCursor: focused,
+          win: win ?? undefined,
+          pinned: built.pinned,
+        });
       } while (again);
     } finally {
       drawing = false;
@@ -318,6 +343,13 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
     const width = (await neosh.opt.get<number>("sidebar.width")) ?? 34;
     win = await neosh.win.open(buf, "left", { size: width });
     await draw();
+    // And again once the frontend has said how tall the panel turned out to be. The foot is held
+    // against the bottom edge, which is a measurement — and on the first frame there is nothing to
+    // measure yet, so without this the strip sits under the last project until something else
+    // happens to redraw.
+    // Not held in `subscriptions`: the panel is opened and closed as often as `^B` is pressed, and
+    // the runtime cancels a plugin's timers when it unloads anyway.
+    neosh.timer.after(120, () => void draw());
   };
 
   const close = async () => {
@@ -368,6 +400,12 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
     subscriptions,
     list,
     arrangement,
+    count,
+    height: async () => {
+      if (win === null) return 20;
+      const v = await neosh.win.viewport(win).catch(() => null);
+      return v?.height ?? 20;
+    },
     draw,
     open,
     close,
@@ -406,8 +444,11 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
       if (e.name === "ui.motion" || e.name === "ui.ascii_only") {
         void applyMotion().then(draw);
       } else if (e.name === "sidebar.width" && win !== null) {
-        // Reopening is the only way to change a docked size today.
-        void close().then(open);
+        // In place. Reopening was how this used to work, and it gave the panel a new window id and
+        // dropped whatever had the keyboard — so resizing from inside the panel threw the cursor
+        // back to the composer on every press.
+        panelWidth = (typeof e.value === "number" ? e.value : null) ?? panelWidth;
+        void neosh.win.resize(win, panelWidth).then(draw).catch(() => {});
       } else if (e.name.startsWith("sidebar.") || e.name === "ui.theme") {
         void draw();
       }
@@ -719,6 +760,16 @@ interface Wiring {
   subscriptions: PluginContext["subscriptions"];
   list: CursoredList<Target>;
   arrangement: Arrangement;
+  /**
+   * A count typed before a motion — `5j`, `12G`.
+   *
+   * State between two keystrokes, so it lives beside the panel rather than in the key table, and
+   * it is drawn in the hint strip: a count you cannot see is a keypress that appears to have done
+   * nothing at all.
+   */
+  count: { pending: string };
+  /** How many rows of panel there are, for the two keys that mean "a screen". */
+  height(): Promise<number>;
   draw(): Promise<void>;
   open(): Promise<void>;
   close(): Promise<void>;
@@ -759,6 +810,9 @@ async function registerCommands(w: Wiring): Promise<void> {
     w.subscriptions.push(
       await neosh.cmd.register(name, async (args) => {
         await fn(list.value, args);
+        // A count belongs to the motion typed straight after it. Anything else ends it — otherwise
+        // a `5` you thought better of sits there and turns the next `j` into five.
+        w.count.pending = "";
         if (opts.redraw !== false) await w.draw();
       }, { desc }),
     );
@@ -771,12 +825,108 @@ async function registerCommands(w: Wiring): Promise<void> {
   };
 
   // ---- moving ----
-  await verb(`${NS}.down`, "j", "Next row", () => void list.move(1));
-  await verb(`${NS}.up`, "k", "Previous row", () => void list.move(-1));
-  await neosh.keymap.set("chat", "<Down>", `${NS}.down`, { scope: { kind: "buf_kind", name: KIND } });
-  await neosh.keymap.set("chat", "<Up>", `${NS}.up`, { scope: { kind: "buf_kind", name: KIND } });
-  await neosh.keymap.set("chat", "<C-n>", `${NS}.down`, { scope: { kind: "buf_kind", name: KIND } });
-  await neosh.keymap.set("chat", "<C-p>", `${NS}.up`, { scope: { kind: "buf_kind", name: KIND } });
+  //
+  // Vim's motions, because this is a cursor in a column in a terminal and that is the vocabulary
+  // everybody's hands already have. A count works the way it does there — `5j` is five rows, `3G`
+  // is the third — and it counts *rows you can land on*, so the headings and rules the cursor
+  // already skips do not silently eat two of the five.
+  const scope = { kind: "buf_kind", name: KIND } as const;
+  const also = async (key: string, command: string, desc: string): Promise<void> => {
+    await neosh.keymap.set("chat", key, command, { scope, desc });
+  };
+
+  /** Take the count that was typed, if one was, and forget it. */
+  const take = (fallback = 1): number => {
+    const n = Number.parseInt(w.count.pending, 10);
+    w.count.pending = "";
+    // Bounded, because the count is typed and `999999j` is a keystroke that would walk the list a
+    // million times before drawing anything.
+    return Number.isFinite(n) && n > 0 ? Math.min(n, 999) : fallback;
+  };
+
+  await verb(`${NS}.down`, "j", "Next row", () => void list.move(take()));
+  await verb(`${NS}.up`, "k", "Previous row", () => void list.move(-take()));
+  await also("<Down>", `${NS}.down`, "Next row");
+  await also("<Up>", `${NS}.up`, "Previous row");
+  await also("<C-n>", `${NS}.down`, "Next row");
+  await also("<C-p>", `${NS}.up`, "Previous row");
+
+  // A screen is however tall the panel turned out to be, which only the frontend knows — asked for
+  // rather than assumed, the same way every other display measurement here is. Half a screen for
+  // `^D`/`^U` because that is what it is everywhere, and a whole one loses the row you were on.
+  const by = (fraction: number, sign: 1 | -1) => async (): Promise<void> => {
+    const rows = Math.max(2, await w.height());
+    const step = Math.max(1, Math.floor(rows * fraction)) * take();
+    // No wrapping on a page step: `^D` at the foot of the list means there is no more of it, and a
+    // cursor that reappears at the top has thrown away the place you were reading from.
+    list.move(sign * step, { wrap: false });
+  };
+  await verb(`${NS}.half.down`, "<C-d>", "Half a screen down", by(0.5, 1));
+  await verb(`${NS}.half.up`, "<C-u>", "Half a screen up", by(0.5, -1));
+  // A whole screen is `PgUp`/`PgDn` and deliberately *not* `^F`/`^B`. Those two are `^F` archive
+  // and `^B` hide the panel — both of which somebody in this panel is more likely to want than a
+  // page step in a column that is rarely taller than one screen, and a key that means something
+  // else only while the cursor happens to be here is the worst kind of key.
+  await verb(`${NS}.page.down`, "<PageDown>", "A screen down", by(1, 1));
+  await verb(`${NS}.page.up`, "<PageUp>", "A screen up", by(1, -1));
+
+  /** The count, when a verb wants the number itself rather than a repetition. */
+  const typed = (): number | null => {
+    const n = Number.parseInt(w.count.pending, 10);
+    w.count.pending = "";
+    return Number.isFinite(n) && n > 0 ? n : null;
+  };
+  // With a count these are a *row* — `5gg` and `5G` are both the fifth — and without one they are
+  // the two ends, exactly as in Vim.
+  await verb(`${NS}.top`, "gg", "The first row, or the n-th with a count", () => {
+    const n = typed();
+    if (n === null) list.toEnd("first");
+    else list.nth(n);
+  });
+  await verb(`${NS}.bottom`, "G", "The last row, or the n-th with a count", () => {
+    const n = typed();
+    if (n === null) list.toEnd("last");
+    else list.nth(n);
+  });
+
+  /**
+   * A digit, before a motion.
+   *
+   * One command for all ten, reading which digit it was off the key that ran it — so `F1` lists it
+   * once and `init.ts` can move it, rather than ten near-identical verbs. A leading `0` is not a
+   * count anywhere and is left to whatever else might want the key.
+   */
+  w.subscriptions.push(
+    await neosh.cmd.register(`${NS}.count`, async (_args, key) => {
+      const code = key?.key.code;
+      if (code?.kind !== "char") return;
+      if (w.count.pending === "" && code.c === "0") return;
+      // Bounded while it is being typed, not only when it is read: three digits is more rows than
+      // this panel will ever have, and it stops a leant-on key growing a string forever.
+      if (w.count.pending.length < 3) w.count.pending += code.c;
+      // Drawn straight away — the strip is the only thing saying the digit landed anywhere.
+      await w.draw();
+    }, { desc: "Begin a count for the next motion" }),
+  );
+  for (const digit of "0123456789") {
+    await also(digit, `${NS}.count`, "Count for the next motion");
+  }
+
+  // ---- how wide the column is ----
+  //
+  // A resize rather than a reopen: reopening gives the window a new id and drops whatever had the
+  // keyboard, so the panel would throw you back to the composer on every press. The width is the
+  // *setting*, so it is the same number `config.toml` sets and one place decides it.
+  const resize = (delta: number) => async (): Promise<void> => {
+    const now = (await neosh.opt.get<number>("sidebar.width")) ?? 34;
+    const want = Math.max(16, Math.min(120, now + delta * take()));
+    if (want !== now) await neosh.opt.set("sidebar.width", want);
+  };
+  await verb(`${NS}.wider`, ">", "Widen the panel", resize(2), { redraw: false });
+  await verb(`${NS}.narrower`, "<lt>", "Narrow the panel", resize(-2), { redraw: false });
+  await verb(`${NS}.width.reset`, "=", "Back to the default width", async () => {
+    await neosh.opt.reset("sidebar.width");
+  }, { redraw: false });
 
   // ---- leaving ----
   await verb(`${NS}.leave`, "<Esc>", "Back to the composer", () => w.leave(), { redraw: false });
@@ -1103,7 +1253,10 @@ const RESERVED = new Set([
   "<Esc>", "<CR>", "<Up>", "<Down>", "<Space>", "<C-n>", "<C-p>", "<C-c>",
 ]);
 
-function applies(on: "project" | "session" | "any", target: Target | undefined): boolean {
+function applies(
+  on: "project" | "session" | "custom" | "any",
+  target: Target | undefined,
+): boolean {
   if (on === "any") return target !== undefined;
   return target?.kind === on;
 }
@@ -2158,6 +2311,8 @@ interface DrawOptions {
   actions: ActionItem[];
   /** Which conversations are waiting on an answer from you. See [`VAR_ASKING`]. */
   asking: Set<string>;
+  /** A count typed but not yet spent, drawn at the foot the way Vim draws it. */
+  count: string;
   /** Conversations on other computers, grouped by the project key they share with ours. */
   remote: Map<string, SwarmAgent[]>;
   /** Which other machines have each project, by key. */
@@ -2180,7 +2335,7 @@ async function collect(
   neosh: Neosh,
   arrangement: Arrangement,
   opts: DrawOptions,
-): Promise<{ rows: ListRow<Target>[]; running: boolean }> {
+): Promise<{ rows: ListRow<Target>[]; running: boolean; pinned: number }> {
   const rows: ListRow<Target>[] = [];
 
   // Failures absorbed: a panel that renders an exception instead of your conversations is worse
@@ -2293,11 +2448,16 @@ async function collect(
     });
   }
 
+  // Everything from here down is the panel's foot: rows somebody contributed below the list, and
+  // the key strip. Counted so the list can hold them against the bottom edge — a plan gauge that
+  // sits under the last project is in a different place every time a project is added or folded,
+  // which is the one thing a status strip must not be.
+  const body = rows.length;
   rows.push(...sectionRows(sections, "below", opts));
 
   if (opts.hints) rows.push(...hints(opts));
 
-  return { rows, running };
+  return { rows, running, pinned: rows.length - body };
 }
 
 /**
@@ -2328,13 +2488,18 @@ function sectionRows(
     }
     for (const r of contributed) {
       if (typeof r?.text !== "string") continue;
+      const text = `   ${clip(r.text, Math.max(4, opts.width - 6))}`;
       rows.push({
-        text: `   ${clip(r.text, Math.max(4, opts.width - 6))}`,
+        text,
         // A third party's row gets the same treatment ours do: we have no idea how long its text
         // is, and a plugin's row cut at our column is our bug rather than theirs.
         full: `   ${r.text}`,
         indent: 3,
         hl: typeof r.hl === "string" ? r.hl : undefined,
+        // Shifted by our indent and clamped to what survived the clip. Checked rather than
+        // trusted, like every other field here: a span running off the end of a row this panel
+        // shortened is a mark on a column that is not there.
+        spans: shift(r.spans, byteLength("   "), byteLength(text)),
         right: typeof r.right?.text === "string"
           ? { text: `${r.right.text} `, hl: r.right.hl }
           : undefined,
@@ -2357,6 +2522,24 @@ function sectionRows(
  * weight and the eye has to parse the words to find the structure — which is exactly the work a
  * layout is supposed to have already done.
  */
+/** Somebody else's spans, in this panel's coordinates. */
+function shift(
+  spans: unknown,
+  by: number,
+  eol: number,
+): Array<{ from: number; to: number; hl: string }> | undefined {
+  if (!Array.isArray(spans)) return undefined;
+  const out = spans.flatMap((s) => {
+    if (typeof s?.from !== "number" || typeof s?.to !== "number" || typeof s?.hl !== "string") {
+      return [];
+    }
+    const from = Math.max(0, Math.floor(s.from)) + by;
+    const to = Math.min(Math.max(0, Math.floor(s.to)) + by, eol);
+    return to > from ? [{ from, to, hl: s.hl }] : [];
+  });
+  return out.length > 0 ? out : undefined;
+}
+
 function heading(text: string, width: number, hint?: string): ListRow<Target>[] {
   return [
     {
@@ -2496,10 +2679,12 @@ function worktreeRow(
   const mark = unseen === 0 ? "" : unseen === 1
     ? opts.ascii ? " !" : " ●"
     : opts.ascii ? ` !${unseen}` : ` ●${unseen}`;
-  const name = clip(p.name, Math.max(6, opts.width - 10 - byteLength(mark)));
-  const from = byteLength(`     ${arrow} ${name}`);
+  const name = clip(p.name, Math.max(6, opts.width - 9 - byteLength(mark)));
+  const from = byteLength(`    ${arrow} ${name}`);
   return {
-    text: `     ${arrow} ${name}${mark}`,
+    text: `    ${arrow} ${name}${mark}`,
+    full: `    ${arrow} ${p.name}`,
+    indent: 6,
     hl: here ? "Directory" : "Sidebar.Dim",
     spans: mark === "" ? undefined : [{ from, to: from + byteLength(mark), hl: "Status.Unread" }],
     right,
@@ -2518,11 +2703,11 @@ function remoteRow(r: SwarmAgent, opts: DrawOptions, now: number): ListRow<Targe
     const working = r.agent.state === "running";
     const glyph = working ? (opts.ascii ? "*" : "◍") : opts.ascii ? "." : "·";
     const host = clip(r.node.name, 12);
-    const width = Math.max(8, opts.width - 11 - host.length);
+    const width = Math.max(8, opts.width - 8 - host.length);
     return {
-      text: `     ${glyph} ${clip(r.agent.label, width)}`,
-      full: `     ${glyph} ${r.agent.label}`,
-      indent: 7,
+      text: `    ${glyph} ${clip(r.agent.label, width)}`,
+      full: `    ${glyph} ${r.agent.label}`,
+      indent: 6,
       hl: working ? "Status.Monitoring" : "Sidebar.Remote",
       right: { text: `${host} `, hl: "Sidebar.Remote" },
       value: {
@@ -2578,14 +2763,28 @@ function sessionRow(
     : s.updated_at > 0 ? ago(now / 1000 - s.updated_at) : "";
   // Two more columns per level: a conversation inside a worktree sits inside the worktree's row
   // the way the worktree sits inside its repository's.
-  const pad = "     " + "  ".repeat(depth);
+  const pad = "    " + "  ".repeat(depth);
+  // What is left for the title, counted rather than guessed at. The indent, the glyph and the
+  // space after it come off the front; the age column and the space keeping it off the panel edge
+  // come off the end, plus one column of air so a title cannot run into a timestamp. The old
+  // number was a constant two columns larger than the prefix it stood for, which is two characters
+  // of every title in the panel spent on nothing.
+  const room = Math.max(
+    8,
+    opts.width - pad.length - 2 - (right === "" ? 0 : right.length + 2),
+  );
   return {
-    text: `${pad}${glyph} ${clip(s.label, Math.max(8, opts.width - 9 - 2 * depth - right.length))}`,
+    text: `${pad}${glyph} ${clip(s.label, room)}`,
     // The title is the only thing telling two conversations in one project apart, and a generated
     // title is a sentence rather than a word — so the column cuts it at about the point where it
     // was going to say which of them this is.
     full: `${pad}${glyph} ${s.label}`,
-    indent: 7 + 2 * depth,
+    // The conversation you are in is not a row you are considering, it is where you are — so it
+    // says its whole name whether or not the cursor is on it. Everything else in this column is
+    // scannable because it is one line each; the current row is the one place that trade is wrong,
+    // and there is only ever one of it.
+    expand: s.is_active,
+    indent: pad.length + 2,
     hl: asking
       // The palette's group for waiting on something outside the program — which here is a person,
       // and the reason it is the one row in this column that moves. `Status.Unread` deliberately
@@ -2640,6 +2839,8 @@ function hints(opts: DrawOptions): ListRow<Target>[] {
     // `^O` is not here and `+ Add project` is a row you can see: a key strip has two lines, and the
     // verb with a row of its own is the one that can afford to give up its place on them.
     ? ["^T projects  ^N new   ^F archive", "^K palette   ^B hide  F1 keys"]
+    : kind === "custom"
+      ? ["↵ open it     <> width", "esc back      ? keys"]
     : kind === "project"
       // `X` is on the strip because a list you cannot shorten is a list that grows forever, and a
       // project that outlives its conversations — which is the point of it — has to have a way off.
@@ -2658,7 +2859,16 @@ function hints(opts: DrawOptions): ListRow<Target>[] {
   return [
     blank(),
     { text: "─".repeat(Math.max(1, opts.width)), hl: "Separator", inert: true },
-    ...lines.map((text) => ({ text: ` ${text}`, hl: "Sidebar.Dim", inert: true })),
+    // Half a motion, at the foot, where Vim puts it: without it a count is a keypress with no
+    // effect until the next one, which is indistinguishable from a key that does nothing. On the
+    // first key line rather than on the rule above it — the rule is a row of full width, and a
+    // flush-right virtual text has nowhere to sit on a row that is already full.
+    ...lines.map((text, i) => ({
+      text: ` ${text}`,
+      hl: "Sidebar.Dim",
+      right: i === 0 && opts.count !== "" ? { text: `${opts.count} `, hl: "Accent" } : undefined,
+      inert: true,
+    })),
     ...(mine === "" ? [] : [{ text: ` ${mine}`, hl: "Sidebar.Dim", inert: true }]),
   ];
 }

--- a/plugins/builtin/titles/main.ts
+++ b/plugins/builtin/titles/main.ts
@@ -11,16 +11,30 @@
 
 import type { Neosh, PluginContext, SessionId } from "@neosh/api";
 
-const DEFAULT_PROMPT = `Generate a title that will help someone recognise this conversation weeks later.
+/**
+ * How much of a title a list can actually show.
+ *
+ * A sidebar is a narrow column with an indent, a state glyph and an age on it, so a title of forty
+ * characters is a title that ends in an ellipsis in the one place it is read. Asked for *and*
+ * enforced: a model told "under 40" writes 46 often enough that the clamp is what the panel
+ * actually gets, and a clamp is a truncation — the sentence it cuts is one the model would have
+ * written shorter if it had been asked to.
+ */
+const LIMIT = 32;
+
+const DEFAULT_PROMPT =
+  `Generate a title that will help someone recognise this conversation weeks later.
 Return a JSON object with exactly one key: title.
 
 Rules:
-- 3 to 8 words, under 40 characters.
+- 2 to 5 words, at most ${LIMIT} characters. Shorter is better.
 - A compact noun phrase, or a clear action phrase.
 - Name the subject and what the user wants, not the process used to get there.
+- Leave out articles, and anything a sidebar already shows: the project, the language, the word
+  "conversation".
 - Do not claim the work is finished.
 - Do not copy and truncate the user's message.
-- No quotes, no trailing punctuation, no project name that a sidebar already shows.`;
+- No quotes, no trailing punctuation.`;
 
 export async function activate({ neosh, subscriptions }: PluginContext) {
   await neosh.opt.declare({
@@ -61,6 +75,19 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
   );
 }
 
+/**
+ * A title that is too long for the column it lives in, cut at a word.
+ *
+ * Mid-word is worse than short: `Fix the authenticati` reads as a bug in the panel, and the two
+ * characters saved by cutting there buy nothing.
+ */
+function clamp(title: string): string {
+  if (Array.from(title).length <= LIMIT) return title;
+  const cut = Array.from(title).slice(0, LIMIT).join("");
+  const space = cut.lastIndexOf(" ");
+  return (space > LIMIT / 2 ? cut.slice(0, space) : cut).trimEnd();
+}
+
 async function retitle(neosh: Neosh, attempted: Set<SessionId>, forced: boolean): Promise<void> {
   if (!forced && !((await neosh.opt.get<boolean>("session.autotitle")) ?? true)) return;
 
@@ -95,7 +122,7 @@ async function retitle(neosh: Neosh, attempted: Set<SessionId>, forced: boolean)
     if (title === "") return;
     // The conversation may have been switched away from while the model was thinking; renaming by
     // id rather than "the current one" is what stops the answer landing on the wrong thread.
-    await neosh.session.rename(current.id, title.slice(0, 60));
+    await neosh.session.rename(current.id, clamp(title));
   } catch (e) {
     // Not worth a message: failing to name a conversation costs the user nothing, and a popup
     // every time a cheap model hiccups would cost them plenty.

--- a/plugins/builtin/usage/main.ts
+++ b/plugins/builtin/usage/main.ts
@@ -77,6 +77,16 @@ async function declareOptions(neosh: Neosh) {
     description: "Show what the plan has left at the foot of the sidebar.",
   });
   await neosh.opt.declare({
+    name: "usage.sidebar.style",
+    type: { type: "str" },
+    default: "one",
+    description:
+      "How much of the plan the sidebar spends rows on. `one` is a row per account — the limit " +
+      "that would refuse the next request, plus any other that is already critical. `windows` is " +
+      "a row per limit. `full` adds the account row and the sentence under it. `<Tab>` on a plan " +
+      "row steps through them, and `^L` is the whole of it whichever is set.",
+  });
+  await neosh.opt.declare({
     name: "usage.poll",
     type: { type: "bool" },
     default: true,
@@ -138,7 +148,7 @@ async function installStrip({ neosh, subscriptions }: PluginContext) {
       }
       return;
     }
-    const [quotas, ascii, nerd, width] = await Promise.all([
+    const [quotas, ascii, nerd, width, style] = await Promise.all([
       neosh.quota.list().catch(() => [] as QuotaSnapshot[]),
       neosh.opt.get<boolean>("ui.ascii_only").catch(() => false),
       neosh.opt.get<boolean>("ui.nerd_font").catch(() => false),
@@ -147,6 +157,7 @@ async function installStrip({ neosh, subscriptions }: PluginContext) {
       // built to a guessed width does not wrap — it collides, and the countdown lands on the last
       // letter of the label.
       neosh.opt.get<number>("sidebar.width").catch(() => 34),
+      neosh.opt.get<string>("usage.sidebar.style").catch(() => "one"),
     ]);
     // An account we cannot name yet. Reaching a quota for an instance that is not in the credential
     // list means the list is stale — a provider registered late, or somebody has just signed in —
@@ -154,7 +165,7 @@ async function installStrip({ neosh, subscriptions }: PluginContext) {
     // this avoids. Once per staleness, not once per frame: `who` is replaced before the next one.
     if (quotas.some((q) => !who.some((c) => c.instance === q.instance))) await reload();
     const glyphs = { ascii: ascii ?? false, nerd: nerd ?? false };
-    const item = section(quotas, who, glyphs, width ?? 34, Date.now() / 1000);
+    const item = section(quotas, who, glyphs, width ?? 34, Date.now() / 1000, styleOf(style));
     // Compared as JSON rather than by identity: this runs on a tick, and re-contributing the same
     // rows makes the sidebar rebuild its whole list — cursor, scroll and all — several times a
     // second, for no change anybody can see.
@@ -168,6 +179,36 @@ async function installStrip({ neosh, subscriptions }: PluginContext) {
     await neosh.ext.contribute("sidebar.section", "plan", item, { priority: -10 });
   };
 
+  // Stepping the density, and taking the strip off the column altogether. Commands rather than
+  // config-file lines: `^K` runs them, `F1` lists the key, and `init.ts` moves it — the same way
+  // every other verb here works. They write the *setting*, so `config.toml` decides where you
+  // start and the key decides where you are.
+  subscriptions.push(
+    await neosh.cmd.register(`${NS}.sidebar.cycle`, async () => {
+      const now = styleOf(await neosh.opt.get<string>("usage.sidebar.style").catch(() => "one"));
+      const next = STYLES[(STYLES.indexOf(now) + 1) % STYLES.length] ?? "one";
+      await neosh.opt.set("usage.sidebar.style", next);
+    }, { desc: "How much of the plan the sidebar shows" }),
+  );
+  subscriptions.push(
+    await neosh.cmd.register(`${NS}.sidebar.toggle`, async () => {
+      const on = (await neosh.opt.get<boolean>("usage.sidebar").catch(() => true)) ?? true;
+      await neosh.opt.set("usage.sidebar", !on);
+    }, { desc: "Show or hide the plan at the foot of the sidebar" }),
+  );
+  // And a key on the rows themselves. `<Tab>` because that is what opens and folds a thing you are
+  // standing on everywhere else in neosh, and `on: "custom"` so it is a verb about *these* rows
+  // rather than one advertised over every conversation in the panel.
+  await neosh.ext.contribute("sidebar.action", "plan.detail", {
+    key: "<Tab>",
+    label: "plan detail",
+    command: `${NS}.sidebar.cycle`,
+    on: "custom",
+  }).catch(() => {});
+  subscriptions.push({
+    dispose: () => void neosh.ext.remove("sidebar.action", "plan.detail").catch(() => {}),
+  });
+
   await reload();
   await refresh();
   subscriptions.push(neosh.quota.onChange((s) => {
@@ -176,8 +217,8 @@ async function installStrip({ neosh, subscriptions }: PluginContext) {
   }));
   subscriptions.push(neosh.opt.onChange((e) => {
     if (
-      e.name === "usage.sidebar" || e.name === "ui.ascii_only" || e.name === "ui.nerd_font" ||
-      e.name === "sidebar.width"
+      e.name === "usage.sidebar" || e.name === "usage.sidebar.style" ||
+      e.name === "ui.ascii_only" || e.name === "ui.nerd_font" || e.name === "sidebar.width"
     ) void refresh();
   }));
   // A selection change is the cheap signal that the provider list may have moved — signing in is
@@ -195,6 +236,8 @@ async function installStrip({ neosh, subscriptions }: PluginContext) {
 interface StripRow {
   text: string;
   hl?: string;
+  /** Pieces of the row in their own group, over the top of `hl`: the provider's mark. */
+  spans?: Array<{ from: number; to: number; hl: string }>;
   right?: { text: string; hl?: string };
   command?: string;
 }
@@ -219,53 +262,124 @@ interface StripRow {
  * round they go. One line in words, about the limit that actually binds, says both: how much is
  * left, and when it comes back.
  */
+/**
+ * How much of the column the plan is allowed to be.
+ *
+ * A plan with three limits and a name and a sentence under it is five rows, which is most of a
+ * short sidebar spent on a number that changes twice an hour. `one` is the answer to the question
+ * people actually have — *may I start something long* — and the rest is a keypress away.
+ *
+ * Ordered, because `<Tab>` steps along them.
+ */
+const STYLES = ["one", "windows", "full"] as const;
+type Style = (typeof STYLES)[number];
+
+export function styleOf(value: unknown): Style {
+  return STYLES.includes(value as Style) ? value as Style : "one";
+}
+
+/**
+ * The limits worth a row when there is only room for the answer.
+ *
+ * The one that binds, because it is the one that would refuse the next request — and anything else
+ * already critical, because a weekly cap at 94% is news whether or not the session limit is the one
+ * about to stop you. Never more than that: this is the summary, and a summary that grows back to
+ * the full list is not one.
+ */
+function summarised(q: QuotaSnapshot): QuotaWindow[] {
+  const first = q.windows.find((w) => w.active) ?? binding(q.windows);
+  const out = first ? [first] : [];
+  for (const w of q.windows) {
+    if (w === first) continue;
+    if (w.severity === "critical" || w.severity === "exhausted") out.push(w);
+  }
+  return out;
+}
+
 function section(
   quotas: QuotaSnapshot[],
   who: CredentialInfo[],
   glyphs: { ascii: boolean; nerd: boolean },
   width: number,
   now: number,
+  style: Style,
 ) {
   const rows: StripRow[] = [];
   // What the sidebar leaves for the text (`   ` and its own margin), less the widest countdown and
   // a space to keep it off the label.
   const room = Math.max(14, width - 6 - 5);
+  const accounts = quotas.filter((q) => q.windows.length > 0);
 
-  for (const q of quotas) {
-    if (q.windows.length === 0) continue;
+  for (const q of accounts) {
     // Air between accounts. Two of them run together into one block of bars otherwise, and the
-    // second account's name reads as another limit belonging to the first.
-    if (rows.length > 0) rows.push({ text: "" });
-    rows.push(accountRow(q, who, glyphs, room));
+    // second account's name reads as another limit belonging to the first. Not in `one`, where an
+    // account *is* a row and a blank line between two of them costs more than it separates.
+    if (rows.length > 0 && style !== "one") rows.push({ text: "" });
+    // Whose allowance this is. Always in `full`; in `windows` only when there is more than one
+    // account, since with a single one it is a row that says what the mark on the bar already
+    // says; never in `one`, where an account is a row.
+    if (style === "full" || (style === "windows" && accounts.length > 1)) {
+      rows.push(accountRow(q, who, glyphs, room));
+    }
+    const windows = style === "one" ? summarised(q) : q.windows;
+    // The mark goes on the bar itself when there is no account row above it to carry it: a row of
+    // brand colour with no brand on it is a coloured bar nobody can attribute.
+    const brand = style === "one" ? `${markFor(brandOf(q, who), glyphs)} ` : "";
+    // A `▸` says which limit binds, and is worth two columns only when there is more than one
+    // limit on screen to distinguish it from.
+    const marker = windows.length > 1 ? MARKER : 0;
     // Widest label first, so every bar in an account starts in the same column — a bar whose left
     // edge moves from row to row cannot be compared with the one above it, which is the only thing
     // a stack of bars is for.
-    const labels = q.windows.map((w) => compactLabel(w, room));
+    const labels = windows.map((w) => compactLabel(w, room - cells(brand)));
     const labelWidth = Math.min(
-      Math.max(...labels.map(cells)),
-      Math.max(6, room - MARKER - BAR_MIN - PCT - 1),
+      Math.max(...labels.map(cells), 0),
+      Math.max(6, room - cells(brand) - marker - BAR_MIN - PCT - 1),
     );
-    const bar = Math.max(BAR_MIN, Math.min(10, room - MARKER - labelWidth - PCT - 1));
-    for (const [i, w] of q.windows.entries()) {
+    const bar = Math.max(
+      BAR_MIN,
+      Math.min(10, room - cells(brand) - marker - labelWidth - PCT - 1),
+    );
+    // The mark keeps its own colour. The row is graded by severity — that is what a bar is for —
+    // but the one thing on it that says *whose* allowance this is has a brand colour of its own,
+    // and Anthropic's orange on the `✳` is how you know which of two accounts you are looking at
+    // without reading a word. The theme owns the colour: `Brand.Anthropic` is a group, never a
+    // value, so a palette that wants a different orange changes it in one place.
+    const mark = brand === ""
+      ? undefined
+      : [{ from: 0, to: byteLength(brand.trimEnd()), hl: brandOf(q, who)?.hl ?? "Sidebar.Heading" }];
+    for (const [i, w] of windows.entries()) {
       rows.push({
-        text: windowRow(w, labels[i] ?? w.label, labelWidth, bar, glyphs.ascii),
+        text: brand + windowRow(w, labels[i] ?? w.label, labelWidth, bar, glyphs.ascii, marker > 0),
         hl: severityGroup(w),
+        spans: mark,
         right: { text: countdown(w, now), hl: "Sidebar.Dim" },
         // Every row opens the panel, so there is no row here you can land on and press `↵` on to
         // no effect — which is the thing that teaches people the column is not interactive.
         command: `${NS}.panel`,
       });
     }
-    const said = plainly(q, now, room);
-    if (said) rows.push({ ...said, command: `${NS}.panel` });
-    const credit = creditRow(q);
-    if (credit) rows.push({ ...credit, command: `${NS}.panel` });
+    // The sentence under the bars, and the credit line: both are explanations, and an explanation
+    // is the first thing to give up when the column is being asked to say less.
+    if (style === "full") {
+      const said = plainly(q, now, room);
+      if (said) rows.push({ ...said, command: `${NS}.panel` });
+    }
+    if (style !== "one") {
+      const credit = creditRow(q);
+      if (credit) rows.push({ ...credit, command: `${NS}.panel` });
+    }
   }
   if (rows.length === 0) return null;
   // The way in, on the heading. Every row here opens the panel too, but a key you can press from
   // the composer without going to the sidebar first is a different affordance from a row you have
   // to arrive at — and it is the one somebody who has never focused this column will find.
   return { title: "PLAN", hint: "^L", at: "below" as const, rows };
+}
+
+/** The credential this allowance belongs to, for its mark and its colour. */
+function brandOf(q: QuotaSnapshot, who: CredentialInfo[]): Brand | null | undefined {
+  return who.find((c) => c.instance === q.instance)?.brand;
 }
 
 /**
@@ -351,10 +465,13 @@ function windowRow(
   labelWidth: number,
   bar: number,
   ascii: boolean,
+  marked = true,
 ): string {
   // The limit that would actually refuse the next request, marked the way the panel marks it. Two
-  // spaces otherwise, so the labels stay in one column.
-  const marker = w.active ? (ascii ? "> " : "▸ ") : "  ";
+  // spaces otherwise, so the labels stay in one column — and nothing at all when there is only one
+  // limit on the strip, since a marker that is on every row it can be on marks nothing and costs
+  // two columns of a label that is being clipped.
+  const marker = !marked ? "" : w.active ? (ascii ? "> " : "▸ ") : "  ";
   const pct = `${Math.round(w.used_percent)}%`.padStart(PCT);
   const name = clip(label, labelWidth);
   return `${marker}${name}${" ".repeat(Math.max(0, labelWidth - cells(name)))} ${


### PR DESCRIPTION
Three complaints from using it, and one bug found while fixing them.

## The panel

`j` and `k` were the whole of it. Now the motions are Vim's and they take a count, in the two
places that have a cursor over rows and no text field — the project panel and the transcript
reader:

| | |
|---|---|
| `5j` `3k` | that many rows you can *land on*, so headings and rules do not eat two of the five |
| `^D` `^U` | half the panel's real height; `PgUp`/`PgDn` for a whole one |
| `gg` `G` | the ends, and `5gg` / `5G` for the fifth row |
| `>` `<` `=` | wider, narrower, default — it is the `sidebar.width` setting, so `config.toml` and the key say one number |

A half-typed count is drawn at the foot, because a first press with no visible effect is
indistinguishable from a key that does nothing. Counts are deliberately *not* in the core: panel
keys live in `chat` mode, which is the mode the composer types in.

Not `^F`/`^B` for a page — those stay the archive and hiding the panel.

## The column

- **The conversation you are in says its whole title**, cursor or no cursor (`ListRow.expand`).
- **The foot is held against the bottom edge** (`render({ pinned })`), so the plan gauge is not in
  a different place every time a project is folded.
- **A dock resizes in place** — new `ApiCall::WinResize`. Reopening gives the window a new id and
  drops the keyboard, so a panel resized from inside itself threw the cursor back to the composer.
- Session rows gave back two columns of indent, and the clip maths stopped subtracting two more
  than the prefix it stood for.
- Generated titles are asked for at 2–5 words and clamped at a word boundary.

## The plan strip

Five rows for one account became one: the limit that would refuse the next request, plus anything
else already `critical`, with the provider's mark in the provider's colour on it. `⇥` on the row
steps up to every window and then to the whole block. `usage.sidebar.style` sets where it starts,
`usage.sidebar` takes it off the column, and `^L` is all of it whichever is showing.

Two gaps in the contribution model closed to do it on the public API:

- `sidebar.action` takes `on: "custom"`, so a plugin can put a key on the rows it contributed
  rather than on every row in somebody else's panel.
- `sidebar.section` rows carry `spans`, so a contributed row can wear a mark that is not the row's
  own colour.

## Tool cards

No blank row above a card, and its body under a corner (`└`) at a four-column indent rather than a
rule down the whole left side. Prose keeps its paragraph break; two commands are not two
paragraphs. See ADR 0049 for why both of ADR 0040's arguments were right about a shape that has
since changed.

## The bug

`Activity::Compacted { after }` was drawn as a card and then thrown away. A driver that has once
answered *how full is it* turns off the estimate `Session::add_usage` derives from a request's
prompt — so nothing else was going to correct the footer, and it reported the pre-compaction number
for the rest of the conversation, directly under a card saying `180k → 12k`.

## Verification

Per-crate, plus the screen: `builtin_plugins` (140), `reading` (25), `editing`, `sessions`,
`questions`, `approvals`, `user_config`, `workspace`, `neosh-core`, and the binary's own 220 unit
tests. Bindings regenerate with no drift; both TS trees typecheck. Four new tests — counts, resize,
the plan density ladder, the brand colour on a strip row, and the compaction meter, which was
checked against the un-fixed host to confirm it fails without it.

Everything visual was driven under a pty with `scripts/shot.py` rather than read off the code.