### PR TITLE
A branch named by what you asked for

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,23 @@ per decision, and records the *reasoning*, not the choice.
   no `<repo>` level, nothing else's trees can land there — and `add_worktree` writes the directory
   into the repository's `.gitignore` (tracked, so every clone gets it; skipped when already
   ignored), or every `git status` reads as one giant untracked directory. See ADR 0046.
+- **A branch is named by what you asked for, once you have asked.** A worktree you did not name
+  starts on `wily-nimbus`, because naming a branch before the work is a decision made at the worst
+  possible moment — and the first message sent in it *is* that decision, arriving on its own, so
+  the branch is renamed from it and never touched again. Only a name nobody chose: the mark is a
+  session var written by whoever generated it (`git.branch.scratch`), never a pattern match on the
+  shape of the name, which cannot tell `brisk-otter` we picked from `brisk-otter` you typed. At
+  turn *start*, because the panel is drawn all through a turn — `git branch -m` is one ref write,
+  so it is safe under a running agent and safe on uncommitted work. **One attempt, ever**: the mark
+  is spent before the model is asked, or a cheap model's hiccup becomes a request per message. The
+  *type* is the model's — `feature/`, `fix/`, `chore/` — so `git.branch.prefix` applies only to a
+  name that arrived without one, or you get `feature/fix/the-login` under a type that is now wrong.
+  `git.branch.model` is unset by default and the plugin sends **no selection at all** rather than a
+  guess, so the fallback stays the host's: `gen.model`, then the model you are already talking to.
+  And the host has to put *its own* label right — `ProjectFacts` is asked once per directory and
+  read on every redraw, so `GitRenameBranch` is the one git write handled on the host loop, which
+  is what makes the sidebar row follow instead of saying `wily-nimbus` until restart. The directory
+  keeps the old name on purpose: moving it would invalidate the conversation's `cwd`. See ADR 0051.
 - **A project outlives the conversations in it.** The panel's list is written down (`sidebar.projects`,
   a workspace var) rather than worked out from where the conversations happen to be — derived, it
   deleted the directory you had worked in all month the moment you cleared out the last thread in
@@ -407,7 +424,7 @@ only way to do anything. See ADR 0048.
 | `^T` | Projects and conversations. Switching is never refused — turns keep running where they are |
 | `^J` | The computers in this workspace. Add one by its address, allow one that is asking, or open what it is running |
 | `^F` | What you have archived. Filter it, put one back, or finally throw it away |
-| `^N` | New conversation. In a repository it asks where: here, a worktree you need not name, one kept inside the project, one you do name, an existing one, another machine, elsewhere |
+| `^N` | New conversation. In a repository it asks where: here, a worktree you need not name, one kept inside the project, one you do name, an existing one, another machine, elsewhere. A worktree you did not name is named by your first message — `fix/composer-paste-truncation`, not `wily-nimbus` |
 | `^O` | Add a project |
 | `^B` | Toggle the sidebar |
 | `^K` | Command palette |

