### PR TITLE
fix: work is not lost when the workspace stops

### DIFF
--- a/crates/neosh-agent/src/session.rs
+++ b/crates/neosh-agent/src/session.rs
@@ -95,6 +95,19 @@ pub struct Session {
     /// there is more than one list: the panel, a status segment and a picker all have to agree,
     /// and a second panel deriving it from timestamps would disagree with the first.
     pub unread: bool,
+    /// A turn was in flight here when this conversation was last written to disk.
+    ///
+    /// Seconds since the epoch, stamped when the turn began. Persisted, and that is the entire
+    /// point: nothing running in a process can tell you that a *previous* process died, so the only
+    /// way to know a turn was cut off is to have written down that one had started and to find the
+    /// note still there. Cleared when the turn ends, however it ends — an interrupt and an error
+    /// are both endings, and neither is what this is for.
+    pub running_since: Option<i64>,
+    /// The workspace stopped while a turn was running here.
+    ///
+    /// See [`neosh_proto::SessionInfo::interrupted`]. Derived once, where it can be: at load, from
+    /// a `running_since` that outlived the process that set it.
+    pub interrupted: bool,
     /// Put away, not thrown away: still on disk, still openable, just not in the everyday list.
     pub archived: bool,
     /// When it was put away, in seconds since the epoch. Set by whoever archives it, for the same
@@ -145,6 +158,8 @@ impl Session {
             created_at: 0,
             updated_at: 0,
             unread: false,
+            running_since: None,
+            interrupted: false,
             archived: false,
             archived_at: None,
             permission_mode: None,
@@ -291,6 +306,7 @@ impl Session {
             // Filled in by the store, which is the only thing that knows.
             is_active: false,
             unread: self.unread,
+            interrupted: self.interrupted,
             archived: self.archived,
             archived_at: self.archived_at,
             permission_mode: self.permission_mode,

--- a/crates/neosh-proto/src/agent.rs
+++ b/crates/neosh-proto/src/agent.rs
@@ -222,6 +222,23 @@ pub struct SessionInfo {
     /// conversation with the answer in it.
     #[serde(default)]
     pub unread: bool,
+    /// The workspace stopped while a turn was running here, and nothing ended that turn.
+    ///
+    /// The one thing a conversation cannot notice about itself: a process that is killed does not
+    /// get to write down that it was. So a turn writes down that it *started* and clears the note
+    /// when it ends, and a note still there when the conversation is next loaded says the process
+    /// that made it never got to the end — the machine was shut down, the workspace was `SIGKILL`ed,
+    /// the OOM killer chose it. Whatever the agent had already done is in `messages`; what it was
+    /// in the middle of is gone, and this is the only thing that will ever say so.
+    ///
+    /// Deliberately *not* the same kind of mark as [`Self::unread`], which is news and is cleared
+    /// by arriving. This is a fact about the conversation's last turn, and arriving does not change
+    /// it: at startup you land in the conversation you were last in, which is usually the one that
+    /// was cut off, and a mark that cleared on arrival would clear exactly the one that mattered
+    /// most before you had read it. It goes when a new turn starts here, because that is the point
+    /// at which the last turn stops being the last turn.
+    #[serde(default)]
+    pub interrupted: bool,
     /// Put away rather than thrown away.
     ///
     /// An archived conversation keeps every message and can be brought back; it is simply not in

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -4335,6 +4335,48 @@ impl Host {
     /// messages rather than replayed from the UI events that first produced it: the messages are
     /// the truth, and a switch that reconstructed the buffer from a log of edits would drift the
     /// moment anything else touched it.
+    /// Draw the conversation on screen again from its messages, and touch nothing else.
+    ///
+    /// The buffer half of [`Self::enter_session`], for the times the *replay* has changed its mind
+    /// about a conversation you are already in. The live path only ever appends, so anything it has
+    /// already drawn stays drawn — which is right for a transcript, and wrong for the one row in it
+    /// that is a statement about the conversation's tail rather than about something that happened.
+    ///
+    /// Deliberately not `enter_session`: that clears the unread mark, leaves reading mode, and
+    /// resets the working line and the scroll, all of which are correct on arrival and destructive
+    /// in the middle of a conversation you never left.
+    fn redraw_transcript(&mut self) {
+        let ascii = self.option_bool("ui.ascii_only");
+        let limits = self.limits();
+        let width = self.chat_width();
+        let show_tools = self.option_bool("chat.show_tools");
+        let here = self.active_session();
+        let running = self.turns.contains_key(&here);
+        let (lines, marks) = {
+            let store = self.agent.sessions();
+            let s = store.active();
+            let (lines, marks, _) = transcript(s, ascii, limits, width, show_tools, running);
+            (lines, marks)
+        };
+        let plugin = PluginId::from(BUILTIN);
+        // Marks first, and all of them: a mark clamps rather than dies when the line under it is
+        // replaced, so a rebuild that skipped this would leave every previous mark stacked on the
+        // rows that happen to survive.
+        let _ = self.editor.apply(&plugin, ApiCall::MarkClear {
+            ns: self.chat_ns,
+            buf: self.chat,
+            start: None,
+            end: None,
+        });
+        let _ = self.editor.apply(&plugin, ApiCall::BufSetLines {
+            buf: self.chat,
+            start: 0,
+            end: -1,
+            lines,
+        });
+        self.draw_marks(&marks, 0);
+    }
+
     fn enter_session(&mut self) {
         // First, and while the transcript being read is still the one on screen. Reading is a place
         // *in* a conversation — a cursor at a row, a selection between two of them, a search
@@ -5392,6 +5434,30 @@ impl Host {
         let on_screen = &self.active_session() == ev.session();
         match ev {
             AgentEvent::TurnStarted { session, turn } => {
+                // Write down that a turn is in flight, and clear whatever the last one left. This
+                // has to reach the disk *now* rather than at the next commit: the window it covers
+                // starts here, and a note written after the first tool round would miss every turn
+                // that was killed before it got that far — which is most of a turn's first minute.
+                //
+                // Starting a turn is also what ends the previous one's mark. The row is red because
+                // the last turn here never finished; it stops being the last turn at this moment,
+                // and the transcript keeps the evidence either way.
+                let was_cut_off = match self.agent.sessions().get_mut(&session) {
+                    Some(sess) => {
+                        sess.running_since = Some(now_secs());
+                        std::mem::take(&mut sess.interrupted)
+                    }
+                    None => false,
+                };
+                self.persist_session(&session);
+                // The line saying the last turn was killed is now a lie, and the live path cannot
+                // take back something it has drawn — so the replay draws it again without. Done
+                // here rather than when the message was pushed because everything up to and
+                // including the new question is in `messages` by now and nothing of the answer has
+                // been drawn yet, which is the one moment a rebuild costs nothing.
+                if was_cut_off && on_screen {
+                    self.redraw_transcript();
+                }
                 // Out to anybody watching from another machine, before the local broadcast: the
                 // two are independent, and a watcher waiting on a plugin round trip would see the
                 // turn start late for no reason.
@@ -5505,6 +5571,10 @@ impl Host {
                 self.rounds.remove(&session);
                 if let Some(s) = self.agent.sessions().get_mut(&session) {
                     s.updated_at = now_secs();
+                    // The turn ended, so there is nothing for a later process to notice. Cleared
+                    // here for *every* ending — finished, errored, interrupted — because the note
+                    // means "no one ended this", and all three of those are someone ending it.
+                    s.running_since = None;
                     // News, and only where you were not looking. A turn that ended in the
                     // conversation on screen has been seen by definition — including with nothing
                     // attached, because reattaching lands you in that conversation with the answer
@@ -5546,10 +5616,21 @@ impl Host {
             }
             // What the turn produced is in the conversation now, so the round's copy of it would
             // only go stale — and drawing both on a switch would say everything twice.
+            //
+            // And it is the moment to write it down. A turn is minutes of work and dozens of tool
+            // rounds, and until this the only saves were at either end of it: the conversation on
+            // disk held the message you typed and nothing after it, for as long as the turn ran.
+            // Anything that took the workspace out without warning — a crash, an OOM kill, a
+            // reboot — lost the whole answer and left the transcript ending on your own question.
+            // A round boundary is what the agent itself resumes from, so it is the right grain to
+            // save at, and one conversation is written rather than every conversation in the
+            // workspace: `persist_sessions` several times a minute for the sake of the one that
+            // changed is a hundred files rewritten to record one.
             AgentEvent::Committed { session, .. } => {
                 if let Some(r) = self.rounds.get_mut(&session) {
                     r.said.clear();
                 }
+                self.persist_session(&session);
             }
             AgentEvent::Steered { prompt, .. } => {
                 // Drawn now rather than when it was typed: until the model has been told, a
@@ -6383,6 +6464,25 @@ impl Host {
         serde_json::from_value(self.pstate.get(BUILTIN, &key)).unwrap_or_default()
     }
 
+    /// Write one conversation, now.
+    ///
+    /// The cheap half of [`Self::persist_sessions`], for the places that fire *inside* a turn.
+    /// Ordering is not at stake — `order.json` records which conversations exist and which one you
+    /// were in, and neither changes because a tool round finished.
+    ///
+    /// A [placeholder](neosh_agent::Session::ephemeral) is skipped, the same as in `save_all`: no
+    /// caller can reach here with one today, because saying anything is what stops a session being
+    /// one and a turn cannot start before that — but the rule is about what may be written down,
+    /// not about who happens to be calling.
+    fn persist_session(&self, id: &neosh_proto::SessionId) {
+        let Some(dir) = &self.state_dir else { return };
+        let store = self.agent.sessions();
+        let Some(s) = store.get(id).filter(|s| !s.ephemeral) else { return };
+        if let Err(e) = crate::sessions::save(dir, s) {
+            tracing::warn!("could not save conversation {}: {e}", id.0);
+        }
+    }
+
     fn persist_sessions(&self) {
         let Some(dir) = &self.state_dir else { return };
         if let Err(e) = crate::sessions::save_all(dir, &self.agent.sessions()) {
@@ -6730,11 +6830,29 @@ impl Host {
         }
         let armed = self.quit_armed.is_some_and(|at| at.elapsed() < ARM_WINDOW);
         if armed {
-            self.quitting = true;
+            self.leave();
             return;
         }
         self.quit_armed = Some(std::time::Instant::now());
-        self.editor_message(MessageLevel::Info, "press ^C again to quit, or ^Q");
+        self.editor_message(MessageLevel::Info, match self.on_quit {
+            OnQuit::Stop => "press ^C again to quit, or ^Q",
+            OnQuit::Detach => "press ^C again to close this terminal, or ^Q",
+        });
+    }
+
+    /// What `quit` does here — from the key, from the command, from the last rung of `^C`.
+    ///
+    /// One door, because there is only one door. A workspace is a process with turns running in it
+    /// and possibly other terminals looking at it, so the key that ends *this* terminal must not be
+    /// able to end that. `^C^C` set `quitting` directly and took the workspace with it: every
+    /// conversation, in every project, on a key whose first four meanings — copy, leave reading,
+    /// interrupt, clear the draft — are all local. ADR 0036's rule that `^Q` must never stop a
+    /// workspace was never really about `^Q`; it is about every way out there is.
+    fn leave(&mut self) {
+        match self.on_quit {
+            OnQuit::Stop => self.quitting = true,
+            OnQuit::Detach => self.detaching = Some(self.from_view),
+        }
     }
 
     /// Page the transcript. `0` returns to following the tail.
@@ -6781,10 +6899,7 @@ impl Host {
     fn run_builtin(&mut self, name: &str, args: Vec<String>) {
         match name {
             "config.reload" => self.reload_config(),
-            "quit" => match self.on_quit {
-                OnQuit::Stop => self.quitting = true,
-                OnQuit::Detach => self.detaching = Some(self.from_view),
-            },
+            "quit" => self.leave(),
             "stop" => self.quitting = true,
             "interrupt" => self.interrupt(),
             "chat.scroll_up" => self.scroll_chat(-1),
@@ -8011,6 +8126,25 @@ fn transcript(
     // when it ends, by whoever is looking then.
     if !running {
         summarise(&mut lines, &mut marks, &mut changes);
+    }
+    // Where it stopped, when nothing stopped it.
+    //
+    // The sidebar can say *which* conversation was cut off; only the transcript can say where. What
+    // the agent had finished is above this line and is real; what it was in the middle of is not
+    // anywhere, and without a line saying so the conversation simply ends — on a half-written
+    // sentence, or on a tool call with no result, which reads exactly like an agent that gave up.
+    //
+    // Not drawn for a turn that is running: `running` is a turn in flight *now*, in this process,
+    // and this mark is about one that was in flight in a process that is gone.
+    if session.interrupted && !running {
+        gap(&mut lines);
+        let row = lines.len() as u32;
+        let r = cards::Row::plain(
+            format!("{} the workspace stopped while this turn was running", g.fail),
+            "Diagnostic.Error",
+        );
+        marks.extend(Mark::of(row, &r));
+        lines.push(r.text);
     }
     (lines, marks, cards)
 }

--- a/crates/neosh/src/main.rs
+++ b/crates/neosh/src/main.rs
@@ -400,10 +400,14 @@ fn with_signals(
     });
 
     tokio::spawn(async move {
-        // Not from any terminal, so it is tagged with the view that is always the process's
-        // own. In a served workspace that names nobody, which is right: a signal is a reason to
-        // stop the work, not to close one of somebody's windows.
-        let quit = (views::ViewId::LOCAL, InputEvent::Command { name: "quit".into(), args: Vec::new() });
+        // `stop` rather than `quit`, because a signal is a reason to stop the work and not to
+        // close one of somebody's windows — and in a served workspace `quit` is exactly "close
+        // one of somebody's windows". Tagged with the process's own view, which in a workspace
+        // names nobody: `quit` therefore detached a view that was not there, so a `kill` on a
+        // workspace did nothing at all and the `SIGKILL` behind it was what actually stopped it,
+        // with whatever had not been written to disk still in memory. This is also the path a
+        // machine shutting down takes.
+        let quit = (views::ViewId::LOCAL, InputEvent::Command { name: "stop".into(), args: Vec::new() });
         #[cfg(unix)]
         {
             use tokio::signal::unix::{SignalKind, signal};

--- a/crates/neosh/src/sessions.rs
+++ b/crates/neosh/src/sessions.rs
@@ -54,6 +54,18 @@ struct Stored {
     /// that a restart cleared would go out precisely when the wait was longest.
     #[serde(default)]
     unread: bool,
+    /// A turn was in flight when this file was written.
+    ///
+    /// The one field here whose value is in its *staleness*. Everything else is written down so a
+    /// later process can read what this one knew; this is written down so a later process can
+    /// notice that this one never came back to clear it. See [`Session::running_since`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    running_since: Option<i64>,
+    /// And the answer, once some load has drawn it. Persisted rather than re-derived, because the
+    /// load that derives it also clears the `running_since` it derived it from — a second restart
+    /// before you had been back would otherwise lose the mark entirely.
+    #[serde(default)]
+    interrupted: bool,
     /// Put away rather than deleted. Defaulted, so a session written before archiving existed
     /// comes back in the open list, which is where it was.
     #[serde(default)]
@@ -121,6 +133,8 @@ impl From<&Session> for Stored {
             context_tokens: s.context_tokens,
             context_window: s.context_window,
             unread: s.unread,
+            running_since: s.running_since,
+            interrupted: s.interrupted,
             archived: s.archived,
             archived_at: s.archived_at,
             permission_mode: s.permission_mode,
@@ -143,6 +157,14 @@ impl Stored {
         s.context_tokens = self.context_tokens;
         s.context_window = self.context_window;
         s.unread = self.unread;
+        // A turn that was in flight when this was written is a turn nobody ended: the only process
+        // that could have ended it is the one that wrote this and is now gone. Loading is the only
+        // moment that can be noticed, and noticing it is the whole reason the note exists.
+        //
+        // The note is then dropped, so it is not re-derived forever — which is why the answer has
+        // to be saved rather than recomputed.
+        s.interrupted = self.interrupted || self.running_since.is_some();
+        s.running_since = None;
         s.archived = self.archived;
         s.archived_at = self.archived_at;
         s.permission_mode = self.permission_mode;

--- a/crates/neosh/tests/workspace.rs
+++ b/crates/neosh/tests/workspace.rs
@@ -135,6 +135,16 @@ impl Workspace {
     fn alive(&mut self) -> bool {
         matches!(self.child.try_wait(), Ok(None))
     }
+
+    /// End it the way a crash does: no shutdown, no last flush, no chance to save anything.
+    ///
+    /// `Child::kill` is already `SIGKILL`, so this is that plus waiting for the socket to be
+    /// unusable — the process is gone before the next workspace tries to bind over it.
+    fn kill_hard(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = std::fs::remove_file(&self.socket);
+    }
 }
 
 /// A terminal, minus the terminal.
@@ -232,6 +242,18 @@ impl Client {
                 },
             });
         }
+    }
+
+    /// A chord, which is a different key from the letter it is made of.
+    fn ctrl(&mut self, c: char) {
+        self.send(ClientMessage::Input {
+            event: InputEvent::Key {
+                key: neosh_proto::KeyPress {
+                    code: neosh_proto::KeyCode::Char { c: c.to_string() },
+                    mods: neosh_proto::KeyMods { ctrl: true, ..Default::default() },
+                },
+            },
+        });
     }
 
     fn enter(&mut self) {
@@ -576,4 +598,171 @@ fn status_answers_while_a_turn_is_running_which_is_when_it_is_asked() {
         assert!(Instant::now() < deadline, "status never reported the turn: {text}");
         std::thread::sleep(Duration::from_millis(100));
     }
+}
+
+/// `^C` twice is a way out of a *terminal*, and a workspace is not one.
+///
+/// `^Q` has always known that. `^C`'s cascade — copy, leave reading, interrupt the turn, clear the
+/// draft, and only then quit — ended by setting `quitting` directly, so the last rung of the key
+/// people press when they want out of something took the whole workspace with it: every
+/// conversation, in every project, and every turn running in any of them.
+#[test]
+fn pressing_ctrl_c_twice_closes_the_terminal_and_not_the_workspace() {
+    let sb = Sandbox::new("ctrlc");
+    let mut ws = sb.serve("hello_turn.jsonl");
+
+    let mut c = Client::attach(&ws.socket, neosh_proto::PROTOCOL_VERSION);
+    c.ready();
+    // Nothing selected, nothing being read, no turn, no draft: the cascade is empty, so the first
+    // press arms and the second one is the way out.
+    c.ctrl('c');
+    c.ctrl('c');
+    c.until("to be sent away", |c| c.ended == Some(DetachReason::Asked));
+
+    assert!(ws.alive(), "^C^C closed the terminal, not the workspace");
+    assert!(status(&sb).contains("running"), "{}", status(&sb));
+
+    // And it is still a workspace you can come back to, which is the part that matters.
+    let mut again = Client::attach(&ws.socket, neosh_proto::PROTOCOL_VERSION);
+    again.ready();
+}
+
+/// What a turn has already done is on disk while it is still doing the rest.
+///
+/// A turn is minutes of work and a dozen tool rounds, and the only saves used to be at either end
+/// of it — so for the whole time it ran, the conversation on disk held the message you typed and
+/// nothing after it. Anything that took the workspace out without warning lost the entire answer
+/// and left the transcript ending on your own question.
+#[test]
+fn what_a_turn_has_done_is_on_disk_before_the_turn_ends() {
+    let sb = Sandbox::new("midturn");
+    let mut ws = sb.serve_paced("hello_turn.jsonl", 700);
+
+    let mut c = Client::attach(&ws.socket, neosh_proto::PROTOCOL_VERSION);
+    c.ready();
+    c.ask("read it for me");
+
+    // The first round's tool call, written down while the second round is still going. Waited for
+    // rather than slept on, and the turn is asserted to be still in flight when it arrives — a
+    // save that only happened because the turn had quietly finished would prove nothing.
+    let deadline = Instant::now() + PATIENCE;
+    loop {
+        let saved = sessions_on_disk(&sb);
+        if saved.contains("hello_greet") {
+            assert!(
+                status(&sb).contains("read it for me"),
+                "the turn was already over, so this says nothing about saving during one"
+            );
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the turn's first round never reached the disk:\n{saved}"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    // And the real test of it: take the workspace out the way a crash would, with no chance to
+    // flush anything, and see what a new one finds.
+    ws.kill_hard();
+    drop(c);
+    let ws2 = sb.serve_paced("hello_turn.jsonl", 0);
+    let mut c2 = Client::attach(&ws2.socket, neosh_proto::PROTOCOL_VERSION);
+    c2.ready();
+    c2.until("the killed turn's work to come back", |c| {
+        c.transcript().iter().any(|l| l.contains("read it for me"))
+    });
+    let back = c2.transcript().join("\n");
+    assert!(back.contains("hello_greet"), "the tool round the turn had finished is gone:\n{back}");
+}
+
+/// Every session file the sandbox has written, as one string to look for things in.
+fn sessions_on_disk(sb: &Sandbox) -> String {
+    let dir = sb.root.join("state/sessions");
+    let Ok(entries) = std::fs::read_dir(&dir) else { return String::new() };
+    entries
+        .flatten()
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("json"))
+        .filter_map(|e| std::fs::read_to_string(e.path()).ok())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// A turn killed with the workspace says so, in the panel and in the transcript.
+///
+/// The one thing a conversation cannot notice about itself. Someone shuts the computer down mid
+/// turn; the process does not get to write down that it died, so the conversation comes back
+/// ending on a half-finished piece of work with nothing anywhere saying that is what it is.
+#[test]
+fn a_turn_killed_with_the_workspace_is_marked_when_it_comes_back() {
+    let sb = Sandbox::new("cutoff");
+    let mut ws = sb.serve_paced("hello_turn.jsonl", 700);
+
+    let mut c = Client::attach(&ws.socket, neosh_proto::PROTOCOL_VERSION);
+    c.ready();
+    c.ask("do the long thing");
+    // Wait until the turn is genuinely in flight before pulling the plug, so what is being tested
+    // is a turn that was killed rather than one that had never started.
+    let deadline = Instant::now() + PATIENCE;
+    while !status(&sb).contains("do the long thing") {
+        assert!(Instant::now() < deadline, "the turn never started");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    // No shutdown, no last flush: the machine went away.
+    ws.kill_hard();
+    drop(c);
+
+    let ws2 = sb.serve_paced("hello_turn.jsonl", 0);
+    let mut c2 = Client::attach(&ws2.socket, neosh_proto::PROTOCOL_VERSION);
+    c2.ready();
+    c2.until("the cut-off turn to be accounted for", |c| {
+        c.transcript().iter().any(|l| l.contains("the workspace stopped while this turn was running"))
+    });
+
+    // And it survives a second start. The note the mark is derived from is cleared by the load that
+    // reads it, so a mark that was not itself written down would last exactly one restart — and the
+    // restart after that would quietly say everything was fine.
+    drop(c2);
+    let out = sb.neosh(&["stop"]).output().expect("stop");
+    assert!(String::from_utf8_lossy(&out.stdout).contains("stopped"));
+    let ws3 = sb.serve_paced("hello_turn.jsonl", 0);
+    let mut c3 = Client::attach(&ws3.socket, neosh_proto::PROTOCOL_VERSION);
+    c3.ready();
+    c3.until("the mark to survive a second restart", |c| {
+        c.transcript().iter().any(|l| l.contains("the workspace stopped while this turn was running"))
+    });
+}
+
+/// And it goes away when a new turn starts there, because then it is not the last turn any more.
+#[test]
+fn asking_again_clears_the_mark_a_killed_turn_left() {
+    let sb = Sandbox::new("cutoffclear");
+    let mut ws = sb.serve_paced("hello_turn.jsonl", 700);
+    let mut c = Client::attach(&ws.socket, neosh_proto::PROTOCOL_VERSION);
+    c.ready();
+    c.ask("the one that dies");
+    let deadline = Instant::now() + PATIENCE;
+    while !status(&sb).contains("the one that dies") {
+        assert!(Instant::now() < deadline, "the turn never started");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    ws.kill_hard();
+    drop(c);
+
+    let ws2 = sb.serve_paced("hello_turn.jsonl", 0);
+    let mut c2 = Client::attach(&ws2.socket, neosh_proto::PROTOCOL_VERSION);
+    c2.ready();
+    c2.until("the mark", |c| {
+        c.transcript().iter().any(|l| l.contains("the workspace stopped while this turn was running"))
+    });
+    c2.ask("and the one that does not");
+    c2.until("the new turn to finish", |c| {
+        c.transcript().iter().any(|l| l.contains("All done."))
+    });
+    let after = c2.transcript().join("\n");
+    assert!(
+        !after.contains("the workspace stopped while this turn was running"),
+        "a finished turn left the previous turn's mark behind:\n{after}"
+    );
 }

--- a/plugins/api/src/generated/SessionInfo.ts
+++ b/plugins/api/src/generated/SessionInfo.ts
@@ -95,6 +95,24 @@ export type SessionInfo = {
    */
   unread: boolean;
   /**
+   * The workspace stopped while a turn was running here, and nothing ended that turn.
+   *
+   * The one thing a conversation cannot notice about itself: a process that is killed does not
+   * get to write down that it was. So a turn writes down that it *started* and clears the note
+   * when it ends, and a note still there when the conversation is next loaded says the process
+   * that made it never got to the end — the machine was shut down, the workspace was `SIGKILL`ed,
+   * the OOM killer chose it. Whatever the agent had already done is in `messages`; what it was
+   * in the middle of is gone, and this is the only thing that will ever say so.
+   *
+   * Deliberately *not* the same kind of mark as [`Self::unread`], which is news and is cleared
+   * by arriving. This is a fact about the conversation's last turn, and arriving does not change
+   * it: at startup you land in the conversation you were last in, which is usually the one that
+   * was cut off, and a mark that cleared on arrival would clear exactly the one that mattered
+   * most before you had read it. It goes when a new turn starts here, because that is the point
+   * at which the last turn stops being the last turn.
+   */
+  interrupted: boolean;
+  /**
    * Put away rather than thrown away.
    *
    * An archived conversation keeps every message and can be brought back; it is simply not in

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -2663,15 +2663,26 @@ function projectRow(
   // A question in there outranks it, and for the same reason it does on the conversation's own row:
   // one of them is news that will keep, and the other is a turn that has stopped until you answer.
   // Only one mark, because there is one column and two would be a puzzle rather than a summary.
-  const unseen = folded && !waiting
+  // A third thing the fold can be hiding, and it sits between the other two: a question stops the
+  // workspace until you answer, a killed turn lost work, and an unread answer is waiting patiently.
+  const cut = folded && !waiting
+    ? within.filter((s) => !s.active_turn && s.interrupted).length
+    : 0;
+  const unseen = folded && !waiting && cut === 0
     ? within.filter((s) => !s.active_turn && s.unread).length
     : 0;
   const mark = folded && waiting
     ? " ?"
-    : unseen === 0 ? "" : unseen === 1
-      ? opts.ascii ? " !" : " ●"
-      : opts.ascii ? ` !${unseen}` : ` ●${unseen}`;
-  const markHl = folded && waiting ? "Status.Pending" : "Status.Unread";
+    : cut > 0
+      ? cut === 1
+        ? opts.ascii ? " x" : " ✗"
+        : opts.ascii ? ` x${cut}` : ` ✗${cut}`
+      : unseen === 0 ? "" : unseen === 1
+        ? opts.ascii ? " !" : " ●"
+        : opts.ascii ? ` !${unseen}` : ` ●${unseen}`;
+  const markHl = folded && waiting
+    ? "Status.Pending"
+    : cut > 0 ? "Diagnostic.Error" : "Status.Unread";
 
   const name = clip(
     p.name,
@@ -2725,10 +2736,17 @@ function worktreeRow(
     : p.sessions.length > 0
       ? { text: `${p.sessions.length} `, hl: "Sidebar.Dim" }
       : { text: "" };
-  const unseen = folded ? p.sessions.filter((s) => !s.active_turn && s.unread).length : 0;
-  const mark = unseen === 0 ? "" : unseen === 1
-    ? opts.ascii ? " !" : " ●"
-    : opts.ascii ? ` !${unseen}` : ` ●${unseen}`;
+  const cut = folded ? p.sessions.filter((s) => !s.active_turn && s.interrupted).length : 0;
+  const unseen = folded && cut === 0
+    ? p.sessions.filter((s) => !s.active_turn && s.unread).length
+    : 0;
+  const mark = cut > 0
+    ? cut === 1
+      ? opts.ascii ? " x" : " ✗"
+      : opts.ascii ? ` x${cut}` : ` ✗${cut}`
+    : unseen === 0 ? "" : unseen === 1
+      ? opts.ascii ? " !" : " ●"
+      : opts.ascii ? ` !${unseen}` : ` ●${unseen}`;
   // The branch glyph, in the branch colour — what says "this row is a checkout" at a glance, so
   // the name can be just the branch. No ASCII stand-in earns its column, so ASCII goes without.
   const glyph = opts.ascii ? "" : "⎇ ";
@@ -2744,7 +2762,11 @@ function worktreeRow(
   }
   if (mark !== "") {
     const at = byteLength(`${pad}${arrow} ${glyph}${name}`);
-    spans.push({ from: at, to: at + byteLength(mark), hl: "Status.Unread" });
+    spans.push({
+      from: at,
+      to: at + byteLength(mark),
+      hl: cut > 0 ? "Diagnostic.Error" : "Status.Unread",
+    });
   }
   return {
     text: `${pad}${arrow} ${glyph}${name}${mark}`,
@@ -2807,7 +2829,12 @@ function sessionRow(
   // something, so it is the one row that gets the attention colour — and it does not move, because
   // it is not going to stop being true on its own and a mark that pulses forever is a mark you
   // learn to look past. It goes away by being opened. See ADR 0042.
-  const unread = !working && !asking && s.unread;
+  const unread = !working && !asking && !s.interrupted && s.unread;
+  // The turn that was running here never ended, because the workspace it was running in stopped:
+  // the machine was shut down, the process was killed. It outranks `unread` — a turn that finished
+  // while you were away and a turn that was killed are both news, and only one of them lost work —
+  // and it does not move, because nothing is happening here: it already happened.
+  const interrupted = !working && !asking && s.interrupted;
   const glyph = asking
     // A question mark, in both alphabets. Every other glyph here has an ASCII understudy because
     // the Unicode one is prettier; this one is already the character that means what it means, and
@@ -2817,6 +2844,10 @@ function sessionRow(
       ? s.is_active
         ? spinnerFrame()
         : opts.ascii ? "*" : "◍"
+      // The same mark a tool call that failed wears, and for the same reason: this did not finish.
+      // A conversation is the largest thing in the workspace that can fail to finish.
+      : interrupted
+        ? opts.ascii ? "x" : "✗"
       : unread
         ? opts.ascii ? "!" : "●"
         : s.is_active
@@ -2861,6 +2892,11 @@ function sessionRow(
       ? "Status.Pending"
       : working
         ? s.is_active && pulseBright() ? "Status.Working" : "Status.Monitoring"
+        // Red, and the palette's red for something that went wrong rather than a status colour of
+        // its own: work was lost here. The whole row again, for the reason the unread mark takes
+        // the whole row.
+        : interrupted
+          ? "Diagnostic.Error"
         : unread
           // The whole row, not only the dot: a single coloured character five columns in is findable
           // if you already know it is there, which is the one thing you cannot assume about the
@@ -2874,7 +2910,11 @@ function sessionRow(
       text: right === "" ? "" : `${right} `,
       hl: asking
         ? "Status.Pending"
-        : working ? "Status.Working" : unread ? "Status.Unread" : "Sidebar.Dim",
+        : working
+          ? "Status.Working"
+          : interrupted
+            ? "Diagnostic.Error"
+            : unread ? "Status.Unread" : "Sidebar.Dim",
     },
     value: { kind: "session", id: s.id, cwd: s.cwd },
   };


### PR DESCRIPTION
Four ways a workspace meant to outlive its terminal did not, and one new mark for when it genuinely could not.

## `^C^C` stopped the whole workspace

`interrupt()` set `quitting` directly instead of going through `OnQuit`, so the last rung of a key whose first four meanings are all local — copy, leave reading, interrupt the turn, clear the draft — stopped everything: every conversation, in every project, and every turn running in any of them. `^Q` had always known better. Both go through one `leave()` now, and the arming message says which door it is.

ADR 0036's rule that `^Q` must never stop a workspace was never really about `^Q`.

## A turn wrote nothing to disk while it ran

Saves happened when you sent a message and when the turn ended, and nowhere between. For the minutes a turn ran, the conversation on disk held your question and nothing after it — so anything that took the workspace out without warning lost the whole answer and left the transcript ending on your own message.

`AgentEvent::Committed` fires at every tool round and already meant "this is in the conversation now". It now writes that **one** conversation down; `save_all` several times a minute would rewrite every conversation in the workspace for the sake of the one that moved.

Saving is per tool round, not per token: a partial assistant message is still in the `TurnAssembler` and is not a message yet, and writing a half-finished one would corrupt what gets resent to the model on resume.

## A signal did nothing

`with_signals` sent `quit`, which in a served workspace detaches `ViewId::LOCAL` — a view that does not exist there. So `kill` was a no-op and the `SIGKILL` behind it is what actually stopped the workspace, with whatever had not reached disk still in memory. It sends `stop`, which is also the path a machine shutting down takes.

## A turn killed with the workspace now says so

A process that is killed does not get to write down that it was. So a turn writes down that it *started* (`Session::running_since`) and clears the note when it ends; a note still there when the conversation is next loaded is a turn nobody ended.

- The conversation's row goes red in the sidebar (`Diagnostic.Error`, whole row including the age column), wearing the `✗` a failed tool call wears.
- A folded project carries a red mark and a count, ranked above the unread dot and below a waiting question.
- The transcript says where it stopped — the panel can say *which* conversation was cut off, only the transcript can say *where*.

Unlike `unread` it is **not** cleared by arriving. At startup you land in the conversation you were last in, which is usually the one that was cut off; clearing on arrival would wipe the mark that mattered most before it had been read. It goes when a new turn starts there, and the transcript is rebuilt at that moment so the live path and the replay do not disagree about a conversation you never left.

`interrupted` is persisted as well as derived: the load that reads `running_since` also clears it, so a mark that was not itself written down would survive exactly one restart and the next one would quietly say everything was fine.

## Verification

- `cargo test -p neosh --test workspace` — **16/16**, including three new tests. One kills the workspace with `SIGKILL` mid-turn and asserts the mark survives a *second* restart.
- `cargo test -p neosh-agent` — 93 pass.
- `cargo test -p neosh-proto export_bindings` — 163 pass, generated TS committed and in sync.
- `tsc --noEmit` — clean on `plugins/api` and `plugins/builtin`.
- `cargo test -p neosh --test builtin_plugins` — 143/144. The one failure, `the_plan_row_keeps_the_providers_own_colour`, fails at `main` in isolation too: c280938 changed the one-row plan strip to label the binding row by the account and updated the test above it (`Session` → `Planner`), but this sibling still searches for `"Session"`. Left alone as out of scope.

Both regressions were confirmed by backing the fixes out and watching the new tests fail.

Also driven on a real terminal under a pty — the red row and the transcript line were read back as `#fca5a5` with `shot.py --color`, not inferred from the renderer.