### PR TITLE
fix: closing the last conversation empties the workspace

### DIFF
--- a/crates/neosh-agent/src/session.rs
+++ b/crates/neosh-agent/src/session.rs
@@ -111,6 +111,20 @@ pub struct Session {
     /// See [`neosh_proto::TurnRequest::resume`]. Held here rather than in the driver because the
     /// driver is a process and this is not: the whole point of the value is that it survives one.
     pub resume: Option<String>,
+    /// A place to type, minted because there was nowhere else — not a conversation you started.
+    ///
+    /// The store always has an active session: there has to be somewhere for the next message to
+    /// go. That invariant is what used to make "the last session cannot be closed" a rule, and a
+    /// workspace you have just cleared out is exactly when you want the opposite. So closing or
+    /// archiving the last one lands you in one of these instead: it is the active session, the
+    /// composer types into it and the transcript shows the welcome — but it is not in
+    /// [`list`](crate::store::SessionStore::list) and it is never written to disk, because nobody
+    /// asked for it and an empty workspace should look empty.
+    ///
+    /// It stops being one the moment anything is said in it, which is the only thing that makes a
+    /// conversation a conversation. From then on it is an ordinary session: it appears in the
+    /// panel, in its project, and is saved with the rest.
+    pub ephemeral: bool,
 }
 
 impl Session {
@@ -135,6 +149,7 @@ impl Session {
             archived_at: None,
             permission_mode: None,
             resume: None,
+            ephemeral: false,
         }
     }
 