--- a/crates/neosh-core/src/editor.rs
+++ b/crates/neosh-core/src/editor.rs
@@ -177,6 +177,7 @@ impl Editor {
                 | ApiCall::GitDefaultBranch
                 | ApiCall::GitCreateBranch { .. }
                 | ApiCall::GitCheckout { .. }
+                | ApiCall::GitRenameBranch { .. }
                 | ApiCall::GitStage { .. }
                 | ApiCall::GitUnstage { .. }
                 | ApiCall::GitCommit { .. }
@@ -1336,6 +1337,7 @@ fn call_name(call: &ApiCall) -> &'static str {
         ApiCall::GitDiff { .. } => "git.diff",
         ApiCall::GitDefaultBranch => "git.defaultBranch",
         ApiCall::GitCreateBranch { .. } => "git.createBranch",
+        ApiCall::GitRenameBranch { .. } => "git.renameBranch",
         ApiCall::GitCheckout { .. } => "git.checkout",
         ApiCall::GitStage { .. } => "git.stage",
         ApiCall::GitUnstage { .. } => "git.unstage",

--- a/crates/neosh-proto/src/api.rs
+++ b/crates/neosh-proto/src/api.rs
@@ -1021,6 +1021,21 @@ pub enum ApiCall {
     GitCheckout {
         rev: String,
     },
+    /// Move a branch to another name — `git branch -m`.
+    ///
+    /// One ref write, so it is safe on the branch a worktree has checked out and safe while an
+    /// agent is mid-turn in that worktree: nothing about the files changes. What *does* change is
+    /// the label every project list is drawing, which is why the host refreshes what it knows
+    /// about the directory here rather than leaving a panel to say the old name until restart.
+    GitRenameBranch {
+        old: String,
+        new: String,
+        /// The checkout the branch belongs to. `git branch -m` runs *inside* a repository, and a
+        /// caller renaming the branch of a worktree other than the active conversation's has to
+        /// say which — the same reason [`Self::GitAddWorktree`] takes one.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cwd: Option<String>,
+    },
     /// Empty `paths` stages everything, matching `git add .` from the root.
     GitStage {
         #[serde(default)]

--- a/crates/neosh-vcs/src/lib.rs
+++ b/crates/neosh-vcs/src/lib.rs
@@ -233,6 +233,20 @@ impl Git {
         self.git(["switch", rev]).await.map(|_| ())
     }
 
+    /// Move a branch to another name, keeping everything on it.
+    ///
+    /// `git branch -m` writes one ref and leaves the working tree alone, which is what makes it
+    /// safe to run on the branch a worktree currently has checked out — including while an agent
+    /// is editing files in that worktree. Renaming is therefore not a checkout: nothing is
+    /// stashed, nothing is rewritten, and a half-finished edit survives it.
+    ///
+    /// Fails rather than clobbers when `new` is taken. `-M` would overwrite the other branch, and
+    /// silently discarding somebody's work to give a generated name its first choice is not a
+    /// trade worth making — the caller has the branch list and can pick a free name.
+    pub async fn rename_branch(&self, old: &str, new: &str) -> Result<(), VcsError> {
+        self.git(["branch", "-m", old, new]).await.map(|_| ())
+    }
+
     pub async fn stage(&self, paths: &[String]) -> Result<(), VcsError> {
         let mut args = vec!["add".to_string(), "--".to_string()];
         if paths.is_empty() {

--- a/crates/neosh-vcs/tests/real_repo.rs
+++ b/crates/neosh-vcs/tests/real_repo.rs
@@ -259,3 +259,55 @@ async fn worktrees_report_which_one_we_are_in() {
 
     let _ = std::fs::remove_dir_all(&extra);
 }
+
+/// Renaming the branch a worktree is standing on moves the ref and leaves the tree alone.
+///
+/// The case this exists for: an agent is working in a scratch worktree, the first message has
+/// arrived, and the branch is about to be given the name that message implies. If `git branch -m`
+/// touched the working tree — reset it, stashed it, refused while it was dirty — the whole
+/// approach would be unavailable, because the one moment there is enough information to name the
+/// branch is the moment there is also uncommitted work sitting on it.
+#[tokio::test]
+async fn a_branch_is_renamed_under_the_worktree_standing_on_it() {
+    if !have_git() {
+        return;
+    }
+    let repo = Repo::new("renamebranch");
+    repo.write("a.txt", "1\n");
+    repo.git(&["add", "."]);
+    repo.git(&["commit", "-m", "initial"]);
+
+    let extra = repo
+        .path()
+        .parent()
+        .unwrap()
+        .join(format!("neosh-vcs-rename-tree-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&extra);
+
+    let git = Git::discover(repo.path()).await.expect("repo");
+    git.add_worktree(&extra, "wily-nimbus", true).await.expect("worktree add");
+
+    // Uncommitted work in the tree, which is the realistic state at the moment of naming.
+    std::fs::write(extra.join("a.txt"), "1\n2\n").expect("write");
+
+    let inside = Git::discover(&extra).await.expect("the worktree is a repo too");
+    inside.rename_branch("wily-nimbus", "fix/the-login").await.expect("rename");
+
+    let (branch, _) = inside.identity().await;
+    assert_eq!(branch.as_deref(), Some("fix/the-login"), "the tree is on the new name");
+    assert_eq!(
+        std::fs::read_to_string(extra.join("a.txt")).expect("read"),
+        "1\n2\n",
+        "and the uncommitted edit survived it"
+    );
+
+    // A name already taken is refused rather than overwritten: a generated name does not get to
+    // discard somebody's branch to have its first choice.
+    assert!(
+        inside.rename_branch("fix/the-login", "master").await.is_err()
+            || inside.rename_branch("fix/the-login", "main").await.is_err(),
+        "renaming onto the default branch is refused"
+    );
+
+    let _ = std::fs::remove_dir_all(&extra);
+}

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -1319,6 +1319,20 @@ impl Host {
             ApiCall::ProviderSetCredential { .. } => Err(ApiError::Internal {
                 message: "credential prompts are answered by the host loop".into(),
             }),
+            // On the host loop rather than through `spawn_slow`, and it is the *only* git write
+            // that is. `git branch -m` is one ref write — the same order of cost as the
+            // `rev-parse` `remember_repo` already awaits here — and what follows it cannot be done
+            // from a spawned task: the branch is half of what [`ProjectFacts`] cached the first
+            // time this directory was seen, so a rename that did not reach the host would leave
+            // every project list drawing the old name until the workspace restarted. ADR 0036's
+            // rule, from the other end: a value the host *kept* has to be put right by whatever
+            // changed it.
+            ApiCall::GitRenameBranch { old, new, cwd } => {
+                let svc = self.services(plugin);
+                svc.git_rename_branch(old.clone(), new, cwd.clone()).await?;
+                self.rebranded(&old, cwd.as_deref()).await;
+                Ok(ApiOk::Unit)
+            }
             ApiCall::SessionRename { session, title } => {
                 self.agent
                     .sessions()
@@ -6359,6 +6373,57 @@ impl Host {
             }
         }
         self.repos.insert(dir, found);
+    }
+
+    /// A branch was renamed: put right everything the host had written down about it.
+    ///
+    /// [`ProjectFacts`] is asked once, when a directory is first seen, and then read on every
+    /// redraw of every panel — which is right, because a label is not worth a subprocess per
+    /// frame, and wrong for exactly one moment: the one where somebody moves the branch. The
+    /// worktree row in the sidebar *is* `SessionInfo::branch`, so without this the panel says
+    /// `spry-reef` under a conversation working on `feature/proxy-rate-limiter` until the
+    /// workspace is restarted.
+    ///
+    /// Matched on the cached branch rather than on `cwd`, because one rename can move several
+    /// rows: `cwd` names the checkout the git call ran in, and the branch may be checked out in a
+    /// worktree that is a different directory from it. Every directory the host knows that was on
+    /// `old` is on `new` now.
+    ///
+    /// The name is rebuilt through [`project_name`] rather than patched, so `neosh · spry-reef`
+    /// becomes `neosh · feature/proxy-rate-limiter` by the one function that decides what a
+    /// checkout is called — a second place that formats it is a second place to get it wrong.
+    async fn rebranded(&mut self, old: &str, cwd: Option<&str>) {
+        let touched: Vec<std::path::PathBuf> = self
+            .projects
+            .iter()
+            .filter(|(dir, facts)| {
+                facts.branch.as_deref() == Some(old)
+                    // The checkout the call named counts even on a detached head or a stale
+                    // cache: it is the one directory we know for certain was involved.
+                    || cwd.is_some_and(|c| std::path::Path::new(c) == dir.as_path())
+            })
+            .map(|(dir, _)| dir.clone())
+            .collect();
+        for dir in touched {
+            // Re-asked rather than patched: `identity()` is the same call the facts were built
+            // from, and a rename that failed halfway is then simply not reflected.
+            // Cloned rather than borrowed: `Git` is a path and a fact, cheap to copy, and this
+            // holds it across an await while the map it came from is written to below.
+            let Some(g) = self.repos.get(&dir).and_then(Option::as_ref).cloned() else { continue };
+            let (branch, main) = g.identity().await;
+            let name = project_name(&dir, branch.clone(), main.clone());
+            self.projects.insert(
+                dir,
+                ProjectFacts { name, repo_root: main.map(|p| p.display().to_string()), branch },
+            );
+        }
+        // Every list that draws a conversation is drawing a name that just changed, and the panel
+        // redraws on this. Not the same event as switching — nothing moved — but it is the one
+        // signal a thread list already listens to for "the conversations are not what you drew".
+        self.bridge.broadcast(PluginEvent::SessionChanged {
+            session: self.agent.sessions().active_id().clone(),
+        });
+        self.refresh_status();
     }
 
     /// Stamp the display name onto a conversation's info.

--- a/crates/neosh/src/services.rs
+++ b/crates/neosh/src/services.rs
@@ -203,6 +203,24 @@ impl Services {
         Ok(ApiOk::Unit)
     }
 
+    /// `git branch -m`, in whichever checkout the branch belongs to.
+    ///
+    /// Takes a `cwd` where [`Self::git_checkout`] does not, because the caller this exists for is
+    /// renaming the branch of a *worktree* — very often not the one the active conversation is
+    /// standing in. Nothing about the working tree changes, so it is safe on a branch that is
+    /// checked out and safe while an agent is mid-turn against it.
+    pub async fn git_rename_branch(
+        &self,
+        old: String,
+        new: String,
+        cwd: Option<String>,
+    ) -> ApiResult {
+        self.permit_write("branch -m")?;
+        let repo = self.repo_at(cwd).await?;
+        repo.rename_branch(&old, &new).await.map_err(vcs_err)?;
+        Ok(ApiOk::Unit)
+    }
+
     pub async fn git_stage(&self, paths: Vec<String>) -> ApiResult {
         self.permit_write("add")?;
         self.repo()?.stage(&paths).await.map_err(vcs_err)?;

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -873,6 +873,155 @@ fn a_branch_name_is_generated_slugged_and_prefixed_from_config() {
     s.wait_for("feature/fix-the-login-redirect");
 }
 
+/// A prefix the user configured and a type the model chose are the same decision, made twice.
+///
+/// The built-in prompt asks for `fix/`, `feature/`, `chore/` and the rest, so a
+/// `git.branch.prefix` bolted on unconditionally reads `feature/fix/the-login-redirect` — a
+/// namespace nobody meant, under a type that is now wrong. The prefix is for a name that arrived
+/// without one, which is what it does here and what it still does in the test above.
+#[test]
+fn a_configured_prefix_does_not_stack_on_a_type_the_model_chose() {
+    if !have_git() {
+        return;
+    }
+    let sb = Sandbox::new("branchtyped");
+    sb.git_init();
+    sb.write_config("[options]\n\"git.branch.prefix\" = \"feature/\"\n");
+
+    let mut s = sb.start_with(
+        &Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/branch_name_typed.jsonl"),
+    );
+    s.wait_for("PROJECTS");
+
+    s.send(&command("git.branch.new"));
+    s.wait_for("What are you about to work on?");
+    s.type_text("the login page bounces");
+    s.special("enter");
+
+    s.wait_for("fix/the-login-redirect");
+    assert!(
+        !s.saw("feature/fix/the-login-redirect"),
+        "and the configured prefix was not stacked on top of it\n{}",
+        s.transcript()
+    );
+}
+
+/// `git.branch.model` is a model, and an unset one is the fallback rather than a guess.
+///
+/// The option is `instance/model`, parsed in the plugin and handed to `gen.complete` as a
+/// selection — so a malformed or absent one has to mean "you decide" all the way down to the host,
+/// which then tries `gen.model` and finally the conversation's own. A plugin that filled in a
+/// default here would be a third place the precedence is written, and the first to disagree.
+#[test]
+fn the_model_that_names_a_branch_is_a_setting() {
+    if !have_git() {
+        return;
+    }
+    let sb = Sandbox::new("branchmodel");
+    sb.git_init();
+    sb.write_config("[options]\n\"git.branch.model\" = \"mock/mock\"\n");
+
+    let mut s = sb.start_with(&branch_fixture());
+    s.wait_for("PROJECTS");
+
+    s.send(&command("git.branch.new"));
+    s.wait_for("What are you about to work on?");
+    s.type_text("the login page bounces");
+    s.special("enter");
+
+    // Named at all is the assertion: a selection the host could not resolve fails the call, and
+    // the plugin says so instead of proposing a name.
+    s.wait_for("fix-the-login-redirect");
+}
+
+/// A scratch worktree is named by the first thing asked in it, and the panel says so.
+///
+/// The whole shape of this: `git.worktree.new.inside` gives you `brisk-otter` because naming a
+/// branch before the work is a decision made at the worst possible moment — and the first message
+/// *is* that decision, arriving on its own. Three things have to happen and the third is the one
+/// that was missing: git renames the branch, the host notices that the label it wrote down when it
+/// first saw the directory is now wrong, and the sidebar row — which is that label — redraws.
+#[test]
+fn a_scratch_worktree_is_named_by_the_first_message_and_the_sidebar_follows() {
+    if !have_git() {
+        return;
+    }
+    let sb = Sandbox::new("branchauto");
+    sb.git_init();
+
+    let mut s = sb.start_with(
+        &Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/branch_name_typed.jsonl"),
+    );
+    s.wait_for("PROJECTS");
+
+    s.send(&command("git.worktree.new.inside"));
+    let under = sb.work().join(".worktrees");
+    assert!(
+        s.pump(|_| std::fs::read_dir(&under).is_ok_and(|d| d.count() > 0)),
+        "the worktree exists, on a name nobody chose"
+    );
+    let tree = std::fs::read_dir(&under)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .next()
+        .expect("one worktree");
+
+    // Whatever two words it landed on. Named for us, which is exactly what makes it replaceable.
+    let scratch = head_of(&tree);
+    assert!(scratch.contains('-'), "a two-word scratch name, not {scratch:?}");
+
+    // Waited for rather than assumed: creating the tree also starts a conversation in it and
+    // switches to it, and a test that types before that lands is typing into the conversation in
+    // the *main* checkout — where there is no scratch branch and nothing to rename.
+    let row_says = |s: &Session, want: &str| s.sidebar_now().iter().any(|l| l.contains(want));
+    let named_scratch = scratch.clone();
+    assert!(
+        s.pump(move |s| row_says(s, &named_scratch)),
+        "the worktree is a row in the panel, under the name nobody chose\n{:?}",
+        s.sidebar_now()
+    );
+
+    // The first thing asked in it. The turn and the naming call both read the same fixture, so
+    // which of them the mock answers first does not decide the test.
+    s.type_text("the login page bounces");
+    s.special("enter");
+
+    assert!(
+        s.pump(|_| head_of(&tree) == "fix/the-login-redirect"),
+        "git renamed the branch — it is on {:?}\n{}",
+        head_of(&tree),
+        s.transcript()
+    );
+    // And the row followed. Without the host putting right the label it wrote down the first time
+    // it saw this directory, the panel says the scratch name until the workspace restarts.
+    //
+    // Matched on the start of the name, because the row is a branch in a narrow column and the
+    // panel elides the end of it — `⎇ fix/the-login-redire…`. Asserting the whole string would be
+    // asserting the sidebar's width.
+    assert!(
+        s.pump(move |s| row_says(s, "⎇ fix/the-login")),
+        "the sidebar row followed it\n{:?}",
+        s.sidebar_now()
+    );
+    let gone = scratch.clone();
+    assert!(
+        !s.sidebar_now().iter().any(|l| l.contains(&gone)),
+        "and the scratch name is not still a row beside it\n{:?}",
+        s.sidebar_now()
+    );
+}
+
+/// Which branch a checkout is on, asked of git rather than of anything under test.
+fn head_of(dir: &Path) -> String {
+    let out = Command::new("git")
+        .current_dir(dir)
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .expect("git runs");
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
 #[test]
 fn the_generated_name_is_editable_before_the_branch_is_created() {
     if !have_git() {

--- a/crates/neosh/tests/fixtures/branch_name_typed.jsonl
+++ b/crates/neosh/tests/fixtures/branch_name_typed.jsonl
@@ -1,0 +1,27 @@
+{"type": "message_start", "model": "mock", "usage": {}}
+{"type": "block_start", "index": 0, "block": {"kind": "text"}}
+{"type": "text_delta", "index": 0, "text": "{\"branch\": \"Fix / The Login Redirect\"}"}
+{"type": "block_stop", "index": 0}
+{"type": "message_delta", "stop_reason": {"kind": "end_turn"}, "usage": {}}
+{"type": "message_stop"}
+
+{"type": "message_start", "model": "mock", "usage": {}}
+{"type": "block_start", "index": 0, "block": {"kind": "text"}}
+{"type": "text_delta", "index": 0, "text": "{\"branch\": \"Fix / The Login Redirect\"}"}
+{"type": "block_stop", "index": 0}
+{"type": "message_delta", "stop_reason": {"kind": "end_turn"}, "usage": {}}
+{"type": "message_stop"}
+
+{"type": "message_start", "model": "mock", "usage": {}}
+{"type": "block_start", "index": 0, "block": {"kind": "text"}}
+{"type": "text_delta", "index": 0, "text": "{\"branch\": \"Fix / The Login Redirect\"}"}
+{"type": "block_stop", "index": 0}
+{"type": "message_delta", "stop_reason": {"kind": "end_turn"}, "usage": {}}
+{"type": "message_stop"}
+
+{"type": "message_start", "model": "mock", "usage": {}}
+{"type": "block_start", "index": 0, "block": {"kind": "text"}}
+{"type": "text_delta", "index": 0, "text": "{\"branch\": \"Fix / The Login Redirect\"}"}
+{"type": "block_stop", "index": 0}
+{"type": "message_delta", "stop_reason": {"kind": "end_turn"}, "usage": {}}
+{"type": "message_stop"}

--- a/docs/adr/0051-a-branch-is-named-by-what-you-asked-for.md
+++ b/docs/adr/0051-a-branch-is-named-by-what-you-asked-for.md
@@ -1,0 +1,100 @@
+# 0051 — A branch is named by what you asked for
+
+## What happened
+
+`^N` → *In a new worktree* gives you a checkout on a branch called `spry-reef`. That is deliberate
+and ADR 0046 argues for it: naming a branch before the work is a decision made at the worst possible
+moment, and every one of those is a reason not to start. Two words from a word list are a fine thing
+to *begin* on.
+
+They are a poor thing to find a week later. `git branch` in a repository somebody has been working
+in reads:
+
+```text
+  amber-heron
+  brisk-otter
+  hardy-quartz
+  spry-reef
+* wily-nimbus
+```
+
+Five branches, four of them somebody else's problem, and nothing on the list says which one is the
+rate limiter. The panel is no better — a worktree row *is* its branch — so the column whose job is
+to tell you where your work is says `wily-nimbus` about all of it. The name was never wrong; it was
+simply chosen before there was anything to choose it from.
+
+The information arrives about ninety seconds later, on its own, and nobody has to be asked for it:
+the first message sent in that worktree is exactly the description a branch name is made of. t3code
+does this — a temporary `t3code/<8 hex>` branch, regenerated and renamed on the first turn — and it
+is right for the reason the scratch name is right. Both halves are the same argument: do not ask for
+a decision at the moment you cannot make it, and do not throw the decision away when it arrives.
+
+## The decision
+
+**A worktree names itself from the first thing asked in it.** `git.worktree.new.auto` and
+`git.worktree.new.inside` create the branch they always did; the first turn started in that
+conversation renames it — `wily-nimbus` becomes `fix/composer-paste-truncation` — and nothing here
+touches it again.
+
+**Only a name nobody chose.** The mark is a session var, `git.branch.scratch`, written at the one
+moment the difference is known: the plugin that generated `wily-nimbus` says so. t3code recognises
+its own temporary branches by their *shape*, which works until a real branch happens to look like
+one and which cannot tell `brisk-otter` that we generated from `brisk-otter` that you typed. Writing
+it down costs one key and removes the guess. It is removed the moment the branch is named, after
+which this is an ordinary worktree.
+
+**At turn start, not turn end.** The panel is drawn all the way through a turn, and the row you are
+watching should say what you asked for rather than what a word list picked. `git branch -m` is one
+ref write: the working tree is untouched, so it is safe under a running agent and safe on a branch
+with uncommitted work on it — which is the realistic state at the only moment there is enough
+information to name the branch.
+
+**One attempt, ever.** The mark is removed *before* the model is asked, so a cheap model that
+hiccups costs one request rather than one per message for the life of the conversation. This is the
+rule the titles plugin arrived at from the same direction. Too *early* is not a failure and does not
+spend it: a turn with nothing readable yet leaves the mark alone.
+
+**The type is the model's, and the prefix is for a name that arrived without one.** The built-in
+prompt asks for `feature/`, `fix/`, `chore/`, `refactor/`, `docs/`, `test/` or `perf/`, chosen from
+what the work *is* rather than from the words used to ask for it. `git.branch.prefix` therefore
+applies only when the generated name has no namespace of its own — a prefix bolted on
+unconditionally reads `feature/fix/the-login-redirect`, which is a namespace nobody meant under a
+type that is now wrong. Somebody who wants the prefix always has the prompt, which is a setting for
+exactly this reason.
+
+**Every part of it is a setting, and every default is the one you already have.**
+`git.branch.prompt` replaces the prompt, `git.branch.instructions` appends to it,
+`git.branch.model` names the model, `git.branch.auto` turns the whole thing off. An unset
+`git.branch.model` falls to `gen.model` and then to the model the conversation is using — the
+plugin returns *no selection at all* rather than guessing, because the fallback is the host's and
+duplicating it is how the two come to disagree. Out of the box a branch is named by whatever you are
+already talking to, which is the right answer in a workspace where the cheap model was never
+configured and the alternative is failing.
+
+**The host puts its own label right.** This is the part that was not obvious. `ProjectFacts` — the
+display name, the repository root and the branch — is asked once, the first time the host sees a
+directory, and read on every redraw of every panel. That is correct: a label is not worth a
+subprocess per frame. It is wrong for exactly one moment, and this feature is that moment. So
+`GitRenameBranch` is handled *on the host loop* rather than through `spawn_slow`, alone among the
+git writes: it re-reads the facts for every directory that was on the old branch and announces it,
+and without that the panel says `wily-nimbus` under a conversation working on
+`fix/composer-paste-truncation` until the workspace is restarted. ADR 0036's rule from the other
+end — a value the host *kept* has to be put right by whatever changed it.
+
+Matched on the cached branch rather than on the directory the git call ran in, because one rename
+can move several rows: `cwd` names a checkout, and the branch may be checked out in a worktree that
+is a different directory from it.
+
+## What this does not do
+
+**It does not rename the directory.** `~/.nsh/neosh/wily-nimbus` stays `wily-nimbus` while the
+branch becomes `fix/composer-paste-truncation`. Moving it would invalidate the conversation's `cwd`,
+the agent's own resolved paths and any process it has open — a much larger promise than a better
+name is worth. The panel names the row by its branch, so the stale directory is visible only to
+somebody looking at the path, and `y` still copies a path that works.
+
+**It does not make a branch the default.** `^N` still asks where, and `Here` is still the selected
+row. This changes what the worktree rows *give* you, not which one is chosen for you.
+
+**It does not touch a branch you named.** `git.worktree.new feat/thing` is yours, is never marked,
+and is never renamed.

--- a/plugins/api/src/generated/ApiCall.ts
+++ b/plugins/api/src/generated/ApiCall.ts
@@ -363,6 +363,17 @@ export type ApiCall =
   | { "call": "git_default_branch" }
   | { "call": "git_create_branch"; name: string; from?: string | null }
   | { "call": "git_checkout"; rev: string }
+  | {
+    "call": "git_rename_branch";
+    old: string;
+    new: string;
+    /**
+     * The checkout the branch belongs to. `git branch -m` runs *inside* a repository, and a
+     * caller renaming the branch of a worktree other than the active conversation's has to
+     * say which — the same reason [`Self::GitAddWorktree`] takes one.
+     */
+    cwd?: string | null;
+  }
   | { "call": "git_stage"; paths: Array<string> }
   | { "call": "git_unstage"; paths: Array<string> }
   | { "call": "git_commit"; message: string }

--- a/plugins/api/src/index.ts
+++ b/plugins/api/src/index.ts
@@ -862,6 +862,20 @@ export interface GitApi {
   /** What this branch would merge into: `origin/HEAD`, else `main`/`master`. */
   defaultBranch(): Promise<string | null>;
   createBranch(name: string, opts?: { from?: string }): Promise<void>;
+  /**
+   * Move a branch to another name — `git branch -m`.
+   *
+   * One ref write. The working tree is untouched, so this is safe on a branch that is checked out
+   * and safe while an agent is editing files against it — which is the case it exists for: naming
+   * a worktree's branch from the first message, once there is a message to name it from.
+   *
+   * `cwd` is the checkout the branch belongs to, and you almost always want it: the worktree being
+   * renamed is very often not the one the active conversation is standing in.
+   *
+   * Fails if `next` is taken — a generated name does not get to overwrite somebody's branch. Ask
+   * `branches()` and pick a free one.
+   */
+  renameBranch(name: string, next: string, opts?: { cwd?: string }): Promise<void>;
   checkout(rev: string): Promise<void>;
   /** Empty `paths` stages everything, like `git add .` from the repository root. */
   stage(paths?: string[]): Promise<void>;
@@ -2107,6 +2121,9 @@ export function __createContext(plugin: string, config: unknown, version: number
       },
       async createBranch(name, opts) {
         await c({ call: "git_create_branch", name, from: opts?.from ?? null });
+      },
+      async renameBranch(name, next, opts) {
+        await c({ call: "git_rename_branch", old: name, new: next, cwd: opts?.cwd ?? null });
       },
       async checkout(rev) {
         await c({ call: "git_checkout", rev });

--- a/plugins/builtin/git/main.ts
+++ b/plugins/builtin/git/main.ts
@@ -9,16 +9,30 @@
  *
  * ```toml
  * [options]
- * "git.branch.prefix" = "feature/"
  * "git.branch.instructions" = "Start with the Jira key when the message mentions one."
+ * "git.branch.model" = "anthropic/claude-haiku-4-5-20251001"  # empty uses the model you talk to
+ * "git.branch.auto" = false                            # keep the scratch name
  * ```
+ *
+ * **A worktree names itself once you have said what it is for.** `git.worktree.new.auto` creates a
+ * branch called `brisk-otter`, because a name chosen before the work is a decision made at the
+ * worst possible moment. The first message sent in it is that decision, arriving on its own, so
+ * the branch is renamed from it — `fix/composer-paste-truncation` — and never touched again.
  *
  * Nothing in this file is privileged. It is an ordinary plugin over `neosh.git` and `neosh.gen`,
  * and replacing it with your own is `plugins.disabled = ["git"]` plus a plugin directory.
  */
 
-import { byteLength } from "@neosh/api";
-import type { CommitInfo, Neosh, PluginContext, RepoStatus, WorktreeInfo } from "@neosh/api";
+import { byteLength, sessionScope } from "@neosh/api";
+import type {
+  CommitInfo,
+  ModelSelection,
+  Neosh,
+  PluginContext,
+  RepoStatus,
+  SessionId,
+  WorktreeInfo,
+} from "@neosh/api";
 import {
   confirm,
   confirmDestructive,
@@ -36,10 +50,19 @@ const BRANCH_PROMPT = `You generate git branch names.
 Return a JSON object with exactly one key: branch.
 
 Rules:
-- Describe the work in the message, not the act of asking for it.
-- 2 to 6 words, lowercase, hyphen separated.
-- No ticket prefixes, no punctuation, no trailing slash.
-- Prefer the noun the change is about over the verb used to request it.`;
+- Start with the type of work, as a prefix ending in a slash. Use exactly one of:
+  feature/ for something new, fix/ for a defect, refactor/ for a change that keeps behaviour,
+  chore/ for maintenance, docs/ for documentation, test/ for tests, perf/ for a speed-up.
+- Choose the type from what the work is, not from the words used to ask for it: "the sidebar
+  flickers" is fix/, "add a sidebar" is feature/.
+- After the prefix, 2 to 6 words describing the work, lowercase, hyphen separated.
+- Prefer the noun the change is about over the verb used to request it.
+- No ticket keys, no punctuation, no trailing slash, nothing after the words.
+
+Examples:
+- "the composer eats the last character when you paste" -> fix/composer-paste-truncation
+- "let people pin a project to the top" -> feature/pin-project
+- "bump the deno version" -> chore/bump-deno`;
 
 const COMMIT_PROMPT = `You write git commit messages.
 Return a JSON object with keys: subject, body.
@@ -75,7 +98,16 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
     {
       name: "git.branch.prefix",
       description:
-        'Prepended to every generated branch name, e.g. "feature/". Applied after slugging, so it survives verbatim.',
+        'Prepended to a generated branch name that has no prefix of its own, e.g. "feature/". \
+Applied after slugging, so it survives verbatim — and skipped when the model already chose a \
+type, which the built-in prompt asks it to, so setting this does not produce "feature/fix/thing".',
+    },
+    {
+      name: "git.branch.model",
+      description:
+        "Model for naming branches, as `instance/model`. Empty falls back to `gen.model`, and \
+then to the model the conversation is using — so out of the box a branch is named by whatever you \
+are already talking to.",
     },
   ]) {
     await neosh.opt.declare({
@@ -86,6 +118,14 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
     });
   }
 
+  await neosh.opt.declare({
+    name: "git.branch.auto",
+    type: { type: "bool" },
+    default: true,
+    description:
+      "Name an auto-created worktree's branch from the first message sent in it. Off leaves the \
+two-word scratch name it was created with.",
+  });
   await neosh.opt.declare({
     name: "git.commit.confirm",
     type: { type: "bool" },
@@ -194,6 +234,10 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
   await footer();
   subscriptions.push(neosh.agent.onTurnEnd(() => void footer()));
   subscriptions.push(neosh.session.onChange(() => void footer()));
+  // The first thing asked in a scratch worktree is what its branch should have been called.
+  subscriptions.push(
+    neosh.agent.onTurnStart((e) => void nameScratchBranch(neosh, e.session as SessionId)),
+  );
   // The working tree changes whenever anything writes a file, including the agent.
   subscriptions.push(neosh.timer.every(5000, () => void footer()));
 }
@@ -263,28 +307,13 @@ async function newBranch(neosh: Neosh): Promise<void> {
   if (!description || !description.trim()) return;
 
   neosh.notify("naming the branch…");
-  let name: string;
+  let unique: string;
   try {
-    const answer = await neosh.gen.json<{ branch?: string }>(
-      `${await promptFor(neosh, "branch", BRANCH_PROMPT)}\n\nUser message:\n${description}`,
-    );
-    if (typeof answer.branch !== "string" || answer.branch.trim() === "") {
-      throw new Error("the model returned no branch name");
-    }
-    name = answer.branch;
+    unique = await nameBranch(neosh, description);
   } catch (e) {
     neosh.notify(`could not name the branch: ${e}`, "error");
     return;
   }
-
-  const prefix = (await neosh.opt.get<string>("git.branch.prefix")) ?? "";
-  // Slugged here rather than in the host, so the name shown for approval below is exactly the
-  // refname that will be created. "Why is my branch called that" is a question best answered
-  // before the branch exists.
-  const full = `${prefix}${slug(name)}`;
-
-  const taken = new Set((await neosh.git.branches({ includeRemote: true })).map((b) => b.name));
-  const unique = dedupe(full, taken);
 
   const edited = await prompt(neosh, "Branch name", { initial: unique, width: 76 });
   if (!edited || !edited.trim()) return;
@@ -295,6 +324,63 @@ async function newBranch(neosh: Neosh): Promise<void> {
   } catch (e) {
     neosh.notify(String(e), "error");
   }
+}
+
+/**
+ * A refname for `description`: generated, slugged, prefixed and not already taken.
+ *
+ * Every step of it happens here rather than in the host so that the name a caller shows for
+ * approval is exactly the name that will exist. "Why is my branch called that" is a question best
+ * answered before the branch does.
+ *
+ * Throws rather than returning a fallback. There is no useful default branch name, and the two
+ * callers want opposite things when this fails — one tells you, the other says nothing — which is
+ * a decision for them and not for this.
+ */
+async function nameBranch(neosh: Neosh, description: string, cwd?: string): Promise<string> {
+  const answer = await neosh.gen.json<{ branch?: string }>(
+    `${await promptFor(neosh, "branch", BRANCH_PROMPT)}\n\nUser message:\n${description}`,
+    await branchModel(neosh),
+  );
+  if (typeof answer.branch !== "string" || answer.branch.trim() === "") {
+    throw new Error("the model returned no branch name");
+  }
+  const name = slug(answer.branch);
+  const prefix = (await neosh.opt.get<string>("git.branch.prefix")) ?? "";
+  // Skipped when the model already chose a type. The built-in prompt asks for `fix/`, `feature/`
+  // and the rest, so a `git.branch.prefix` applied unconditionally on top of it would read
+  // `feature/fix/composer-paste` — a prefix nobody meant and a type that is now wrong. Somebody
+  // who wants the prefix *always* has the prompt: it is a setting for the same reason.
+  const full = name.includes("/") ? name : `${prefix}${name}`;
+
+  const taken = new Set(
+    (await neosh.git.branches({ includeRemote: true, ...(cwd ? { cwd } : {}) }).catch(() => []))
+      .flatMap((b) => [b.name, b.name.replace(/^[^/]+\//, "")]),
+  );
+  return dedupe(full, taken);
+}
+
+/**
+ * Which model names a branch, if anyone said.
+ *
+ * Three rungs and this is only the first: `git.branch.model`, then `gen.model`, then the model the
+ * conversation is using — and the last two are the host's, which is why an unset option returns
+ * nothing at all rather than a guess. Out of the box that means your own model names the branch,
+ * which is the right default for a workspace where the cheap model is not configured and the only
+ * alternative would be failing.
+ */
+async function branchModel(
+  neosh: Neosh,
+): Promise<{ selection: ModelSelection } | undefined> {
+  const spec = ((await neosh.opt.get<string>("git.branch.model")) ?? "").trim();
+  const cut = spec.indexOf("/");
+  if (cut <= 0 || cut === spec.length - 1) return undefined;
+  return {
+    selection: {
+      instance: spec.slice(0, cut) as ModelSelection["instance"],
+      model: spec.slice(cut + 1) as ModelSelection["model"],
+    },
+  };
 }
 
 async function commit(neosh: Neosh): Promise<void> {
@@ -651,8 +737,10 @@ interface WorktreeSpec {
  *
  * `auto` drops the last question too. Naming a branch before you know what the work is is a
  * decision you are not yet equipped to make, and every one of those is a reason not to start —
- * which is the opposite of what a key for "somewhere clean to try this" is for. The name is
- * generated, the branch is real, and renaming it later is `git branch -m` like any other.
+ * which is the opposite of what a key for "somewhere clean to try this" is for. So the branch is
+ * real and its name is two words from a list, and the decision is deferred rather than skipped:
+ * the first message sent in the tree is what it should have been called, so that is what it gets
+ * called. See [`nameScratchBranch`].
  *
  * Landing in it is the point. Creating a directory you then have to go and find is not a feature,
  * it is a chore with extra steps.
@@ -686,8 +774,81 @@ async function newWorktree(neosh: Neosh, spec: WorktreeSpec = {}): Promise<void>
     neosh.notify(String(e), "error");
     return;
   }
-  await neosh.session.create({ cwd: where });
+  const session = await neosh.session.create({ cwd: where });
+  // Only a name *nobody chose* is one this plugin may replace later. A branch somebody typed is
+  // theirs, and `git.worktree.new feat/thing` must not be quietly renamed the moment a message is
+  // sent — so the mark goes on here, where the difference is still known, rather than being
+  // guessed at afterwards from the shape of the name.
+  if (spec.auto && create) {
+    await neosh.vars.set(sessionScope(session.id), VAR_SCRATCH, name)
+      .catch((e: unknown) => neosh.log.info(`could not mark ${name} as scratch: ${e}`));
+  }
   neosh.notify(`${create ? "branched" : "checked out"} ${name} in ${where}`);
+}
+
+/**
+ * The branch this conversation's worktree was created on, while that is still a name nobody chose.
+ *
+ * A var rather than a pattern match on the name. t3code recognises its own temporary branches by
+ * their shape — `t3code/<8 hex>` — which works until somebody's real branch happens to look like
+ * one, and which cannot tell `brisk-otter` that we generated from `brisk-otter` that you typed.
+ * Writing it down at the one moment the difference is known costs a key and removes the guess.
+ *
+ * Session-scoped, so it is deleted with the conversation, and removed the moment the branch is
+ * named — after which this worktree is an ordinary worktree and nothing here will touch it again.
+ */
+const VAR_SCRATCH = "git.branch.scratch";
+
+/**
+ * Name the branch of a scratch worktree after the first thing asked in it.
+ *
+ * The alternative is asking before the work starts, and a branch named before you know what the
+ * work is is a decision made at the worst possible moment — which is the whole reason
+ * `git.worktree.new.auto` exists and gives you `brisk-otter` instead. This is the other half:
+ * `brisk-otter` is a fine thing to *start* on and a poor thing to find in `git branch` next week.
+ *
+ * On turn start rather than turn end, because the panel is drawn all through a turn and the row
+ * you are watching should say what you asked for, not what a word list picked. `git branch -m` is
+ * one ref write, so doing it under a running agent changes nothing about the files it is editing.
+ *
+ * **One attempt, ever.** The mark is removed before the model is asked, so a cheap model that
+ * hiccups costs one request rather than one per message for the life of the conversation — the
+ * rule the titles plugin arrived at the same way. Too *early* is not a failure and does not spend
+ * it: a turn with nothing to read yet leaves the mark alone and waits for the next one.
+ */
+async function nameScratchBranch(neosh: Neosh, session: SessionId): Promise<void> {
+  if (!((await neosh.opt.get<boolean>("git.branch.auto")) ?? true)) return;
+  const scope = sessionScope(session);
+  const scratch = await neosh.vars.get<string>(scope, VAR_SCRATCH).catch(() => null);
+  if (!scratch) return;
+
+  const info = (await neosh.session.list().catch(() => [])).find((x) => x.id === session);
+  // Somebody renamed it themselves, or moved off it. Either way the name is theirs now.
+  if (!info || info.branch !== scratch) {
+    await neosh.vars.remove(scope, VAR_SCRATCH).catch(() => {});
+    return;
+  }
+
+  const messages = await neosh.session.messages(session).catch(() => []);
+  const asked = messages
+    .filter((m) => m.role === "user")
+    .flatMap((m) => m.content.flatMap((b) => (b.type === "text" ? [b.text] : [])))
+    .join("\n\n")
+    .trim()
+    .slice(0, 4000);
+  if (asked === "") return;
+
+  await neosh.vars.remove(scope, VAR_SCRATCH).catch(() => {});
+  try {
+    const named = await nameBranch(neosh, asked, info.cwd);
+    if (named === scratch) return;
+    await neosh.git.renameBranch(scratch, named, { cwd: info.cwd });
+    neosh.notify(`branch is ${named}`);
+  } catch (e) {
+    // Not worth interrupting for: the worktree works, the branch has a name, and a popup every
+    // time a model hiccups would cost more than the name it failed to improve.
+    neosh.log.info(`could not name ${scratch}: ${e}`);
+  }
 }
 
 /**


### PR DESCRIPTION
A worktree you did not name starts on `wily-nimbus`, because naming a branch before the work is a decision made at the worst possible moment. The first message sent in it *is* that decision, arriving on its own — so the branch is renamed from it and never touched again.

```
^N → In a new worktree     branch `wily-nimbus`, conversation opens
> the composer eats the last character when you paste
…                          branch is fix/composer-paste-truncation
```

### The decisions

- **Only a name nobody chose.** The mark is a session var (`git.branch.scratch`) written at the one moment the difference is known, by the plugin that generated the scratch name. t3code recognises its own temporary branches by their *shape*, which works until a real branch happens to look like one and which cannot tell `brisk-otter` we picked from `brisk-otter` you typed. `git.worktree.new feat/thing` is yours and is never marked.
- **At turn start, not turn end.** The panel is drawn all through a turn and the row you are watching should say what you asked for. `git branch -m` is one ref write: the working tree is untouched, so it is safe under a running agent and safe on a branch with uncommitted work on it — which is the realistic state at the only moment there is enough information to name the branch.
- **One attempt, ever.** The mark is removed *before* the model is asked, so a cheap model that hiccups costs one request rather than one per message for the life of the conversation. Too early is not a failure and does not spend it.
- **The type is the model's; the prefix is for a name that arrived without one.** The built-in prompt asks for `feature/`, `fix/`, `chore/`, `refactor/`, `docs/`, `test/` or `perf/`, chosen from what the work *is* rather than the words used to ask for it. `git.branch.prefix` applied unconditionally on top would read `feature/fix/the-login-redirect` — a namespace nobody meant under a type that is now wrong.
- **The host puts its own label right.** `ProjectFacts` — display name, repo root, branch — is asked once the first time the host sees a directory and read on every redraw. Correct, and wrong for exactly this moment. So `GitRenameBranch` is handled *on the host loop*, alone among the git writes: it re-reads the facts for every directory that was on the old branch and announces it. Without that the sidebar says `wily-nimbus` under a conversation working on `fix/composer-paste-truncation` until the workspace restarts. ADR 0036's rule from the other end — a value the host *kept* has to be put right by whatever changed it.

### Settings — every default is the one you already have

| Option | Default |
|---|---|
| `git.branch.prompt` | replaces the built-in prompt wholesale |
| `git.branch.instructions` | appended — the house-rule hatch |
| `git.branch.model` | empty → `gen.model` → the model you are talking to |
| `git.branch.auto` | `true`; off keeps the scratch name |

`branchModel` returns *no selection at all* when unset rather than a guess, so the precedence stays the host's and the two cannot come to disagree.

### What this does not do

- **It does not rename the directory.** Moving it would invalidate the conversation's `cwd`, the agent's resolved paths and anything it has open — a much larger promise than a better name is worth. The panel names the row by its branch, so the stale directory is visible only to somebody looking at the path.
- **It does not make a branch the default.** `^N` still asks where, and `Here` is still the selected row.

### API

`ApiCall::GitRenameBranch` + generated TS + `neosh.git.renameBranch(name, next, { cwd })`, in that order — the plugin uses exactly the public call a third party would.

### Verification

- `neosh-vcs` 8/8, including a new test that renames under a worktree standing on the branch with uncommitted work in it, and asserts a taken name is refused rather than clobbered.
- `neosh-core` green; `workspace` 12/12.
- `builtin_plugins` 146/147 — the one failure is `the_plan_row_keeps_the_providers_own_colour`, which already fails on `main`.
- Three new end-to-end tests driving the real binary: the scratch rename asserts git's HEAD *and* that the sidebar row goes from `wily-nimbus` to `⎇ fix/the-login-redire…`; plus prefix-non-stacking and `git.branch.model`.
- Bindings regenerated and committed; `tsc --noEmit` clean on the API package and on the plugin.

See `docs/adr/0051-a-branch-is-named-by-what-you-asked-for.md`.
