### PR TITLE
fix(images): a clipboard that only names a picture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,12 +265,19 @@ per decision, and records the *reasoning*, not the choice.
 - **A terminal cannot paste a picture, so pasting one is a key.** Bracketed paste is a text
   protocol: a screenshot arrives as nothing, and a dragged file arrives as its path. `^V` asks the
   system clipboard through whichever of `wl-paste`/`xclip`/`pngpaste`/`osascript`/`powershell` is
-  there; a pasted line that is unambiguously a path to an image becomes that image. An attachment
-  is a **chip above the field**, never a token in it — the message you send is the message you
-  typed. `ContentBlock::Image` carries a *path*, not bytes: a transcript that is mostly base64 is
-  one nothing can read back, so the bytes live once in the state directory and a driver reads them
-  when it builds its request. The media type is read off the bytes, because a `.png` that is really
-  a JPEG fails the turn. See ADR 0041.
+  there; a pasted line that is unambiguously a path to an image becomes that image. A clipboard is
+  **asked what it holds, not told**: the best picture type *on offer* is the one requested, because
+  asking for `image/png` and nothing else reads a JPEG, a WebP and a BMP as an empty clipboard. And
+  a picture copied off a page is often not on the clipboard at all — what a browser leaves is an
+  address (`text/uri-list`, an `<img src>` in `text/html`, a `data:` URI, a plain URL), so
+  `from_clipboard` answers with bytes *or* a `Remote` to go and get. That fetch is spawned rather
+  than awaited on the loop, carries the conversation it was asked in, and is the one attachment
+  that says something on the way. A photograph too busy to fit as a PNG is sent as a JPEG rather
+  than refused over an encoding. See ADR 0051. An attachment is a **chip above the field**, never a
+  token in it — the message you send is the message you typed. `ContentBlock::Image` carries a
+  *path*, not bytes: a transcript that is mostly base64 is one nothing can read back, so the bytes
+  live once in the state directory and a driver reads them when it builds its request. The media
+  type is read off the bytes, because a `.png` that is really a JPEG fails the turn. See ADR 0041.
 - **A vendor CLI outlives the turn, so an abandoned turn has to be *drained*.** `Live::lines` is
   per conversation. A turn that is walked away from — `<Esc>`, a switch — leaves the CLI mid-answer
   with the rest of it in the pipe, and the next turn reads it as its own: someone else's reply, and
@@ -399,7 +406,7 @@ only way to do anything. See ADR 0048.
 | `⏎` | Send. While a turn is running, **steer** it: the message is held and taken in at the next gap. |
 | `⇧⏎` | Newline, so a pasted snippet stays one message |
 | `^Y` | Take the last thing you queued back into the composer, to change it or drop it. Readline's yank: `^U`/`^W` kill, `^Y` brings it back |
-| `^V` | Attach the image on the clipboard. A key rather than a paste, because a terminal's paste can only ever hand over text |
+| `^V` | Attach the image on the clipboard — the picture itself, or the one it only names: a page's `<img>`, a URL, a file. A key rather than a paste, because a terminal's paste can only ever hand over text |
 | `⌫` | On an empty composer, take the last attached image back off |
 | `^P` | Pick a model. Mid-turn too — the running agent is told, and thinks the rest with it |
 | `^E` | Everything this model can be told, on one panel: effort, thinking, fast mode, context, and whatever a driver invented. `h`/`l` along a row, `j`/`k` between them, arrows too, and it applies as you move. Nothing else reaches the keyboard while it is open; `^E` again closes it |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2363,6 +2363,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64",
  "clap",
  "crossterm",
  "directories",