@@ -176,6 +191,11 @@ impl Session {
 
     /// What was said, with whatever came with it.
     pub fn push_user(&mut self, prompt: &Prompt) {
+        // Saying something in a placeholder is what makes it a conversation. Here rather than at
+        // any of the call sites because there is more than one way to speak into a session — the
+        // composer, a steering message taken in mid-turn, a peer on another machine — and the one
+        // that forgot would leave a conversation with messages in it that no list ever shows.
+        self.ephemeral = false;
         self.messages.push(Message { role: Role::User, content: prompt.blocks() });
     }
 

--- a/crates/neosh-agent/src/store.rs
+++ b/crates/neosh-agent/src/store.rs
@@ -80,6 +80,11 @@ impl SessionStore {
     }
 
     /// Make `id` the active session, parking the current one.
+    ///
+    /// A placeholder is not parked, it is dropped. It exists only because the workspace had to
+    /// have somewhere to type; the moment you are somewhere else it is an empty conversation
+    /// nobody asked for, invisible in every list, and keeping it would mean `step_away` could
+    /// later land you in a months-old one instead of in something real.
     pub fn switch(&mut self, id: &SessionId) -> Result<(), StoreError> {
         if &self.active.id == id {
             self.active.unread = false;
@@ -91,7 +96,11 @@ impl SessionStore {
         // saying "new" in the status line you did not happen to be looking at.
         next.unread = false;
         let previous = std::mem::replace(&mut self.active, next);
-        self.idle.insert(previous.id.clone(), previous);
+        if previous.ephemeral {
+            self.order.retain(|x| x != &previous.id);
+        } else {
+            self.idle.insert(previous.id.clone(), previous);
+        }
         // Move to the front rather than re-sorting: "most recently active" is a history, and a
         // history is something you append to.
         self.order.retain(|x| x != id);
@@ -211,27 +220,43 @@ impl SessionStore {
     }
 
     /// Every session, most recently active first, with the active one flagged.
+    ///
+    /// A placeholder is never in it, archived or not: it is somewhere to type rather than
+    /// something you started, and a workspace you have just cleared out should read as empty.
+    /// See [`Session::ephemeral`](crate::session::Session::ephemeral).
     pub fn list_with(&self, include_archived: bool) -> Vec<SessionInfo> {
         let mut seen: Vec<SessionInfo> = Vec::with_capacity(self.len());
         for id in &self.order {
-            if let Some(s) = self.get(id) {
+            if let Some(s) = self.get(id).filter(|s| !s.ephemeral) {
                 seen.push(self.info(s));
             }
         }
         // Anything inserted without touching `order` still has to appear; a session you cannot see
         // is a session you cannot get back to.
         for (id, s) in &self.idle {
-            if !self.order.contains(id) {
+            if !self.order.contains(id) && !s.ephemeral {
                 seen.push(self.info(s));
             }
         }
-        if !self.order.contains(&self.active.id) {
+        if !self.order.contains(&self.active.id) && !self.active.ephemeral {
             seen.insert(0, self.info(&self.active));
         }
         if !include_archived {
             seen.retain(|s| !s.archived);
         }
         seen
+    }
+
+    /// Whether there is a conversation you could go to, as opposed to somewhere to start one.
+    ///
+    /// The same question [`list`](Self::list) answers, asked without building the list. Archived
+    /// ones do not count: what you have put away is not in any list you work from, so a workspace
+    /// with nothing but an archive in it reads as empty — and the way back to that archive is one
+    /// of the things an empty workspace has to say. A placeholder does not count either, which is
+    /// the whole of what a placeholder is.
+    pub fn any_open(&self) -> bool {
+        let open = |s: &Session| !s.ephemeral && !s.archived;
+        open(&self.active) || self.idle.values().any(open)
     }
 
     /// Every session, for persistence.
@@ -290,6 +315,37 @@ mod tests {
         assert_ne!(s.active_id(), &a);
         assert!(!s.active().archived);
         assert!(s.list().iter().all(|i| i.id != a));
+    }
+
+    #[test]
+    fn a_placeholder_is_in_no_list_and_is_dropped_the_moment_you_are_somewhere_else() {
+        // Somewhere to type after you have cleared the workspace out, and nothing more than that.
+        // In a list it would be a conversation you never started, in a project you had just
+        // emptied; parked on a switch it would be one more of them every time.
+        let (mut s, _a, b, _c) = store();
+        let here = s.active_id().clone();
+        s.active_mut().ephemeral = true;
+        assert!(s.list().iter().all(|i| i.id != here), "not in the everyday list");
+        assert!(s.list_with(true).iter().all(|i| i.id != here), "nor in the one with the archive");
+        assert!(s.any_open(), "the real conversations are still there");
+
+        s.switch(&b).expect("switches");
+        assert!(s.get(&here).is_none(), "gone rather than parked");
+        assert_eq!(s.len(), 2, "and not counted either");
+    }
+
+    #[test]
+    fn a_workspace_of_a_placeholder_and_an_archive_has_nothing_open() {
+        // What `^F` is for on the empty transcript: everything archived reads as empty, because
+        // what you have put away is not in the list you work from.
+        let mut s = SessionStore::new(Session::new("/tmp"));
+        s.active_mut().ephemeral = true;
+        let away = Session::new("/tmp");
+        let id = away.id.clone();
+        s.insert(away);
+        s.archive(&id, true, 1).expect("archives");
+        assert!(!s.any_open());
+        assert!(s.list_with(true).iter().any(|i| i.id == id), "still there to go back to");
     }
 
     #[test]

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -1249,6 +1249,13 @@ impl Host {
             }
             ApiCall::SessionClose { session } => {
                 let closing_active = self.agent.sessions().active_id() == &session;
+                // Closing the conversation you are in has to land you somewhere, and the store
+                // will not step out of the last one on its own. Same line as the archive path
+                // below and for the same reason: being unable to delete the conversation you have
+                // finished with, because it is the only one, is not a rule anybody wanted.
+                if closing_active {
+                    self.ensure_somewhere_to_go(&session);
+                }
                 // Closing is the one case that does stop a turn: there is about to be nowhere to
                 // put its answer, and a stream writing into a conversation that no longer exists is
                 // a subprocess nobody can reach.
@@ -1277,6 +1284,11 @@ impl Host {
                 // somebody's stale colour.
                 self.vars.forget_session(&session);
                 if closing_active {
+                    // Where you landed is a conversation of its own, and it may be in another
+                    // directory: the banner names one, the file tools are pointed at one, and
+                    // both were still the deleted conversation's until this said otherwise.
+                    let here = { self.agent.sessions().active().cwd.clone() };
+                    self.work_in(here).await;
                     self.enter_session();
                 }
                 self.persist_sessions();
@@ -1289,8 +1301,8 @@ impl Host {
                 let leaving = archived && self.agent.sessions().active_id() == &session;
                 // Archiving the only conversation you have is a reasonable thing to want, and
                 // "there is nowhere to go" is a bad answer to it. Somewhere to go is one line.
-                if leaving && self.agent.sessions().list().len() <= 1 {
-                    self.new_session_in(self.cwd.clone());
+                if leaving {
+                    self.ensure_somewhere_to_go(&session);
                 }
                 let at = now_secs();
                 self.agent.sessions().archive(&session, archived, at).map_err(|e| match e {
@@ -1300,6 +1312,8 @@ impl Host {
                     other => ApiError::NotFound { what: other.to_string() },
                 })?;
                 if leaving {
+                    let here = { self.agent.sessions().active().cwd.clone() };
+                    self.work_in(here).await;
                     self.enter_session();
                 }
                 self.persist_sessions();
@@ -1593,18 +1607,48 @@ impl Host {
         }
     }
 
-    /// Start an empty conversation without switching to it.
+    /// Make sure leaving `session` has somewhere to land, minting a placeholder if it does not.
     ///
-    /// Exists so that archiving the only conversation you have has somewhere to land. It inherits
-    /// the model and system prompt for the same reason a new conversation does: changing what you
-    /// are talking to as a side effect of tidying up would be a strange thing to do.
-    fn new_session_in(&mut self, cwd: std::path::PathBuf) {
+    /// A conversation you are finished with is a conversation you can close, and that includes the
+    /// last one: "the last session cannot be closed" is the store refusing the only thing left to
+    /// do in a workspace you have just cleared out. The store always has an active conversation —
+    /// there has to be somewhere for the next message to go — so "nothing left" is spelled as a
+    /// [placeholder](neosh_agent::Session::ephemeral): the composer types into it and the
+    /// transcript shows the welcome, but no list contains it and nothing is written to disk. An
+    /// emptied workspace should look empty, and one conversation named after nothing is not empty.
+    ///
+    /// Asked of [`list`](neosh_agent::store::SessionStore::list), which leaves out what is
+    /// archived, because landing in something you deliberately put away is the one destination
+    /// that is definitely wrong — a workspace whose every other conversation is archived is as
+    /// alone as one with no other conversation at all.
+    fn ensure_somewhere_to_go(&mut self, leaving: &neosh_proto::SessionId) {
+        let alone = { self.agent.sessions().list().iter().all(|s| &s.id == leaving) };
+        if alone {
+            // In the directory you are leaving rather than the one neosh was started in: the next
+            // thing you type is almost certainly about the project you were just in, and a
+            // placeholder somewhere else would silently move the file tools with it.
+            let id = self.new_session_in(self.cwd.clone());
+            if let Some(s) = self.agent.sessions().get_mut(&id) {
+                s.ephemeral = true;
+            }
+        }
+    }
+
+    /// Start an empty conversation without switching to it, and say which one it is.
+    ///
+    /// Exists so that closing or archiving the only conversation you have has somewhere to land.
+    /// It inherits the model and system prompt for the same reason a new conversation does:
+    /// changing what you are talking to as a side effect of tidying up would be a strange thing to
+    /// do.
+    fn new_session_in(&mut self, cwd: std::path::PathBuf) -> neosh_proto::SessionId {
         let mut session = neosh_agent::Session::new(cwd);
         session.created_at = now_secs();
         session.updated_at = session.created_at;
         session.selection = self.agent.selection();
         session.system = self.agent.session().system.clone();
+        let id = session.id.clone();
         self.agent.sessions().insert(session);
+        id
     }
 
     fn editor_message(&mut self, level: MessageLevel, text: impl Into<String>) {
@@ -2045,8 +2089,10 @@ impl Host {
                     .map(std::path::PathBuf::from)
                     .unwrap_or_else(|| self.cwd.clone());
                 if dir.is_dir() {
-                    self.new_session_in(dir);
-                    Ok(Some(self.agent.sessions().active_id().clone()))
+                    // The one just made, not whatever is on screen here: `new_session_in` inserts
+                    // without switching, so the active id is the conversation this machine happens
+                    // to be looking at and the peer would be handed somebody else's.
+                    Ok(Some(self.new_session_in(dir)))
                 } else {
                     Err(neosh_proto::Refusal::Failed {
                         message: format!("{} is not a directory here", dir.display()),
@@ -2753,6 +2799,11 @@ impl Host {
             None => "nothing configured \u{2014} run `neosh --list-models`".to_string(),
         };
 
+        // Whether this is a workspace or an empty one. A placeholder is what you land in after
+        // closing the last conversation — or after reopening a workspace whose every conversation
+        // was archived — and the transcript is the only thing on screen with room to say what to
+        // press next, because the panel beside it is, correctly, blank.
+        let empty = !self.agent.sessions().any_open();
         let ascii = self.option_bool("ui.ascii_only");
         let width = self.chat_width();
         let mut rows: Vec<String> = vec![String::new()];
@@ -2781,6 +2832,17 @@ impl Host {
         say(&mut rows, format!("  model      {model}"), vec![(0, 13, "Comment")]);
         say(&mut rows, format!("  directory  {}", tilde(&self.cwd)), vec![(0, 13, "Comment")]);
         rows.push(String::new());
+        // Said only when it is true: there is no conversation anywhere, so nothing else on screen
+        // is going to tell you that typing is how one starts.
+        if empty {
+            // Short enough to be one row. Nothing here wraps the welcome, so a sentence longer than
+            // the chat is a second line starting at column zero, under an indented one — and the
+            // row of keys below already says how to add a project, which is the rest of it.
+            let line = "  Nothing open. What you type here starts a conversation.".to_string();
+            let len = line.len();
+            say(&mut rows, line, vec![(0, len, "Comment")]);
+            rows.push(String::new());
+        }
         // Only when there is something to say. On a working setup the welcome should be the word,
         // a few short lines, and then out of the way.
         if selection.as_ref().is_some_and(|s| !self.selection_is_usable(s)) {
@@ -2793,13 +2855,25 @@ impl Host {
         }
         // The keys worth knowing before the first question — and the one most people never find,
         // which is that the transcript is a place you can go. The rest of the table is on `^Z`.
-        let keys: [(&str, &str); 5] = [
-            (if ascii { "Enter" } else { "\u{23ce}" }, "send"),
-            ("^S", "browse & copy"),
-            ("^P", "model"),
-            ("^T", "projects"),
-            ("^Z", "every key"),
-        ];
+        let keys: [(&str, &str); 5] = if empty {
+            // A different five, because four of the everyday ones are about a conversation and
+            // there is not one. What is worth knowing here is how to get one.
+            [
+                (if ascii { "Enter" } else { "\u{23ce}" }, "start"),
+                ("^O", "add project"),
+                ("^T", "projects"),
+                ("^F", "archived"),
+                ("^Z", "every key"),
+            ]
+        } else {
+            [
+                (if ascii { "Enter" } else { "\u{23ce}" }, "send"),
+                ("^S", "browse & copy"),
+                ("^P", "model"),
+                ("^T", "projects"),
+                ("^Z", "every key"),
+            ]
+        };
         let mut line = String::from("  ");
         let mut spans = Vec::new();
         for (i, (key, label)) in keys.iter().enumerate() {
@@ -6228,10 +6302,19 @@ impl Host {
             let target = active.or_else(|| {
                 order.iter().find(|id| store.get(id).is_some_and(|s| !s.archived)).cloned()
             });
-            if let Some(id) = target
-                && store.switch(&id).is_ok()
-            {
-                let _ = store.remove(&placeholder);
+            match target.filter(|id| store.switch(id).is_ok()) {
+                Some(_) => {
+                    let _ = store.remove(&placeholder);
+                }
+                // Nothing to land in, so what you land in is not a conversation either: the
+                // session the store was constructed with becomes the placeholder, which is what
+                // makes "everything is archived" look like an empty workspace rather than like a
+                // workspace with one conversation in it that you never started.
+                None => {
+                    if let Some(s) = store.get_mut(&placeholder) {
+                        s.ephemeral = true;
+                    }
+                }
             }
             store.set_order(order);
         }

--- a/crates/neosh/src/sessions.rs
+++ b/crates/neosh/src/sessions.rs
@@ -173,14 +173,27 @@ pub fn save(state: &Path, session: &Session) -> std::io::Result<()> {
 }
 
 /// Write every session plus the ordering.
+///
+/// Every session that is one: a [placeholder](neosh_agent::Session::ephemeral) is somewhere to
+/// type that was minted because the workspace had nowhere else, and writing it down would mean an
+/// emptied workspace came back with a conversation in it that nobody had started. It is left out
+/// of the order too, and is never what `active` names — restarting into it happens by there being
+/// nothing to restore, which is the state it stands for.
 pub fn save_all(state: &Path, store: &SessionStore) -> std::io::Result<()> {
     std::fs::create_dir_all(dir(state))?;
-    for s in store.iter() {
+    for s in store.iter().filter(|s| !s.ephemeral) {
         save(state, s)?;
     }
+    let order: Vec<SessionId> = store
+        .order()
+        .iter()
+        .filter(|id| store.get(id).is_some_and(|s| !s.ephemeral))
+        .cloned()
+        .collect();
     let order = Order {
-        order: store.order().to_vec(),
-        active: Some(store.active_id().clone()),
+        order,
+        active: Some(store.active_id().clone())
+            .filter(|id| store.get(id).is_some_and(|s| !s.ephemeral)),
     };
     let path = order_path(state);
     let tmp = path.with_extension("json.tmp");

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -5950,7 +5950,7 @@ fn the_plan_row_keeps_the_providers_own_colour() {
     s.send(&command("planner.publish"));
     s.wait_for("published");
     assert!(
-        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("Session"))),
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("Planner"))),
         "the strip is drawn\n{:?}",
         s.sidebar_now()
     );
@@ -5959,7 +5959,7 @@ fn the_plan_row_keeps_the_providers_own_colour() {
     let at = s
         .sidebar_now()
         .iter()
-        .position(|l| l.contains("Session"))
+        .position(|l| l.contains("Planner"))
         .expect("the row with the binding limit on it");
     let groups = s.groups_of(buf);
     let on_row = groups.get(at).cloned().unwrap_or_default();

--- a/crates/neosh/tests/sessions.rs
+++ b/crates/neosh/tests/sessions.rs
@@ -280,6 +280,11 @@ export async function activate({ neosh }: PluginContext) {
       neosh.notify(`close failed: ${e}`);
     }
   });
+  await neosh.cmd.register("t.count", async () => {
+    const open = await neosh.session.list();
+    const all = await neosh.session.list({ includeArchived: true });
+    neosh.notify(`count: ${open.length} open, ${all.length} in all`);
+  });
   await neosh.cmd.register("t.listAll", async () => {
     const all = await neosh.session.list({ includeArchived: true });
     neosh.notify(
@@ -432,14 +437,41 @@ fn a_conversation_in_another_directory_is_how_a_second_project_appears() {
 }
 
 #[test]
-fn closing_the_last_conversation_is_refused() {
-    // There is always somewhere for the next thing you type.
+fn closing_the_last_conversation_leaves_an_empty_workspace() {
+    // There is always somewhere for the next thing you type — which is a reason to *make* one,
+    // not a reason to refuse. "The last session cannot be closed" was the workspace declining the
+    // only thing left to do in a workspace you have finished clearing out.
+    //
+    // What you land in is a placeholder: the composer types into it and the transcript draws into
+    // it, but no list contains it, so an emptied workspace reads as empty rather than as one
+    // conversation nobody started.
     let sb = Sandbox::new("last");
     install_driver(&sb);
     let mut s = sb.start();
     s.wait_for("driver ready");
+
+    s.type_text("the only one");
+    s.enter();
+    s.wait_for("the only one");
+
     s.command("t.closeActive");
-    s.wait_for("close failed:");
+    s.wait_for("closed");
+    // Nothing open and nothing archived: closing is not archiving, and `includeArchived` is what
+    // would still have found it.
+    s.command("t.count");
+    s.wait_for("count: 0 open, 0 in all");
+    assert!(
+        s.pump(|s| !s.chat_now().iter().any(|l| l.contains("the only one"))),
+        "the transcript you closed is off the screen\n{:?}",
+        s.chat_now()
+    );
+    // And the transcript says what to do about it, because the panel beside it is — correctly —
+    // blank.
+    assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("Nothing open"))),
+        "an empty workspace says how to start one\n{:?}",
+        s.chat_now()
+    );
 }
 
 #[test]
@@ -462,6 +494,68 @@ fn closing_the_active_conversation_lands_on_another_one() {
         "landed back in the surviving conversation\n{:?}",
         s.chat_now()
     );
+}
+
+#[test]
+fn saying_something_in_the_placeholder_makes_it_a_conversation() {
+    // The other half of an empty workspace: what you land in is somewhere to type, and typing in it
+    // is what a conversation is. Without this the message would go into something no list ever
+    // showed and nothing ever saved.
+    let sb = Sandbox::new("placeholder");
+    install_driver(&sb);
+    let mut s = sb.start();
+    s.wait_for("driver ready");
+
+    s.command("t.closeActive");
+    s.wait_for("closed");
+    s.command("t.count");
+    s.wait_for("count: 0 open, 0 in all");
+
+    s.type_text("starting again");
+    s.enter();
+    s.wait_for("starting again");
+    s.command("t.count");
+    s.wait_for("count: 1 open, 1 in all");
+    // And it is named after what was said in it, like any other.
+    s.command("t.list");
+    s.wait_for("sessions: *starting again");
+
+    // Including on disk. `save_all` skips placeholders, so the flag being cleared is the only
+    // thing standing between this message and never being written down.
+    s.command("quit");
+    assert!(s.exits_within(Duration::from_secs(10)), "clean exit");
+    let mut s = sb.start();
+    s.wait_for("driver ready");
+    s.command("t.list");
+    s.wait_for("sessions: *starting again");
+}
+
+#[test]
+fn closing_the_only_open_conversation_does_not_land_you_in_an_archived_one() {
+    // Archived is where you put the things you are finished with, so a workspace whose every other
+    // conversation is archived is as alone as one with no other conversation at all — and landing
+    // in something you deliberately put away is the one destination that is definitely wrong.
+    let sb = Sandbox::new("closearchived");
+    install_driver(&sb);
+    let mut s = sb.start();
+    s.wait_for("driver ready");
+
+    s.type_text("put me away");
+    s.enter();
+    s.wait_for("put me away");
+    s.command("t.new");
+    s.wait_for("created");
+    s.command("t.archiveOldest");
+    s.wait_for("archived");
+
+    s.command("t.closeActive");
+    s.wait_for("closed");
+    // A placeholder, not the conversation you put away: one thing in the workspace and none of it
+    // open.
+    s.command("t.count");
+    s.wait_for("count: 0 open, 1 in all");
+    s.command("t.listAll");
+    s.wait_for("all: ~put me away");
 }
 
 #[test]
@@ -492,9 +586,10 @@ fn an_archived_conversation_leaves_the_list_without_leaving_the_store() {
 }
 
 #[test]
-fn archiving_the_only_conversation_lands_you_in_a_fresh_one_rather_than_nowhere() {
-    // The store refuses to leave you with nothing; the host answers by starting something empty,
-    // because "there is nowhere to go" is a bad answer to "I am done with this".
+fn archiving_the_only_conversation_lands_you_somewhere_rather_than_nowhere() {
+    // The store refuses to leave you with nothing; the host answers with a placeholder, because
+    // "there is nowhere to go" is a bad answer to "I am done with this" — and a placeholder rather
+    // than a conversation, because a workspace you have just emptied should read as empty.
     let sb = Sandbox::new("archivelast");
     install_driver(&sb);
     let mut s = sb.start();
@@ -506,8 +601,8 @@ fn archiving_the_only_conversation_lands_you_in_a_fresh_one_rather_than_nowhere(
 
     s.command("t.archiveActive");
     s.wait_for("archived the active one");
-    s.command("t.list");
-    s.wait_for("sessions: *New conversation");
+    s.command("t.count");
+    s.wait_for("count: 0 open, 1 in all");
     s.command("t.listAll");
     s.wait_for("~the only one");
 }
@@ -541,6 +636,37 @@ fn archiving_survives_a_restart() {
     );
     s.command("t.listAll");
     s.wait_for("~shelved");
+}
+
+#[test]
+fn a_workspace_with_everything_archived_starts_empty() {
+    // The restore path's own version of the same rule. There is something saved and nothing open to
+    // land in, so the session the store is constructed with becomes the placeholder rather than
+    // being removed — otherwise reopening a workspace you had put away entirely would greet you
+    // with one conversation you never started, in a project, next to the ones you archived.
+    let sb = Sandbox::new("allarchived");
+    install_driver(&sb);
+    {
+        let mut s = sb.start();
+        s.wait_for("driver ready");
+        s.type_text("all done");
+        s.enter();
+        s.wait_for("all done");
+        s.command("t.archiveActive");
+        s.wait_for("archived the active one");
+        s.command("quit");
+        assert!(s.exits_within(Duration::from_secs(10)), "clean exit");
+    }
+
+    let mut s = sb.start();
+    s.wait_for("driver ready");
+    s.command("t.count");
+    s.wait_for("count: 0 open, 1 in all");
+    assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("Nothing open"))),
+        "and the transcript says so\n{:?}",
+        s.chat_now()
+    );
 }
 
 #[test]

--- a/docs/adr/0039-the-archive-is-a-place-you-go.md
+++ b/docs/adr/0039-the-archive-is-a-place-you-go.md
@@ -102,9 +102,8 @@ It asks by 0039's rule and not by a rule of its own. An empty project is a row a
 is at stake, `o` puts it back, and a dialog there is the kind you learn to clear without reading.
 With conversations still in it, removing the project is deleting every one of them, so it asks like
 the delete it is — how many, how many of those you would still have found in your list, and that
-`x` archives instead. The conversations go first and the project only goes if all of them did: the
-store refuses to delete the very last conversation in a workspace, and a project removed anyway
-would take a row off the list that still had something in it.
+`x` archives instead. The conversations go first and the project only goes if all of them did — a
+project removed anyway would take a row off the list that still had something in it.
 
 ### Consequences
 
@@ -115,3 +114,61 @@ would take a row off the list that still had something in it.
   had to stop counting, or `forget` would put the project straight back as it cleared it.
 - **Only this panel's vars go.** Another plugin's note about the directory is that plugin's to keep,
   and a directory it still cares about comes back the next time it says so.
+
+## What was corrected afterwards: closing the last conversation, and what an empty workspace is
+
+The paragraph above used to end differently. It said the store *refuses* to delete the very last
+conversation in a workspace, and treated that as the reason a project only goes if all of its
+conversations did. That refusal reached the screen as `invalid argument: the last session cannot be
+closed`, and it was wrong twice over.
+
+**It is wrong as a rule.** Archiving the only conversation you have already worked — the host made
+somewhere to land first, because "there is nowhere to go" is a bad answer to "I am finished with
+this". Deleting it, which is the same sentence said harder, was refused. Two verbs on `x` and `X` of
+the same row, disagreeing about whether that row was allowed to be the last one.
+
+**It was wrong more often than "the last one" suggests.** Stepping away lands in another *open*
+conversation and skips archived ones, so a workspace whose every other conversation was archived was
+as alone as one with none: twenty conversations, and you still could not close the one you were in.
+
+### A placeholder is not a conversation
+
+The obvious fix — mint an ordinary empty conversation to land in — trades the error for a different
+lie. You cleared the workspace out and it says you have one conversation, in a project, which you
+never started; `X` on that project deletes it and gets another one; the panel can never be empty
+because emptying it creates the thing that fills it.
+
+So the landing place is marked: `Session::ephemeral`. It is the active session — the composer types
+into it, the transcript draws into it, `^P` picks its model — and it is in no list, in no project,
+and never written to disk. `SessionStore::list` leaves it out archived or not, `save_all` skips it
+and never names it as the active one, and `switch` *drops* it rather than parking it, because the
+moment you are somewhere else it is an empty conversation nobody asked for.
+
+It stops being one the moment anything is said in it. `push_user` clears the flag — there rather
+than at any of the call sites, because there is more than one way to speak into a session (the
+composer, a steering message taken in mid-turn, a peer over ASCP) and the one that forgot would
+leave a conversation with messages in it that no list ever showed.
+
+**An empty workspace therefore looks empty.** No rows in the panel, and the transcript — the only
+surface with room to say anything — says what to press: `↵` starts one here, `^O` adds a project,
+`^T` is the panel, `^F` is what you archived. That last one matters, because "everything is
+archived" is the most likely way to arrive here and the archive is the one place the panel does not
+show. Restoring into it works the same way: with something saved but nothing open to land in, the
+session the store was constructed with becomes the placeholder instead of being removed.
+
+**Where you land decides where "here" is.** Closing or archiving the conversation you are in now
+calls `work_in` on the one you landed in, the same as switching always did, so the banner names that
+directory and the file tools are pointed at it. Without it both verbs left the workspace working in
+the directory of a conversation that no longer existed.
+
+### Consequences
+
+- **`X` on the last project now finishes.** Its conversations go, the placeholder you land in is in
+  no project, and the panel is left with nothing but `+ Add project` — which is what you asked for
+  and what the old refusal made impossible.
+- **The placeholder is not somewhere you can go back to.** Switch away and it is gone; there is
+  nothing to return to, and nothing was lost. That is the same statement as it not being in the
+  list, said about the store rather than about the panel.
+- **A fresh start is still a conversation.** The session a new workspace is constructed with is not
+  a placeholder: nothing was cleared out, and `neosh` in a directory you have never opened should
+  read as a conversation waiting rather than as a workspace you emptied.

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -1640,9 +1640,13 @@ async function deleteSession(neosh: Neosh, session: string): Promise<boolean> {
  * still in it, removing the project is deleting every one of them, so it asks as the delete it is
  * and says how many and where they would otherwise go.
  *
- * The conversations go first and the project only goes if they all did. The store refuses to delete
- * the very last conversation in the workspace — there has to be somewhere for the next message to
- * land — and a project removed anyway would take a row that still had something in it off the list.
+ * The conversations go first and the project only goes if they all did: a project removed anyway
+ * would take a row that still had something in it off the list.
+ *
+ * Removing the *last* project used to be the one case this could not finish: the store refused to
+ * delete the very last conversation in the workspace. It no longer does — what you land in is a
+ * placeholder, which is in no list and so in no project — so `X` here can leave the panel with
+ * nothing but `+ Add project` on it. See ADR 0039.
  */
 async function removeProject(
   neosh: Neosh,


### PR DESCRIPTION
### The bug

`X` on the conversation you were in answered `invalid argument: the last session cannot be closed`.

`SessionStore::remove` steps out of the active conversation into another **open** one and errors with `LastSession` when there isn't one. `SessionArchive` already worked around that in the host by making somewhere to land first; `SessionClose` never did. It also fired more often than "the last one" suggests — stepping away skips archived conversations, so a workspace whose every *other* conversation was archived was just as stuck.

### A placeholder is not a conversation

Minting an ordinary empty conversation to land in trades the error for a different lie: you cleared the workspace out and it says you have one conversation, in a project, that you never started — and `X` on that project can never finish, because emptying it creates the thing that fills it.

So the landing place is marked: `Session::ephemeral`. It is the active session — the composer types into it, the transcript draws into it, `^P` picks its model — and it is in no list, in no project, and never written to disk. `list_with` leaves it out archived or not, `save_all` skips it and never names it as active, and `switch` *drops* it rather than parking it. `push_user` clears the flag, so saying anything makes it an ordinary conversation (there rather than at the call sites, because the composer, a steering message and an ASCP peer all speak into a session).

An emptied workspace therefore looks empty, and the transcript — the only surface with room — says what to press:

```
  Nothing open. What you type here starts a conversation.

  ⏎ start   ^O add project   ^T projects   ^F archived   ^Z every key
```

`^F` is one of the five because "everything is archived" is the likeliest way to arrive here and the archive is the one place the panel does not show. Restoring works the same way: with something saved but nothing open to land in, the session the store is constructed with becomes the placeholder.

### Also

- **Where you land decides where "here" is.** Closing or archiving the conversation you are in now calls `work_in` on the one you landed in, as switching always did. Both verbs used to leave the workspace working in the directory of a conversation that no longer existed — wrong banner, wrong file tools.
- **`X` on the last project now finishes**, leaving the panel with nothing but `+ Add project`.
- One unrelated stale assertion: `the_plan_row_keeps_the_providers_own_colour` still looked for `Session` on the one-row plan strip, which c280938 relabelled to the account. Its sibling test was updated there and this one was missed.

ADR 0039 gains a section for all of it.

### Verification

- `cargo test -p neosh --test sessions -- --test-threads 2` — 32/32, including four new: closing the last one, closing when everything else is archived, a placeholder becoming real and surviving a restart, and a workspace of nothing but an archive starting empty.
- `cargo test -p neosh-agent` — 64 lib + 9, including two new store tests.
- `cargo test -p neosh --test builtin_plugins` — passes; note that suite is flaky under parallel load on this machine (different tests fail per batch run, all pass individually).
- `cargo test -p neosh-proto export_bindings` + `git diff --exit-code plugins/api/src/generated` — clean.
- Driven under a pty with `scripts/shot.py`: `^T`, `X`, confirm on the only conversation, which used to be the error.