@@ -2378,6 +2379,7 @@ dependencies = [
  "neosh-syntax",
  "neosh-tui",
  "neosh-vcs",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ include_dir = "0.7"
 # Images. `base64` is how every provider we target wants the bytes; `image` is for sniffing what
 # was actually on the clipboard and shrinking a 4K screenshot before it is sent five times.
 base64 = "0.22"
-image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp", "bmp"] }
 
 # dev
 insta = { version = "1.48", features = ["json", "redactions"] }

--- a/crates/neosh/Cargo.toml
+++ b/crates/neosh/Cargo.toml
@@ -36,6 +36,8 @@ unicode-width = { workspace = true }
 async-trait = { workspace = true }
 crossterm = { workspace = true }
 url = "2"
+reqwest = { workspace = true }
+base64 = { workspace = true }
 image = { workspace = true }
 uuid = { workspace = true }
 tokio-stream = { workspace = true }

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -390,6 +390,15 @@ pub struct Host {
     quota_rx: Option<tokio::sync::mpsc::UnboundedReceiver<crate::quota::Polled>>,
     /// Set by a turn ending, cleared by the poll that follows it. See [`crate::quota::AFTER_TURN`].
     quota_due: bool,
+    /// Where a picture that had to be fetched comes back to.
+    ///
+    /// Same reason as the quota channel above: what is on the clipboard is sometimes only the
+    /// *address* of a picture, and going to get one is a round trip to a machine we have never met.
+    /// The key press cannot wait for it on the host loop, and the conversation it belongs to is the
+    /// one that was on screen when the key was pressed rather than whichever one is by the time it
+    /// lands.
+    image_tx: tokio::sync::mpsc::UnboundedSender<Fetched>,
+    image_rx: Option<tokio::sync::mpsc::UnboundedReceiver<Fetched>>,
     /// Repositories by directory, discovered on demand.
     ///
     /// Keyed rather than singular because the *conversation* decides which repository is in play:
@@ -639,6 +648,17 @@ impl Drop for SecretPrompt {
     }
 }
 
+/// A picture that had to be fetched, arriving after the key press that asked for it.
+///
+/// Carries the conversation rather than reading one on arrival: switching conversations while a
+/// server takes its time is an ordinary thing to do, and the picture belongs to the one you were
+/// in when you pressed the key. `waiting` is a plugin owed an answer, if a plugin is what asked.
+struct Fetched {
+    session: neosh_proto::SessionId,
+    waiting: Option<(PluginId, RequestId)>,
+    result: Result<crate::images::Attachment, String>,
+}
+
 impl Host {
     pub fn new(
         agent: Arc<Agent>,
@@ -647,6 +667,7 @@ impl Host {
     ) -> Self {
         let mut editor = Editor::new();
         let (quota_tx, quota_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (image_tx, image_rx) = tokio::sync::mpsc::unbounded_channel();
 
         let chat = editor.create_buffer("[chat]");
         let chat_win =
@@ -753,6 +774,8 @@ impl Host {
             quota_tx,
             quota_rx: Some(quota_rx),
             quota_due: false,
+            image_tx,
+            image_rx: Some(image_rx),
             repos: Default::default(),
             cwd: std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
             projects: Default::default(),
@@ -908,7 +931,7 @@ impl Host {
                 // A plugin's own images go on the row first, so they travel with whatever is
                 // already there and in the order they were added — the send is one message.
                 for path in &images {
-                    if let Err(e) = self.attach(Some(std::path::Path::new(path))) {
+                    if let Err(e) = self.attach(std::path::Path::new(path)) {
                         return Err(ApiError::InvalidArgument { message: e });
                     }
                 }
@@ -916,8 +939,17 @@ impl Host {
                 Ok(ApiOk::Unit)
             }
             ApiCall::ChatAttach { path } => {
+                // `None` means the clipboard, and the clipboard is sometimes only the *address* of
+                // a picture — so it is taken over before dispatch, where the request id still is,
+                // and the plugin is answered when the fetch lands. Anything arriving here names a
+                // file and is read now.
+                let Some(path) = path else {
+                    return Err(ApiError::Internal {
+                        message: "the clipboard is answered off the loop".to_string(),
+                    });
+                };
                 let got = self
-                    .attach(path.as_deref().map(std::path::Path::new))
+                    .attach(std::path::Path::new(&path))
                     .map_err(|message| ApiError::InvalidArgument { message })?;
                 Ok(ApiOk::Attachments { attachments: vec![info_of(&got)] })
             }
@@ -1485,21 +1517,113 @@ impl Host {
         }
     }
 
-    /// Put an image on the composer's attachment row.
+    /// Put an image from a file on the composer's attachment row.
     ///
-    /// `path` names a file; `None` is the clipboard. Answers with what it attached, so the caller
-    /// can say so — a chip appearing at the bottom of the screen is not enough on its own when the
-    /// thing you pressed might equally have found nothing.
-    fn attach(&mut self, path: Option<&std::path::Path>) -> Result<crate::images::Attachment, String> {
+    /// Answers with what it attached, so the caller can say so — a chip appearing at the bottom of
+    /// the screen is not enough on its own when the thing you pressed might equally have found
+    /// nothing.
+    fn attach(&mut self, path: &std::path::Path) -> Result<crate::images::Attachment, String> {
         let store = self.image_store();
-        let got = match path {
-            Some(p) => crate::images::from_path(&store, p),
-            None => crate::images::from_clipboard(&store),
-        }?;
+        let got = crate::images::from_path(&store, path)?;
         let here = self.active_session();
-        self.attached.entry(here).or_default().push(got.clone());
-        self.refresh_composer();
+        self.hold(&here, got.clone());
         Ok(got)
+    }
+
+    /// Put an attachment on a conversation's row, redrawing the chips if that is the one on screen.
+    fn hold(&mut self, session: &neosh_proto::SessionId, got: crate::images::Attachment) {
+        self.attached.entry(session.clone()).or_default().push(got);
+        if *session == self.active_session() {
+            self.refresh_composer();
+        }
+    }
+
+    /// `^V`, and `chat.attach` with nothing named: attach the picture the clipboard is holding.
+    ///
+    /// Two shapes of answer, because a clipboard has two ways of holding a picture. Bytes are here
+    /// and the chip appears in the same breath, silently — the chip *is* the report. An address is
+    /// a round trip to somebody else's server, which cannot happen on this loop and cannot be
+    /// silent either: a key press with nothing on screen after it is a key press that did nothing,
+    /// so it says where it has gone and says again when it arrives.
+    fn begin_paste(&mut self, waiting: Option<(PluginId, RequestId)>) {
+        let store = self.image_store();
+        let session = self.active_session();
+        match crate::images::from_clipboard(&store) {
+            Err(e) => self.finish_paste(session, waiting, Err(e), true),
+            Ok(crate::images::Clipped::Image(got)) => {
+                self.finish_paste(session, waiting, Ok(got), false)
+            }
+            Ok(crate::images::Clipped::Remote(url)) => {
+                let where_ = short_url(&url);
+                self.editor_message(MessageLevel::Info, format!("fetching {where_}\u{2026}"));
+                let tx = self.image_tx.clone();
+                tokio::spawn(async move {
+                    let result = crate::images::from_url(&store, &url).await;
+                    let _ = tx.send(Fetched { session, waiting, result });
+                });
+            }
+        }
+    }
+
+    /// A picture that was asked for has arrived, or has not.
+    ///
+    /// `announce` is whether this one owes a sentence: a fetch already said "fetching…", and a line
+    /// left saying that about a picture which is now on screen is the kind of stale that makes
+    /// people stop reading the line at all.
+    fn finish_paste(
+        &mut self,
+        session: neosh_proto::SessionId,
+        waiting: Option<(PluginId, RequestId)>,
+        result: Result<crate::images::Attachment, String>,
+        announce: bool,
+    ) {
+        match &result {
+            Ok(got) => {
+                let elsewhere = session != self.active_session();
+                // The conversation may have been archived or deleted while a server took its time.
+                // A row on one that is gone is a row nothing will ever draw or send.
+                if self.agent.sessions().get(&session).is_none() {
+                    self.editor_message(
+                        MessageLevel::Warn,
+                        format!("{} arrived after its conversation went", got.label()),
+                    );
+                } else {
+                    self.hold(&session, got.clone());
+                    if announce || elsewhere {
+                        // Named when it landed somewhere you are not looking, because the chip that
+                        // usually does the reporting is on a screen you cannot see.
+                        let where_ = match elsewhere {
+                            true => format!(" in {}", self.session_name(&session)),
+                            false => String::new(),
+                        };
+                        self.editor_message(
+                            MessageLevel::Info,
+                            format!("attached {}{where_}", got.label()),
+                        );
+                    }
+                }
+            }
+            Err(e) => self.editor_message(MessageLevel::Warn, e.clone()),
+        }
+        if let Some((plugin, id)) = waiting {
+            let response: ApiResponse = result
+                .map(|got| ApiOk::Attachments { attachments: vec![info_of(&got)] })
+                .map_err(|message| ApiError::InvalidArgument { message })
+                .into();
+            let _ = self.bridge.script().send(ScriptInbound::Plugin {
+                plugin,
+                msg: PluginInbound::Response { id, response },
+            });
+        }
+    }
+
+    /// What to call a conversation in a sentence about it.
+    fn session_name(&self, session: &neosh_proto::SessionId) -> String {
+        self.agent
+            .sessions()
+            .get(session)
+            .and_then(|s| s.title.clone())
+            .unwrap_or_else(|| "another conversation".to_string())
     }
 
     /// Whether the conversation on screen has an image attached that has not been sent.
@@ -5819,6 +5943,13 @@ impl Host {
                     // replied to exactly once, so this settles — unless the peer has gone, which
                     // the swarm reports as a disconnect and which settles it too.
                     // Dials an address that may not answer, so it cannot run on the loop.
+                    // Answered when the picture is here rather than now: what is on the
+                    // clipboard is sometimes a URL, and going to get one is somebody else's server
+                    // taking as long as it likes.
+                    if let ApiCall::ChatAttach { path: None } = &call {
+                        self.begin_paste(Some((plugin.clone(), id.clone())));
+                        return;
+                    }
                     if let ApiCall::SwarmProbe { addr } = &call {
                         self.begin_swarm_probe(addr.clone(), (plugin.clone(), id.clone()));
                         return;
@@ -5842,6 +5973,10 @@ impl Host {
                     });
                 }
                 PluginOutbound::Notify { call } => {
+                    if let ApiCall::ChatAttach { path: None } = &call {
+                        self.begin_paste(None);
+                        return;
+                    }
                     if let ApiCall::ProviderSetCredential { instance, replace } = &call {
                         if let Err(e) = self.begin_secret(instance.clone(), *replace, None) {
                             tracing::warn!(%plugin, "{e}");
@@ -5931,7 +6066,7 @@ impl Host {
                 // is not all four of those is text, because swallowing something somebody meant
                 // to type is much worse than making them press a key.
                 if let Some(path) = crate::images::pasted_path(&text) {
-                    match self.attach(Some(&path)) {
+                    match self.attach(&path) {
                         // Nothing said about it. The chip that just appeared above the field *is*
                         // the report, and a line saying the same words in the same glance is the
                         // kind of noise that teaches people not to read either one.
@@ -6045,6 +6180,7 @@ impl Host {
         // first screen has real numbers on it — a gauge that only appears after five minutes of
         // sitting there is one nobody knows exists.
         let mut quota_rx = self.quota_rx.take();
+        let mut image_rx = self.image_rx.take();
         let plan = tokio::time::sleep(crate::quota::AFTER_TURN);
         tokio::pin!(plan);
         // How many times in a row a poll has come back with nothing. Doubles the wait each time.
@@ -6129,6 +6265,20 @@ impl Host {
                             plan.as_mut().reset(Instant::now() + wait);
                         }
                     }
+                }
+                Some(fetched) = async {
+                    match image_rx.as_mut() {
+                        Some(rx) => rx.recv().await,
+                        // Never ready, rather than ready-with-nothing: the latter would spin.
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    self.finish_paste(
+                        fetched.session,
+                        fetched.waiting,
+                        fetched.result,
+                        true,
+                    );
                 }
                 () = &mut plan => {
                     self.refresh_quota(None);
@@ -6761,11 +6911,7 @@ impl Host {
             // Only the failure is worth a line: a chip appearing above the composer says the
             // other thing better than a sentence could. "Nothing on the clipboard" has nothing to
             // show for itself, and is the answer people actually need explaining.
-            "chat.image.paste" => {
-                if let Err(e) = self.attach(None) {
-                    self.editor_message(MessageLevel::Warn, e);
-                }
-            }
+            "chat.image.paste" => self.begin_paste(None),
             "chat.image.drop" => self.drop_attachment(),
             "chat.image.clear" => {
                 let here = self.active_session();
@@ -8045,6 +8191,16 @@ fn image_row(path: &str, media_type: &str) -> String {
 }
 
 /// What the API says about an attachment.
+/// A URL as much of itself as fits in a line about it: the host, and the last thing in the path.
+fn short_url(url: &str) -> String {
+    let Ok(parsed) = url::Url::parse(url) else { return url.to_string() };
+    let host = parsed.host_str().unwrap_or("").to_string();
+    match parsed.path_segments().and_then(|s| s.filter(|p| !p.is_empty()).next_back()) {
+        Some(last) if last.len() <= 40 => format!("{host}/{last}"),
+        _ => host,
+    }
+}
+
 fn info_of(a: &crate::images::Attachment) -> neosh_proto::AttachmentInfo {
     neosh_proto::AttachmentInfo {
         path: a.path.display().to_string(),

--- a/crates/neosh/src/images.rs
+++ b/crates/neosh/src/images.rs
@@ -13,6 +13,12 @@
 //!   — it is not a separate gesture to learn.
 //! * **a plugin**, through the same [`from_path`], because the API is the product.
 //!
+//! The clipboard is the one with two halves. A program that copies a picture chooses what to put
+//! on the clipboard, and copying one off a web page very often puts no bytes there at all — a URL,
+//! or the `<img>` tag that named it, and the picture itself is still on somebody's server. So
+//! [`from_clipboard`] answers with a [`Clipped`]: bytes it has already kept, or a reference for
+//! [`from_url`] to go and fetch off the loop.
+//!
 //! # What is done to the bytes
 //!
 //! Read, sniffed, shrunk if it is enormous, and written once into the workspace's own directory.
@@ -31,6 +37,15 @@ use std::path::{Path, PathBuf};
 
 /// The long edge past which no provider we target keeps the extra pixels.
 const MAX_EDGE: u32 = 1568;
+
+/// The most that will be pulled off a server for one picture. Not a picture budget — [`MAX_BYTES`]
+/// is that, and it is applied after shrinking — but a stop on a link that turns out to point at a
+/// disc image.
+const MAX_FETCH: u64 = 25_000_000;
+
+/// How long somebody else's server gets. Long enough for a slow one and short enough that a key
+/// press has visibly finished.
+const FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 
 /// What a request will carry. Well under every provider's per-image ceiling once base64 has added
 /// its third, and far past anything a screenshot produces — this is the guard against somebody
@@ -108,24 +123,217 @@ pub fn from_path(store: &Path, path: &Path) -> Result<Attachment, String> {
     keep(store, bytes)
 }
 
-/// Take whatever image is on the system clipboard.
+/// What the clipboard turned out to be holding.
+///
+/// Two answers rather than one, because they cost different things. Bytes are here already and
+/// become an attachment in the same breath. A *reference* — which is what a browser leaves when
+/// you copy a picture off a page: a URL, or the `<img>` tag naming one — is a network round trip,
+/// and the loop that draws the screen is not where a network round trip goes. So this says which
+/// of the two it found and the caller decides where the waiting happens.
+#[derive(Debug)]
+pub enum Clipped {
+    /// Bytes, already sniffed, shrunk and written down. Nothing left to do.
+    Image(Attachment),
+    /// A picture on somebody else's server. [`from_url`] is what finishes it.
+    Remote(String),
+}
+
+/// Take whatever image the system clipboard is holding — or the one it is pointing at.
 ///
 /// Nothing here knows how to talk to a clipboard, and that is on purpose. Every desktop already
-/// ships a program whose whole job this is, all four of them are present by default on the systems
-/// they belong to, and shelling out to them is how the terminal agents that do this do it. A
-/// library instead would mean linking X11 and Wayland into a program that spends its life on a
-/// pipe, and would still be wrong on the machine where the workspace is headless.
+/// ships a program whose whole job this is, all of them are present by default on the systems they
+/// belong to, and shelling out to them is how the terminal agents that do this do it. A library
+/// instead would mean linking X11 and Wayland into a program that spends its life on a pipe, and
+/// would still be wrong on the machine where the workspace is headless.
 ///
-/// Tried in order, first one that produces bytes wins. The error names what was missing, because
-/// "no image on the clipboard" and "no tool installed to look" are different problems with
-/// different fixes and only the second one is ours to explain.
-pub fn from_clipboard(store: &Path) -> Result<Attachment, String> {
-    let mut tried: Vec<&str> = Vec::new();
+/// Two things are looked for, in this order, because a clipboard holds a picture in two quite
+/// different ways and only the first of them is bytes:
+///
+/// * **the picture itself**, under whatever type the program that copied it chose to offer — which
+///   is why the offer is *read* rather than guessed. Asking for `image/png` and nothing else is
+///   how a JPEG copied out of an image viewer, a WebP off a page and a BMP out of an X11
+///   application all arrive as "nothing on the clipboard that is an image".
+/// * **a picture named somewhere else**: a `file://` URI from a file manager, an `<img src>` in
+///   the `text/html` a browser leaves beside the bytes, a `data:` URI, or a plain URL that ends in
+///   `.png`. Copying an image on a web page is *usually* both — and on plenty of pages, and every
+///   time somebody takes the address rather than the picture, it is only ever the second.
+pub fn from_clipboard(store: &Path) -> Result<Clipped, String> {
+    let mut trouble = Trouble::default();
+    // Asked once and passed along: it is a subprocess, and the reference path wants the answer to
+    // the same question the picture path just asked.
+    let offer = asks_first().then(|| offer(&mut trouble)).flatten();
+    if let Some(found) = clipboard_picture(offer.as_ref(), &mut trouble) {
+        return match found {
+            Picture::Bytes(bytes) => keep(store, bytes).map(Clipped::Image),
+            Picture::File(path) => from_path(store, &path).map(Clipped::Image),
+        };
+    }
+    for named in clipboard_references(offer.as_ref(), &mut trouble) {
+        if let Some(resolved) = resolve(store, &named) {
+            return resolved;
+        }
+    }
+    Err(trouble.into_message())
+}
+
+/// What went wrong on the way, for a sentence at the end.
+///
+/// Three outcomes and they are three different problems: nothing installed to look with, something
+/// that looked and could not see, and a clipboard that simply has no picture on it. Only the middle
+/// one is ours to explain, and it is the one nobody can guess — a workspace outlives the terminal
+/// that started it, so a `wl-paste` here can perfectly well be one with no compositor to ask.
+#[derive(Default)]
+struct Trouble {
+    /// Whether any program that could have answered was there to ask.
+    asked: bool,
+    /// What one of them said when it could not look at all.
+    said: Vec<String>,
+}
+
+impl Trouble {
+    fn into_message(self) -> String {
+        if !self.asked {
+            return format!(
+                "no clipboard tool to read an image with \u{2014} install one of {}",
+                reader_names().join(", ")
+            );
+        }
+        if !self.said.is_empty() {
+            return format!("could not read the clipboard: {}", self.said.join("; "));
+        }
+        "nothing on the clipboard that is an image".to_string()
+    }
+}
+
+/// A picture that has been found but not yet kept.
+enum Picture {
+    Bytes(Vec<u8>),
+    File(PathBuf),
+}
+
+/// Whether this desktop's clipboard can be *asked what it holds* before being asked for it.
+///
+/// Wayland and X11 can, and it is the whole difference between this working and not. macOS and
+/// Windows cannot cheaply, so there the programs are tried in turn and the first that answers wins.
+fn asks_first() -> bool {
+    !cfg!(target_os = "macos") && !cfg!(target_os = "windows")
+}
+
+/// What a Wayland or X11 clipboard says it is holding, and the program that answered.
+struct Offer {
+    reader: &'static str,
+    /// Exactly as offered, case and parameters and all: `image/x-MS-bmp` is a real target atom and
+    /// a request for `image/x-ms-bmp` gets nothing.
+    types: Vec<String>,
+}
+
+impl Offer {
+    /// The offered type matching `mime`, or nothing.
+    fn holds(&self, mime: &str) -> Option<&str> {
+        self.types
+            .iter()
+            .find(|t| t.split(';').next().unwrap_or(t).trim().eq_ignore_ascii_case(mime))
+            .map(String::as_str)
+    }
+
+    /// The best picture type on offer. Best rather than first: a program that offers three has
+    /// ranked nothing, and PNG before JPEG before the rest is our ranking to make.
+    fn picture(&self) -> Option<&str> {
+        DECODABLE.iter().find_map(|mime| self.holds(mime))
+    }
+
+    fn read(&self, mime: &str) -> Option<Vec<u8>> {
+        let args: Vec<&str> = match self.reader {
+            "wl-paste" => vec!["--no-newline", "--type", mime],
+            _ => vec!["-selection", "clipboard", "-t", mime, "-o"],
+        };
+        let out = std::process::Command::new(self.reader)
+            .args(&args)
+            .stderr(std::process::Stdio::null())
+            .output()
+            .ok()?;
+        (out.status.success() && !out.stdout.is_empty()).then_some(out.stdout)
+    }
+}
+
+/// The picture types worth asking for, best first.
+///
+/// Every one of them is a type the decoder here can actually read — offering to take a thing we
+/// cannot open would turn "no picture" into "a picture that failed", which is worse. `image/svg+xml`
+/// is the notable absence: it is a document, and the `<img src>` beside it on the clipboard is
+/// usually the real picture.
+const DECODABLE: &[&str] = &[
+    "image/png",
+    "image/webp",
+    "image/jpeg",
+    "image/jpg",
+    "image/gif",
+    "image/bmp",
+    "image/x-bmp",
+    "image/x-ms-bmp",
+];
+
+/// Ask the clipboard what it has, with the first program that can answer.
+fn offer(trouble: &mut Trouble) -> Option<Offer> {
+    // Wayland before X11 because a Wayland session usually has `xclip` too, through XWayland,
+    // looking at a clipboard that is not the one you copied into.
+    let asking: [(&'static str, &[&str]); 2] = [
+        ("wl-paste", &["--list-types"]),
+        ("xclip", &["-selection", "clipboard", "-t", "TARGETS", "-o"]),
+    ];
+    for (reader, args) in asking {
+        if which(reader).is_none() {
+            continue;
+        }
+        trouble.asked = true;
+        let Ok(out) = std::process::Command::new(reader).args(args).output() else { continue };
+        if !out.status.success() {
+            // The one place stderr is repeated. Everything after this point fails quietly and
+            // ordinarily — a type that is not on offer is not an error — but a clipboard that
+            // cannot be reached at all fails *here*, and the reason is the answer.
+            let said = String::from_utf8_lossy(&out.stderr);
+            if let Some(line) = said.lines().map(str::trim).find(|l| !l.is_empty())
+                && !just_empty(line)
+            {
+                trouble.said.push(format!("{reader}: {line}"));
+            }
+            continue;
+        }
+        let types = String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .collect();
+        return Some(Offer { reader, types });
+    }
+    None
+}
+
+/// Whether what a clipboard program complained about is only that there is nothing on it.
+///
+/// An empty clipboard is not a problem with the clipboard: `wl-paste` reports it by failing, and
+/// repeating that back turns the ordinary answer — you pressed the key and there was no picture —
+/// into a sentence that reads like something is broken.
+fn just_empty(said: &str) -> bool {
+    let said = said.to_ascii_lowercase();
+    said.contains("nothing is copied") || said.contains("not available")
+}
+
+/// The picture on the clipboard, as bytes or as the file it turned out to name.
+fn clipboard_picture(offer: Option<&Offer>, trouble: &mut Trouble) -> Option<Picture> {
+    if let Some(offer) = offer {
+        let mime = offer.picture()?;
+        return offer.read(mime).map(Picture::Bytes);
+    }
+    if asks_first() {
+        // There was nothing to ask with; `trouble` already knows.
+        return None;
+    }
     for (program, args) in clipboard_readers() {
         if which(program).is_none() {
             continue;
         }
-        tried.push(program);
+        trouble.asked = true;
         let out = std::process::Command::new(program)
             .args(args)
             .stderr(std::process::Stdio::null())
@@ -135,50 +343,310 @@ pub fn from_clipboard(store: &Path) -> Result<Attachment, String> {
             continue;
         }
         // Some of these print a path rather than the picture — `osascript` asked for a file URL,
-        // `powershell` after it has saved one. One line that names a file that exists is a path;
-        // anything else is the bytes.
+        // and again after it has written the pasteboard's PNG somewhere; `powershell` likewise.
+        // One line that names a file that exists is a path; anything else is the bytes.
         if let Some(p) = as_path_line(&out.stdout) {
-            return from_path(store, &p);
+            return Some(Picture::File(p));
         }
         if sniff(&out.stdout).is_some() {
-            return keep(store, out.stdout);
+            return Some(Picture::Bytes(out.stdout));
         }
     }
-    if tried.is_empty() {
-        return Err(format!(
-            "no clipboard tool to read an image with \u{2014} install one of {}",
-            clipboard_readers()
-                .iter()
-                .map(|(p, _)| *p)
-                .collect::<Vec<_>>()
-                .join(", ")
-        ));
-    }
-    Err("nothing on the clipboard that is an image".to_string())
+    None
 }
 
-/// The programs that can hand over a clipboard image, most specific first.
+/// Everything on the clipboard that names a picture, in the order we trust it.
 ///
-/// Wayland before X11 because a Wayland session usually has `xclip` too, through XWayland, looking
-/// at a clipboard that is not the one you copied into.
+/// A list rather than one answer: a browser puts several things on at once, and the first of them
+/// to look like a picture is not always the one that is. Each is tried in turn.
+fn clipboard_references(offer: Option<&Offer>, trouble: &mut Trouble) -> Vec<String> {
+    // Not lossless and not meant to be — this is text about a picture, and a byte that is not
+    // UTF-8 in it is a byte in something that was never going to be a URL.
+    let mut flavours: Vec<(&'static str, String)> = Vec::new();
+    match offer {
+        Some(offer) => {
+            for kind in ["text/uri-list", "text/html", "text/plain"] {
+                if let Some(mime) = offer.holds(kind)
+                    && let Some(bytes) = offer.read(mime)
+                {
+                    flavours.push((kind, String::from_utf8_lossy(&bytes).into_owned()));
+                }
+            }
+        }
+        None => {
+            for (program, args, kind) in text_readers() {
+                if which(program).is_none() {
+                    continue;
+                }
+                trouble.asked = true;
+                let out = std::process::Command::new(program)
+                    .args(args)
+                    .stderr(std::process::Stdio::null())
+                    .output();
+                let Ok(out) = out else { continue };
+                if !out.status.success() || out.stdout.is_empty() {
+                    continue;
+                }
+                flavours.push((kind, String::from_utf8_lossy(&out.stdout).into_owned()));
+            }
+        }
+    }
+    flavours.iter().flat_map(|(kind, text)| named_in(kind, text)).collect()
+}
+
+/// What one flavour of clipboard text says about where a picture is.
+fn named_in(kind: &str, text: &str) -> Vec<String> {
+    match kind {
+        // A file manager, or a drag that got as far as the clipboard. Comments are part of the
+        // format and are not paths.
+        "text/uri-list" => text
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty() && !l.starts_with('#'))
+            .map(str::to_string)
+            .collect(),
+        "text/html" => img_srcs(text),
+        _ => plain_named(text).into_iter().collect(),
+    }
+}
+
+/// A line of plain text read as "the picture is over there", or nothing.
+///
+/// Strict, and deliberately stricter than the HTML case: an `<img>` tag has already said the thing
+/// it points at is a picture, whereas a line of text is usually a line of text. So a URL here has
+/// to *end* in a picture's extension before a key press will go and fetch it — a clipboard holding
+/// an ordinary link is not a reason to make a request to it.
+fn plain_named(text: &str) -> Option<String> {
+    let text = text.trim();
+    if text.is_empty() || text.lines().count() != 1 {
+        return None;
+    }
+    if text.starts_with("data:") {
+        return Some(text.to_string());
+    }
+    // A path, copied as text. `pasted_path` is the same four gates the paste path uses.
+    if pasted_path(text).is_some() {
+        return Some(text.to_string());
+    }
+    let url = url::Url::parse(text).ok()?;
+    match url.scheme() {
+        "file" => Some(text.to_string()),
+        "http" | "https" => named_like_a_picture(&url).then(|| text.to_string()),
+        _ => None,
+    }
+}
+
+/// Whether a URL's own path ends in something only a picture is called.
+fn named_like_a_picture(url: &url::Url) -> bool {
+    let path = url.path().to_ascii_lowercase();
+    [".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"].iter().any(|ext| path.ends_with(ext))
+}
+
+/// Every `src` in the `<img>` tags of a fragment of clipboard HTML, in the order they appear.
+///
+/// A parser would be a dependency and a worse fit: this is not a document, it is the one tag a
+/// browser wrote out when you pressed copy, and what is wanted from it is one attribute. Relative
+/// srcs are dropped rather than guessed at — the fragment carries no base to resolve them against,
+/// and a wrong URL is a request to somebody who did not ask for one.
+fn img_srcs(html: &str) -> Vec<String> {
+    let lower = html.to_ascii_lowercase();
+    let mut found = Vec::new();
+    let mut from = 0;
+    while let Some(at) = lower[from..].find("<img") {
+        let start = from + at;
+        let end = lower[start..].find('>').map(|e| start + e).unwrap_or(lower.len());
+        if let Some(src) = attribute(&html[start..end], "src")
+            && (src.starts_with("http://")
+                || src.starts_with("https://")
+                || src.starts_with("data:"))
+        {
+            found.push(src);
+        }
+        from = end.max(start + 4);
+    }
+    found
+}
+
+/// One attribute out of one tag.
+fn attribute(tag: &str, name: &str) -> Option<String> {
+    let lower = tag.to_ascii_lowercase();
+    let mut from = 0;
+    while let Some(at) = lower[from..].find(name) {
+        let at = from + at;
+        from = at + name.len();
+        // `srcset` and `data-src` are not `src`: the name has to start and end where it looks
+        // like it does.
+        let before_is_space = tag[..at].chars().last().is_none_or(char::is_whitespace);
+        let rest = tag[from..].trim_start();
+        if !before_is_space || !rest.starts_with('=') {
+            continue;
+        }
+        let rest = rest[1..].trim_start();
+        let (quote, rest) = match rest.chars().next() {
+            Some(q @ ('"' | '\'')) => (Some(q), &rest[1..]),
+            _ => (None, rest),
+        };
+        let end = match quote {
+            Some(q) => rest.find(q)?,
+            None => rest.find(char::is_whitespace).unwrap_or(rest.len()),
+        };
+        return Some(unentity(&rest[..end]));
+    }
+    None
+}
+
+/// The five entities that turn up in an attribute somebody meant as a URL.
+fn unentity(s: &str) -> String {
+    s.replace("&amp;", "&")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+}
+
+/// A thing the clipboard named, turned into an attachment or a reason to go and get one.
+///
+/// `None` is "that was not a picture" — the next candidate gets its turn, and running out of them
+/// is what the sentence at the end of [`from_clipboard`] is for.
+fn resolve(store: &Path, named: &str) -> Option<Result<Clipped, String>> {
+    if let Some(rest) = named.strip_prefix("data:") {
+        return Some(data_url(store, rest));
+    }
+    if let Some(path) = pasted_path(named) {
+        return Some(from_path(store, &path).map(Clipped::Image));
+    }
+    let url = url::Url::parse(named).ok()?;
+    matches!(url.scheme(), "http" | "https").then(|| Ok(Clipped::Remote(String::from(url))))
+}
+
+/// `data:image/png;base64,iVBOR…` — a picture that is *in* the clipboard rather than named by it.
+///
+/// Small images on a page are often only this, so a `data:` URI is the difference between copying
+/// an icon working and not. No network is involved and the bytes still have to earn their type
+/// from [`sniff`]: the `image/png` in the URL is what somebody wrote, not what they encoded.
+fn data_url(store: &Path, rest: &str) -> Result<Clipped, String> {
+    let (meta, payload) = rest.split_once(',').ok_or("that data: URL has no data in it")?;
+    if !meta.split(';').any(|p| p.eq_ignore_ascii_case("base64")) {
+        return Err("that data: URL is not base64, so it is not a picture".to_string());
+    }
+    // Whitespace is how a long one survives being wrapped, and is not part of the payload.
+    let packed: String = payload.chars().filter(|c| !c.is_whitespace()).collect();
+    let bytes = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, packed)
+        .map_err(|e| format!("could not read that data: URL: {e}"))?;
+    keep(store, bytes).map(Clipped::Image)
+}
+
+/// Fetch a picture that is on somebody else's server.
+///
+/// The other half of [`Clipped::Remote`], and it is deliberately not called by [`from_clipboard`]:
+/// this waits on a machine we have never met, for as long as that machine feels like taking, and
+/// the host loop is the single writer for the editor.
+///
+/// What comes back is trusted for its length and nothing else — the bytes are sniffed like every
+/// other picture here, because a URL ending in `.png` is a filename and filenames lie.
+pub async fn from_url(store: &Path, url: &str) -> Result<Attachment, String> {
+    let parsed = url::Url::parse(url).map_err(|e| format!("{url}: {e}"))?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(format!("{}: not a thing to fetch", parsed.scheme()));
+    }
+    let host = parsed.host_str().unwrap_or(url).to_string();
+    let client = reqwest::Client::builder()
+        .timeout(FETCH_TIMEOUT)
+        .user_agent(concat!("neosh/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| format!("could not fetch that: {e}"))?;
+    let response =
+        client.get(parsed).send().await.map_err(|e| format!("could not reach {host}: {e}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        // Said as the server's own answer, because that is what it is. A 403 here is almost always
+        // a site declining to serve a picture to anything that is not its page, which is a thing it
+        // is entitled to do and nothing on this side can put right.
+        return Err(format!("{host} said {status}"));
+    }
+    // The header when there is one, and the running total when there is not: a server is not
+    // obliged to say how big a thing is, and "download it all and then check" is what a cap is for.
+    if response.content_length().is_some_and(|len| len > MAX_FETCH) {
+        return Err(format!(
+            "{host} is offering more than {} of picture",
+            human(MAX_FETCH as usize)
+        ));
+    }
+    let mut response = response;
+    let mut bytes: Vec<u8> = Vec::new();
+    while let Some(chunk) =
+        response.chunk().await.map_err(|e| format!("{host} stopped sending: {e}"))?
+    {
+        if bytes.len() + chunk.len() > MAX_FETCH as usize {
+            return Err(format!("that is more than {} of picture", human(MAX_FETCH as usize)));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    keep(store, bytes)
+}
+
+/// The programs that can hand over a clipboard image where it cannot be asked what it holds.
+///
+/// Linux is not here: [`offer`] is what answers there, and asking for `image/png` and nothing else
+/// is the bug this list used to have.
 fn clipboard_readers() -> Vec<(&'static str, Vec<&'static str>)> {
     if cfg!(target_os = "macos") {
         return vec![
             ("pngpaste", vec!["-"]),
-            // Always present, so it is the floor rather than an extra to install. Asked for a
-            // *file* URL: an image copied in Finder is a file reference, and this is the only one
-            // of the two that can see it.
-            ("osascript", vec!["-e", "get POSIX path of (the clipboard as \u{ab}class furl\u{bb})"]),
+            // Always present, so these are the floor rather than an extra to install. The first
+            // asks for a *file* URL: an image copied in Finder is a file reference, and this is
+            // the only one of the three that can see it. The second is the one that matters for a
+            // picture copied off a page — the pasteboard has the bytes, AppleScript can only hand
+            // over text, so they go through a file.
+            ("osascript", vec!["-e", MAC_FILE]),
+            ("osascript", vec!["-e", MAC_PNG]),
         ];
     }
     if cfg!(target_os = "windows") {
         return vec![("powershell", vec!["-NoProfile", "-Command", WINDOWS_DUMP])];
     }
-    vec![
-        ("wl-paste", vec!["--no-newline", "--type", "image/png"]),
-        ("xclip", vec!["-selection", "clipboard", "-t", "image/png", "-o"]),
-    ]
+    Vec::new()
 }
+
+/// The programs that can hand over clipboard *text*, where it cannot be asked what it holds.
+fn text_readers() -> Vec<(&'static str, Vec<&'static str>, &'static str)> {
+    if cfg!(target_os = "macos") {
+        return vec![("pbpaste", Vec::new(), "text/plain")];
+    }
+    if cfg!(target_os = "windows") {
+        return vec![(
+            "powershell",
+            vec!["-NoProfile", "-Command", "Get-Clipboard -Raw"],
+            "text/plain",
+        )];
+    }
+    Vec::new()
+}
+
+/// Everything that could have looked, for the sentence that says nothing could.
+fn reader_names() -> Vec<&'static str> {
+    if asks_first() {
+        return vec!["wl-paste", "xclip"];
+    }
+    clipboard_readers().iter().map(|(p, _)| *p).collect()
+}
+
+/// The path of whatever file is on the pasteboard — a copy made in Finder.
+const MAC_FILE: &str = "get POSIX path of (the clipboard as \u{ab}class furl\u{bb})";
+
+/// The pasteboard's picture, written to a file and its path printed. Nothing there exits quietly,
+/// which is how the caller tells the two apart.
+const MAC_PNG: &str = "set p to (POSIX path of (path to temporary items)) & \"neosh-clipboard.png\"\n\
+try\n\
+  set d to (the clipboard as \u{ab}class PNGf\u{bb})\n\
+on error\n\
+  return \"\"\n\
+end try\n\
+set f to open for access (POSIX file p) with write permission\n\
+set eof f to 0\n\
+write d to f\n\
+close access f\n\
+return p";
 
 /// Save the clipboard image to a temporary PNG and print where it went. Nothing on the clipboard
 /// exits non-zero, which is how the caller tells the two apart.
@@ -255,25 +723,26 @@ fn unescape(s: &str) -> String {
 
 /// Sniff, shrink if it is worth shrinking, and write it where it will still be in a week.
 fn keep(store: &Path, bytes: Vec<u8>) -> Result<Attachment, String> {
-    let Some(media_type) = sniff(&bytes) else {
-        return Err("that is not an image of a kind any model here can read".to_string());
-    };
-    let decoded = image::load_from_memory(&bytes)
-        .map_err(|e| format!("could not read the image: {e}"))?;
-    let (w, h) = (image::GenericImageView::dimensions(&decoded).0, image::GenericImageView::dimensions(&decoded).1);
+    // What a provider will take, if anything. A `None` here is not the end of it: a BMP off an X11
+    // clipboard is a picture nobody can send and everybody can open, and re-encoding it is a line
+    // of work rather than a refusal.
+    let sendable = sniff(&bytes);
+    let decoded = image::load_from_memory(&bytes).map_err(|e| match sendable {
+        Some(kind) => {
+            format!("could not read the {}: {e}", kind.strip_prefix("image/").unwrap_or(kind))
+        }
+        None => "that is not an image of a kind any model here can read".to_string(),
+    })?;
+    let (w, h) = image::GenericImageView::dimensions(&decoded);
 
-    // Left alone when it is already small enough. Re-encoding costs sharpness on exactly the kind
-    // of image people paste — a screenshot of text — and buys nothing.
-    let (bytes, media_type, w, h) = if w <= MAX_EDGE && h <= MAX_EDGE && bytes.len() <= MAX_BYTES {
-        (bytes, media_type.to_string(), w, h)
-    } else {
-        let small = decoded.resize(MAX_EDGE, MAX_EDGE, image::imageops::FilterType::Lanczos3);
-        let mut png = Vec::new();
-        small
-            .write_to(&mut std::io::Cursor::new(&mut png), image::ImageFormat::Png)
-            .map_err(|e| format!("could not re-encode the image: {e}"))?;
-        let (sw, sh) = (image::GenericImageView::dimensions(&small).0, image::GenericImageView::dimensions(&small).1);
-        (png, "image/png".to_string(), sw, sh)
+    // Left alone when it is already something to send and already small enough. Re-encoding costs
+    // sharpness on exactly the kind of image people paste — a screenshot of text — and buys
+    // nothing.
+    let (bytes, media_type, w, h) = match sendable {
+        Some(kind) if w <= MAX_EDGE && h <= MAX_EDGE && bytes.len() <= MAX_BYTES => {
+            (bytes, kind.to_string(), w, h)
+        }
+        _ => shrunk(&decoded)?,
     };
     if bytes.len() > MAX_BYTES {
         return Err(format!(
@@ -289,6 +758,38 @@ fn keep(store: &Path, bytes: Vec<u8>) -> Result<Attachment, String> {
     let len = bytes.len();
     std::fs::write(&path, bytes).map_err(|e| format!("could not write {}: {e}", path.display()))?;
     Ok(Attachment { path, media_type, width: w, height: h, bytes: len })
+}
+
+/// Bring a picture down to something worth sending: inside [`MAX_EDGE`], inside [`MAX_BYTES`], and
+/// in a format a provider accepts.
+///
+/// PNG first, because most of what is pasted is a screenshot and a screenshot of text is where
+/// every JPEG artefact lands on a letter. JPEG when PNG will not fit, because a photograph is a
+/// photograph: 1568 square of one is several megabytes of PNG and a few hundred kilobytes of JPEG,
+/// and refusing a picture somebody just copied over the encoding it happened to arrive in is the
+/// worse of the two answers.
+fn shrunk(source: &image::DynamicImage) -> Result<(Vec<u8>, String, u32, u32), String> {
+    let (w, h) = image::GenericImageView::dimensions(source);
+    // `resize` fits *within* the bounds either way, so an image already inside them would be
+    // scaled up by it. Nothing here ever adds pixels.
+    let small = match w > MAX_EDGE || h > MAX_EDGE {
+        true => source.resize(MAX_EDGE, MAX_EDGE, image::imageops::FilterType::Lanczos3),
+        false => source.clone(),
+    };
+    let (w, h) = image::GenericImageView::dimensions(&small);
+    let mut png = Vec::new();
+    small
+        .write_to(&mut std::io::Cursor::new(&mut png), image::ImageFormat::Png)
+        .map_err(|e| format!("could not re-encode the image: {e}"))?;
+    if png.len() <= MAX_BYTES {
+        return Ok((png, "image/png".to_string(), w, h));
+    }
+    // Through RGB explicitly: JPEG has no alpha, and the encoder refuses rather than flattening.
+    let mut jpeg = Vec::new();
+    image::DynamicImage::ImageRgb8(small.to_rgb8())
+        .write_to(&mut std::io::Cursor::new(&mut jpeg), image::ImageFormat::Jpeg)
+        .map_err(|e| format!("could not re-encode the image: {e}"))?;
+    Ok((jpeg, "image/jpeg".to_string(), w, h))
 }
 
 /// Where a program is on `PATH`, or nothing.
@@ -315,8 +816,7 @@ mod tests {
     }
 
     fn tmp(name: &str) -> PathBuf {
-        let dir =
-            std::env::temp_dir().join(format!("neosh-img-{}-{name}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("neosh-img-{}-{name}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("dir");
         dir
@@ -402,8 +902,199 @@ mod tests {
         let dir = tmp("space");
         let file = dir.join("my shot.png");
         std::fs::write(&file, pixel()).expect("write");
-        assert_eq!(pasted_path(&format!("file://{}", file.display().to_string().replace(' ', "%20"))).as_ref(), Some(&file));
-        assert_eq!(pasted_path(&file.display().to_string().replace(' ', "\\ ")).as_ref(), Some(&file));
+        assert_eq!(
+            pasted_path(&format!("file://{}", file.display().to_string().replace(' ', "%20")))
+                .as_ref(),
+            Some(&file)
+        );
+        assert_eq!(
+            pasted_path(&file.display().to_string().replace(' ', "\\ ")).as_ref(),
+            Some(&file)
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn the_type_asked_for_is_one_the_clipboard_said_it_had() {
+        // A JPEG copied out of an image viewer. Asking for `image/png` and nothing else is how
+        // this used to come back as "nothing on the clipboard that is an image".
+        let offer = Offer {
+            reader: "wl-paste",
+            types: vec!["text/html".into(), "image/jpeg".into(), "text/plain".into()],
+        };
+        assert_eq!(offer.picture(), Some("image/jpeg"));
+
+        // Several on offer is a program that has ranked nothing, so the ranking is ours: PNG over
+        // JPEG, because it is the one that has not already thrown pixels away.
+        let browser = Offer {
+            reader: "wl-paste",
+            types: vec!["image/jpeg".into(), "image/png".into(), "text/html".into()],
+        };
+        assert_eq!(browser.picture(), Some("image/png"));
+
+        // Exactly as offered, capitals and parameters and all — a request for `image/x-ms-bmp`
+        // against an X11 clipboard offering `image/x-MS-bmp` gets nothing back.
+        let x11 = Offer { reader: "xclip", types: vec!["TARGETS".into(), "image/x-MS-bmp".into()] };
+        assert_eq!(x11.picture(), Some("image/x-MS-bmp"));
+        let with_params =
+            Offer { reader: "wl-paste", types: vec!["image/png;charset=binary".into()] };
+        assert_eq!(with_params.picture(), Some("image/png;charset=binary"));
+
+        // Nothing here can open an SVG, and offering to take one turns "no picture" into "a
+        // picture that failed".
+        let vector = Offer { reader: "wl-paste", types: vec!["image/svg+xml".into()] };
+        assert_eq!(vector.picture(), None);
+    }
+
+    #[test]
+    fn a_page_that_only_named_a_picture_still_gives_one_up() {
+        // What a browser leaves on the clipboard when you copy an image off a page.
+        let html = "<meta charset=\"utf-8\"><img src=\"https://example.com/a%20cat.png?w=800&amp;h=600\" alt=\"a cat\">";
+        assert_eq!(
+            img_srcs(html),
+            vec!["https://example.com/a%20cat.png?w=800&h=600".to_string()],
+            "the entity is part of the markup, not of the URL"
+        );
+
+        // Relative is dropped rather than guessed at: the fragment carries no base, and a wrong
+        // URL is a request to somebody who did not ask for one.
+        assert!(img_srcs("<img src=\"/img/logo.png\">").is_empty());
+
+        // `srcset` and `data-src` are not `src`.
+        assert!(
+            img_srcs("<img srcset=\"https://example.com/2x.png 2x\" data-src=\"https://example.com/lazy.png\">")
+                .is_empty()
+        );
+        assert_eq!(
+            img_srcs(
+                "<img srcset=\"https://example.com/2x.png 2x\" src=\"https://example.com/1x.png\">"
+            ),
+            vec!["https://example.com/1x.png".to_string()]
+        );
+
+        // Unquoted, and more than one.
+        assert_eq!(
+            img_srcs(
+                "<img src=https://example.com/one.png><p>and</p><img src='https://example.com/two.png'>"
+            ),
+            vec![
+                "https://example.com/one.png".to_string(),
+                "https://example.com/two.png".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn a_line_of_text_is_only_a_picture_when_it_is_unmistakably_one() {
+        assert_eq!(
+            plain_named("https://example.com/cat.png").as_deref(),
+            Some("https://example.com/cat.png")
+        );
+        assert_eq!(
+            plain_named("  https://example.com/deep/path/cat.JPEG  ").as_deref(),
+            Some("https://example.com/deep/path/cat.JPEG"),
+            "an extension is a name, and names are not case"
+        );
+        // An ordinary link is not a reason to make a request to it.
+        assert_eq!(plain_named("https://example.com/an/article"), None);
+        assert_eq!(plain_named("have a look at https://example.com/cat.png"), None);
+        assert_eq!(plain_named("a sentence"), None);
+        assert_eq!(plain_named(""), None);
+    }
+
+    #[test]
+    fn what_a_browser_leaves_behind_is_read_in_the_order_we_trust_it() {
+        let dir = tmp("uri-list");
+        let file = dir.join("shot.png");
+        std::fs::write(&file, pixel()).expect("write");
+
+        // A file manager's copy.
+        assert_eq!(
+            named_in("text/uri-list", &format!("# a comment\nfile://{}\n", file.display())),
+            vec![format!("file://{}", file.display())]
+        );
+        // And it comes back as the file it names.
+        let named = format!("file://{}", file.display());
+        assert!(matches!(resolve(&dir, &named), Some(Ok(Clipped::Image(_)))));
+
+        // A page's picture is somewhere else, and saying so is not fetching it.
+        match resolve(&dir, "https://example.com/cat.png") {
+            Some(Ok(Clipped::Remote(url))) => assert_eq!(url, "https://example.com/cat.png"),
+            other => panic!("{other:?} is not a picture on somebody's server"),
+        }
+        // Things that name nothing get out of the way of the next candidate.
+        assert!(resolve(&dir, "just some text").is_none());
+        assert!(resolve(&dir, "mailto:someone@example.com").is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_data_url_is_a_picture_that_needs_no_network() {
+        let dir = tmp("data-url");
+        let encoded = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, pixel());
+        // Wrapped, which is how a long one survives being put on a clipboard.
+        let wrapped = format!("image/png;base64,{}\n{}", &encoded[..8], &encoded[8..]);
+        match data_url(&dir, &wrapped) {
+            Ok(Clipped::Image(got)) => {
+                assert_eq!(got.media_type, "image/png");
+                assert_eq!((got.width, got.height), (1, 1));
+            }
+            other => panic!("{other:?}"),
+        }
+        // The type in the URL is what somebody wrote; the bytes are what they encoded.
+        let lying = format!(
+            "image/png;base64,{}",
+            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"#!/bin/sh\n")
+        );
+        assert!(data_url(&dir, &lying).is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_picture_too_busy_to_be_a_png_is_sent_as_a_jpeg() {
+        let dir = tmp("jpeg");
+        // A photograph's worth of detail, at a size nothing will shrink: the PNG of it is over
+        // what a turn can carry, and refusing it over the encoding it arrived in is the wrong
+        // answer twice — it is a picture somebody just copied.
+        let mut noise = image::RgbImage::new(MAX_EDGE, MAX_EDGE);
+        let mut seed: u32 = 0x1234_5678;
+        for pixel in noise.pixels_mut() {
+            seed = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            let b = seed.to_le_bytes();
+            *pixel = image::Rgb([b[0], b[1], b[2]]);
+        }
+        let mut bytes = Vec::new();
+        image::DynamicImage::ImageRgb8(noise)
+            .write_to(&mut std::io::Cursor::new(&mut bytes), image::ImageFormat::Png)
+            .expect("encode");
+        assert!(bytes.len() > MAX_BYTES, "the test's own premise: {} bytes", bytes.len());
+
+        let got = keep(&dir, bytes).expect("kept");
+        assert_eq!(got.media_type, "image/jpeg");
+        assert_eq!((got.width, got.height), (MAX_EDGE, MAX_EDGE), "nothing was thrown away to fit");
+        assert!(got.bytes <= MAX_BYTES, "{} bytes is still more than a turn can carry", got.bytes);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn something_openable_that_nothing_can_be_sent_is_re_encoded_rather_than_refused() {
+        let dir = tmp("bmp");
+        // What an X11 application puts on the clipboard. No provider takes a BMP and every
+        // decoder opens one.
+        let mut bmp = Vec::new();
+        image::DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
+            2,
+            2,
+            image::Rgba([7, 8, 9, 255]),
+        ))
+        .write_to(&mut std::io::Cursor::new(&mut bmp), image::ImageFormat::Bmp)
+        .expect("encode");
+        assert_eq!(sniff(&bmp), None, "the test's own premise");
+
+        let got = keep(&dir, bmp).expect("kept");
+        assert_eq!(got.media_type, "image/png");
+        assert_eq!((got.width, got.height), (2, 2));
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/docs/adr/0051-a-clipboard-that-only-names-a-picture.md
+++ b/docs/adr/0051-a-clipboard-that-only-names-a-picture.md
@@ -1,0 +1,112 @@
+# 0051 — A clipboard that only names a picture
+
+**Status:** accepted
+
+## Context
+
+`^V` attached a screenshot and did nothing at all with a picture copied off a web page. Reported the
+way it is experienced: *"pasting an image works when I copy a file on disk, but if I copy an image
+on the internet it doesn't."*
+
+Both halves of that are exactly right, and they are two separate failures that end in the same
+sentence — `nothing on the clipboard that is an image`.
+
+**The clipboard was asked for one type and one type only.** `wl-paste --type image/png`, `xclip -t
+image/png`. A clipboard is a *negotiation*: the program that copied says what it can provide, and
+the program that pastes picks from that list. Asking for a single type is not picking from the list,
+it is a guess — and it is wrong for a JPEG copied out of an image viewer, a WebP copied off a page,
+and a BMP out of an X11 application, every one of which reads as an empty clipboard.
+
+**And copying a picture off a page very often puts no picture on the clipboard at all.** What a
+browser leaves is `text/html` — one `<img>` tag naming a URL — and sometimes a `text/uri-list` or
+the plain URL beside it. Nothing but an address. Right-clicking and taking the address is the same
+thing on purpose. There is no amount of asking the clipboard for bytes that finds those bytes,
+because they are on somebody else's server and always were.
+
+Two more things fell out of looking:
+
+* A clipboard program that cannot reach a compositor at all — a workspace outlives the terminal
+  that started it, so this is ordinary rather than exotic — failed exactly like an empty clipboard.
+  The one problem nobody can guess from the outside was reported as the one everybody can.
+* A photograph, once shrunk to 1568px, is several megabytes of PNG. It came back as *"more than a
+  turn can carry"*, which is true of the encoding we chose and not of the picture.
+
+## Decision
+
+### Ask the clipboard what it has
+
+`wl-paste --list-types`, `xclip -t TARGETS -o`. The best picture type *on offer* is the one
+requested — PNG, then WebP, then JPEG, then GIF, then BMP — best rather than first, because a
+program offering three has ranked nothing and the ranking is ours to make. The offered string is
+what is asked for, capitals and parameters and all: `image/x-MS-bmp` is a real target atom and a
+request for `image/x-ms-bmp` gets nothing back.
+
+Only types the decoder here can open are asked for. Offering to take a thing we cannot read turns
+"no picture" into "a picture that failed", which is worse. `image/svg+xml` is the notable absence.
+
+macOS and Windows keep the try-each-program shape: their pasteboards cannot be asked cheaply, so the
+programs *are* the question. macOS gained the one that matters for a picture copied off a page —
+AppleScript can only hand over text, so `«class PNGf»` goes through a file and the path comes back.
+`pngpaste` is still tried first and is still not installed by default.
+
+### A picture the clipboard only names is fetched
+
+`from_clipboard` answers with a `Clipped`: bytes it has already kept, or a `Remote` — an address for
+somebody to go and get. Both are pictures; only one of them is here.
+
+Where the address comes from, in the order it is trusted: `text/uri-list`, then the `src` of an
+`<img>` in `text/html`, then a single line of `text/plain`. A `data:` URI is decoded rather than
+fetched — small pictures on a page are often only that, and no network is involved.
+
+Plain text is held to a stricter test than the HTML: an `<img>` tag has already said the thing it
+points at is a picture, whereas a line of text is usually a line of text, so a URL there has to
+*end* in a picture's extension before a key press will make a request to it. A clipboard holding an
+ordinary link is not consent to fetch it.
+
+The bytes that come back are sniffed like every other picture here. A URL ending in `.png` is a
+filename, and filenames lie.
+
+**The fetch does not happen on the host loop.** It is a round trip to a machine we have never met,
+for as long as that machine feels like taking, and the loop is the single writer for the editor. It
+is spawned, and it carries the conversation that was on screen when the key was pressed — switching
+while a server takes its time is an ordinary thing to do, and the picture belongs where it was
+asked for, not wherever you have got to. A conversation that has gone in the meantime is told so
+rather than given a row nothing will ever draw.
+
+It is also the one attachment that **says something on the way**. A chip appearing above the field
+is the report everywhere else here, and it is enough — but a key press with several seconds of
+nothing after it is a key press that did nothing, so a fetch says where it has gone and says again
+when it arrives. `chat.attach` with nothing named is answered when the picture lands, not when the
+clipboard was read: the plugin asked for a picture.
+
+### A picture too busy to be a PNG is sent as a JPEG
+
+PNG first, because most of what is pasted is a screenshot and a screenshot of text is where every
+JPEG artefact lands on a letter. JPEG when the PNG will not fit, because a photograph is a
+photograph. Refusing a picture over the encoding it happened to arrive in is the wrong answer twice.
+
+Anything a decoder can open but no provider will take — a BMP off an X11 clipboard — is re-encoded
+on the same path rather than refused.
+
+### An empty clipboard is not a broken one
+
+The type listing is the one place a clipboard program's stderr is repeated back, because it is the
+one call that fails when the clipboard cannot be reached at all. Everything after it fails quietly
+and ordinarily: a type that is not on offer is not an error. A program complaining that *nothing is
+copied* is filtered out — that is the ordinary answer, and repeating it reads like something is
+broken.
+
+## Consequences
+
+The workspace now makes an outbound request because of a key press. It is bounded — http and https
+only, one request, no redirect chain worth mentioning, 20 seconds, 25MB — and it is exactly as
+user-initiated as anything else here, but it is the first time `^V` has left the machine. A server
+that answers with a 403 is a site declining to serve a picture to anything that is not its page,
+which it is entitled to do; the number it said is reported as its answer rather than translated
+into one of ours.
+
+The clipboard is still read by the **workspace** rather than by the terminal viewing it, so ADR
+0041's note stands and this makes it slightly sharper: a remote workspace would go and fetch the
+right URL from the wrong machine.
+
+`neosh` gained `reqwest` and `base64`, and `image` gained the `bmp` feature.


### PR DESCRIPTION
`^V` attached a screenshot and did nothing at all with an image copied off a web page. Two separate
causes, both ending in the same sentence — `nothing on the clipboard that is an image`.

## The clipboard was told, not asked

`wl-paste --type image/png`, `xclip -t image/png`, and nothing else. A clipboard is a *negotiation*:
the program that copied says what it can provide and the program that pastes picks from that list.
Asking for one type is a guess, and it is wrong for a JPEG copied out of an image viewer, a WebP off
a page, and a BMP out of an X11 application — every one of which read as an empty clipboard.

It now asks (`wl-paste --list-types`, `xclip -t TARGETS -o`) and requests the best picture type *on
offer*, exactly as offered — `image/x-MS-bmp` is a real target atom and a request for
`image/x-ms-bmp` gets nothing back. Only types the decoder here can open are asked for; offering to
take an SVG would turn "no picture" into "a picture that failed".

macOS and Windows keep the try-each-program shape (their pasteboards cannot be asked cheaply), and
macOS gained the one that matters for a picture copied off a page: `«class PNGf»` through a file,
for when `pngpaste` is not installed — which is by default.

## A picture the clipboard only names is fetched

Copying an image off a page very often puts no image on the clipboard at all. What a browser leaves
is an *address*: `text/html` with one `<img src>`, sometimes a `text/uri-list` or the plain URL.

`from_clipboard` now answers with a `Clipped` — bytes it has already kept, or a `Remote` to go and
get. A `data:` URI is decoded rather than fetched. Plain text is held to a stricter test than the
HTML (an `<img>` has already said the thing is a picture; a line of text is usually a line of text),
so a URL there must *end* in a picture's extension before a key press will make a request to it.

The fetch is **spawned, not awaited on the host loop** — it is a round trip to a machine we have
never met and the loop is the single writer for the editor. It carries the conversation that was on
screen when the key was pressed, and it is the one attachment that says something on the way:
`fetching …`, then `attached png 800×600 · 219 KB`. `chat.attach` with nothing named is answered
when the picture lands.

## Also

- A photograph too busy to fit as a PNG is sent as a **JPEG** rather than refused over an encoding;
  anything a decoder can open but no provider takes (a BMP) is re-encoded on the same path.
- An empty clipboard no longer reports itself as a broken one — and a clipboard that genuinely
  cannot be reached (a workspace outliving the terminal that started it) now says what the tool
  said, which is the one problem nobody can guess from the outside.

See ADR 0051.

## Verification

Driven against the real binary with `scripts/shot.py` and a real clipboard: HTML-only, JPEG-only,
plain URL, `file://` uri-list and `data:` URI all attach; a 404 reports `upload.wikimedia.org said
404 Not Found`; an empty clipboard still says `nothing on the clipboard that is an image`.

- `cargo test -p neosh --bin neosh` — 227 pass (8 new)
- `cargo test -p neosh --test workspace` — 12 pass
- `cargo test -p neosh-proto export_bindings` + `git diff plugins/api/src/generated` — clean, no
  protocol change
- `cargo test -p neosh --test builtin_plugins` — 7 failures in the parallel run; 6 pass singly (the
  known flakiness) and `the_plan_row_keeps_the_providers_own_colour` already fails at HEAD

## One thing worth knowing

This is the first time `^V` leaves the machine. It is bounded — http/https only, 20s, 25MB, sniffed
on arrival — and as user-initiated as anything else here, but the clipboard is read by the
*workspace*, so a remote workspace would fetch the right URL from the wrong machine. ADR 0041's note
on this stands and 0051 makes it sharper.