### PR TITLE
A stack of commands, and the answer is the last one's

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,13 +247,22 @@ per decision, and records the *reasoning*, not the choice.
   is announced once at startup, empty, and that is what clears the one left behind by a workspace
   that stopped mid-question. See ADR 0043.
 - **A card is a row until you ask for more.** A call that only *looked* at something folds to its
-  header with the size of what came back on the end of it; a command keeps its output, an edit keeps
-  its diff, and a failure always shows. See ADR 0033.
-- **A run of calls that only looked at things is one row**, naming as many of them as fit and
-  counting the rest — a turn that read six files reads as one. A run is calls with *nothing drawn
-  between them*, asked the same way by the live path and the replay, or switching away and back
-  re-folds the conversation. Only a mark that is news gets drawn: `▸` while a call is out, `✗` if it
-  failed, and nothing at all when it worked. See ADR 0040.
+  header with the size of what came back on the end of it; a command keeps its output — a stack of
+  them keeps the last one's — an edit keeps its diff, and a failure always shows. See ADR 0033.
+- **A run of calls of one kind is one row**, naming as many of them as fit and counting the rest —
+  a turn that read six files reads as one, and so does a stretch of it spent on `git add`, `git
+  commit`, `git push`. Reads with reads and commands with commands, never one of each, and never an
+  edit. A run is calls with *nothing drawn between them*, asked the same way by the live path and
+  the replay, or switching away and back re-folds the conversation. A stack of commands keeps the
+  **last one's output** — what a command printed is the answer, and the ones before it are how you
+  got there — names each command by what it *is* rather than how it was spelled (`cargo test`, not
+  `cargo test -p neosh-core -- --test-threads 2`), and gives every command back in full, with what
+  it said, on `⇥`. A run **never continues past a failure**, so a failed command is the last call
+  on its card and its output is the one showing. While a run is still going the row is fitted from
+  the *end*: then it is a report of what is happening rather than an account of what happened, and
+  the call being waited on is the one name that must never be the name that did not fit. Only a
+  mark that is news gets drawn: `▸` while a call is out, `✗` if it failed, and nothing at all when
+  it worked. See ADR 0040 and ADR 0051.
 - **A card says what happened, not which tool did it.** `Ran cargo test`, not `Bash cargo test` —
   read off the arguments, like the colour. A call nothing here classifies keeps the name its author
   gave it, so a plugin's tool is never renamed. **A command's output folds from the middle**: the

--- a/crates/neosh/src/cards.rs
+++ b/crates/neosh/src/cards.rs
@@ -395,6 +395,10 @@ pub struct Head<'a> {
     /// was read without saying how much of it there was is a card you have to open to learn the one
     /// thing you would have guessed from the body's height.
     pub output: Option<usize>,
+    /// What came back, for the one card that draws a body per call: a [run of
+    /// commands](run_body). `None` until it has, and `None` for every other purpose here — a
+    /// header is a sentence about a call and never about its output.
+    pub result: Option<&'a neosh_proto::ToolResult>,
 }
 
 /// What the call *did*, in a word, when its arguments say plainly enough.
@@ -460,6 +464,16 @@ pub fn did(input: &serde_json::Value) -> Option<&'static str> {
 /// failures.
 pub fn looks_at_something(input: &serde_json::Value) -> bool {
     Kind::of(input) == Kind::Read
+}
+
+/// Whether a call is one that *ran* something: it was handed a command.
+///
+/// The other half of [`looks_at_something`], and by the same rule — read off the arguments, so a
+/// shell a plugin registers tomorrow is a command because it was given one. A run of these shares
+/// a card the way a run of reads does, with the one difference that follows from what a command
+/// is: what it printed is the answer, so the run keeps the last one's output. See ADR 0051.
+pub fn runs_a_command(input: &serde_json::Value) -> bool {
+    Kind::of(input) == Kind::Run
 }
 
 /// Below this, a call did not take any time worth reporting.
@@ -648,8 +662,10 @@ fn verb<'a>(heads: &'a [Head<'a>], live: bool) -> &'a str {
 /// card: the names, comma-separated, as many as fit, and `+N more` for the rest. `⇥` while reading
 /// opens it back into a row per call.
 ///
-/// Only calls that *looked* at something ever join a run. A command keeps its output and an edit
-/// keeps its diff, and neither has anything to gain from being summarised into a list of names.
+/// Calls of one kind only, and never an edit: a diff is the answer and there is no summarising it
+/// into a list of names. A run of *commands* gets the same row, named by what each command is
+/// rather than how it was spelled, and keeps the last one's output under it — see [`run_body`] and
+/// ADR 0051.
 pub fn group_header(g: &Glyphs, heads: &[Head], root: &std::path::Path, width: usize) -> Row {
     let live = heads.iter().any(|h| h.state == ToolState::Running);
     let failed = heads.iter().any(|h| h.state == ToolState::Failed);
@@ -663,8 +679,12 @@ pub fn group_header(g: &Glyphs, heads: &[Head], root: &std::path::Path, width: u
     let (mark, mark_hl) = g.mark(state);
     let name = verb(heads, live);
 
+    // Coloured by what the run *is*, the same way a card of one call is: a stack of commands is
+    // `Agent.ToolRun`, and reading the kind off the first call is safe because nothing but calls
+    // of one kind ever shares a card. See [`groups_with`].
+    let kind = heads.first().map_or(Kind::Read, |h| Kind::of(h.input));
     let mut text = format!("{mark} {name}");
-    let mut spans = vec![(0, mark.len(), mark_hl), (mark.len() + 1, text.len(), Kind::Read.hl())];
+    let mut spans = vec![(0, mark.len(), mark_hl), (mark.len() + 1, text.len(), kind.hl())];
 
     // The names, then as much of the list as fits. Counting what was dropped rather than clipping
     // the last one mid-word: `+2 more` is a fact, and `cards.r…` is a name that does not exist.
@@ -675,36 +695,31 @@ pub fn group_header(g: &Glyphs, heads: &[Head], root: &std::path::Path, width: u
     let names: Vec<String> = heads.iter().map(|h| short_subject_of(h.input, root)).collect();
     let room = width.saturating_sub(text.chars().count() + 2).max(8);
     let at = text.len() + 2;
-    let mut shown = 0usize;
-    let mut so_far = 0usize;
+    let shown = fits(&names, room, live);
+
     let mut list: Vec<Span> = Vec::new();
     let mut listed = String::new();
-    for (i, n) in names.iter().enumerate() {
-        let rest = names.len() - i - 1;
-        // Room for this name, its separator, and the `+N more` that would follow if any are left.
-        let more = if rest > 0 { format!(", +{rest} more").chars().count() } else { 0 };
-        let sep = if i == 0 { 0 } else { 2 };
-        if so_far + sep + n.chars().count() + more > room && i > 0 {
-            break;
-        }
-        if i > 0 {
+    let add = |listed: &mut String, list: &mut Vec<Span>, piece: &str, hl: &'static str| {
+        if !listed.is_empty() {
             listed.push_str(", ");
         }
         let from = listed.len();
-        listed.push_str(n);
-        list.push((at + from, at + listed.len(), match heads[i].state {
+        listed.push_str(piece);
+        list.push((at + from, at + listed.len(), hl));
+    };
+    if shown.start > 0 {
+        add(&mut listed, &mut list, &format!("+{} earlier", shown.start), "Agent.Usage");
+    }
+    for i in shown.clone() {
+        add(&mut listed, &mut list, &names[i], match heads[i].state {
             ToolState::Running => "Agent.ToolLive",
             ToolState::Failed => "Agent.ToolFailed",
             ToolState::Done => "Agent.Usage",
-        }));
-        so_far += sep + n.chars().count();
-        shown += 1;
+        });
     }
-    let rest = names.len() - shown;
+    let rest = names.len() - shown.end;
     if rest > 0 {
-        let from = listed.len();
-        listed.push_str(&format!(", +{rest} more"));
-        list.push((at + from, at + listed.len(), "Agent.Usage"));
+        add(&mut listed, &mut list, &format!("+{rest} more"), "Agent.Usage");
     }
     if !listed.is_empty() {
         text.push_str("  ");
@@ -712,6 +727,35 @@ pub fn group_header(g: &Glyphs, heads: &[Head], root: &std::path::Path, width: u
         spans.extend(list);
     }
     Row::new(text, spans)
+}
+
+/// Which of `names` fit in `room`, and from which end.
+///
+/// From the front for a run that is over: it is an account of what a stretch of the turn did, and
+/// an account starts at the beginning. From the *back* while one of them is still out, because
+/// then the row is not an account, it is a report of what is happening — the call being waited on
+/// is the last one, and it is the one name that must never be the name that did not fit. A run of
+/// nine commands would otherwise say what it was doing forty seconds ago and `+4 more`.
+///
+/// Always at least one, however long it is: a row of `+9 more` and nothing else answers nothing.
+fn fits(names: &[String], room: usize, from_back: bool) -> std::ops::Range<usize> {
+    let n = names.len();
+    let (mut used, mut kept) = (0usize, 0usize);
+    for step in 0..n {
+        let i = if from_back { n - 1 - step } else { step };
+        // Room for this name, its separator, and the count that stands for whatever is left —
+        // which is a longer word at the front of the row than at the end of it.
+        let dropped = n - kept - 1;
+        let word = if from_back { "earlier" } else { "more" };
+        let more = if dropped > 0 { format!(", +{dropped} {word}").chars().count() } else { 0 };
+        let sep = usize::from(kept > 0) * 2;
+        if used + sep + names[i].chars().count() + more > room && kept > 0 {
+            break;
+        }
+        used += sep + names[i].chars().count();
+        kept += 1;
+    }
+    if from_back { n - kept..n } else { 0..kept }
 }
 
 /// What an opened run shows: one row per call, under the header.
@@ -729,9 +773,14 @@ pub fn group_body(
     g: &Glyphs,
     heads: &[Head],
     root: &std::path::Path,
+    limits: Limits,
     expanded: bool,
     width: usize,
 ) -> Vec<Row> {
+    // A stack of commands is the other kind of run, and it keeps an output. See [`run_body`].
+    if heads.first().is_some_and(|h| runs_a_command(h.input)) {
+        return run_body(g, heads, root, limits, expanded, width);
+    }
     if !expanded {
         return Vec::new();
     }
@@ -751,9 +800,91 @@ pub fn group_body(
     rows
 }
 
-/// Whether two calls may share one card: both only looked at something.
+/// What a stack of commands shows: the last one's output, and every one of them when it is opened.
+///
+/// A run of reads folds to nothing, because the answer to a read is "yes, and it was what you
+/// would expect". A command is the opposite — what it printed *is* the answer — so a stack of them
+/// keeps one output, and it is the last one's:
+///
+/// ```text
+///   Ran  cargo fmt, cargo build, cargo test
+///   └    Compiling neosh v0.1.0
+///     … +18 lines (^S ⇥ to expand)
+///     test result: ok. 142 passed
+/// ```
+///
+/// The last one, because in a stretch of commands the ones before it are how you get there and the
+/// last one is what you were waiting for: `git add` and `git commit` and then `git push`. It is
+/// also the only one that can be the answer while the run is still growing — the moment another
+/// command starts, the one above it has been superseded by the thing the model decided to do next.
+///
+/// Nothing is lost that a key does not give back. `⇥` opens the stack into a row per command with
+/// the whole of its output under it, which is exactly what each of them would have had as a card
+/// of its own:
+///
+/// ```text
+///   └ Ran  cargo fmt --check
+///         all good
+///     Ran  cargo test -p neosh-core -- --test-threads 2
+///         running 142 tests
+///         test result: ok. 142 passed
+/// ```
+///
+/// And a failure is never the output that folded away: a run does not continue past one, so a
+/// command that failed is the last call on its card and its output is the one showing. See ADR
+/// 0051.
+fn run_body(
+    g: &Glyphs,
+    heads: &[Head],
+    root: &std::path::Path,
+    limits: Limits,
+    expanded: bool,
+    width: usize,
+) -> Vec<Row> {
+    let margin = g.margin();
+    let deeper = format!("{margin}    ");
+    let mut rows: Vec<Row> = Vec::new();
+
+    // Which of them get an output. Opened, all of them. Folded, the last one — and anything that
+    // failed, wherever it is in the stack: a run does not usually continue past a failure, but
+    // calls made in parallel land in whatever order they land in, and a fold is about noise.
+    let shown: Vec<usize> = (0..heads.len())
+        .filter(|&i| expanded || i + 1 == heads.len() || heads[i].state == ToolState::Failed)
+        .collect();
+    // Whose output this is only has to be said when more than one of them is saying anything.
+    // Folded to the last command alone, the stack above it is the header's list and a row naming
+    // it again is a row spent repeating the line above.
+    let named = expanded || shown.len() > 1;
+    let room = width.saturating_sub(margin.chars().count()).max(8);
+
+    for i in shown {
+        let h = &heads[i];
+        if named {
+            // The command in full on its own row, and what it printed under it — one indent
+            // deeper, because those rows belong to *that* command and not to the stack. At the
+            // same indent the next command's name reads as another line of the output above it.
+            let (text, spans) = label(h, root, room);
+            let at = margin.len();
+            let mut all = vec![(0, at, "Agent.Usage")];
+            all.extend(spans.into_iter().map(|(a, b, hl)| (at + a, at + b, hl)));
+            rows.push(Row::new(format!("{margin}{text}"), all));
+        }
+        if let Some(result) = h.result {
+            let under = if named { &deeper } else { &margin };
+            rows.extend(result_rows(g, result, limits.output_lines, expanded, width, under));
+        }
+    }
+    attach(g, &mut rows);
+    rows
+}
+
+/// Whether two calls may share one card: both only looked at something, or both ran something.
+///
+/// Never one of each. A run is a row that says *what a stretch of the turn was doing*, and
+/// `Explored  a.rs, cargo test` is two different activities wearing one verb — the mixture that
+/// [`verb`] has no true name for is a mixture of reads, not a mixture of kinds.
 pub fn groups_with(a: &serde_json::Value, b: &serde_json::Value) -> bool {
-    looks_at_something(a) && looks_at_something(b)
+    (looks_at_something(a) && looks_at_something(b)) || (runs_a_command(a) && runs_a_command(b))
 }
 
 /// The agent's own checklist, drawn.
@@ -946,6 +1077,10 @@ fn subject(input: &serde_json::Value) -> Option<(&'static str, String)> {
 pub fn short_subject_of(input: &serde_json::Value, root: &std::path::Path) -> String {
     let Some((key, value)) = subject(input) else { return String::new() };
     let full = relative_to(&value, root);
+    // A command says what it is in its first two or three words and spends the rest on flags.
+    if key == "command" {
+        return short_command(&full);
+    }
     // Only where it is a path. A pattern's last component is not a shorter pattern — `**/*.rs`
     // would come out as `*.rs`, which is a different glob.
     if !PATH_KEYS.contains(&key) {
@@ -955,6 +1090,52 @@ pub fn short_subject_of(input: &serde_json::Value, root: &std::path::Path) -> St
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or(full)
+}
+
+/// A command, as short as a list of them can say it: what it *is*, without its flags.
+///
+/// `cargo test -p neosh-core -- --test-threads 2` is forty-two columns of one card, on a row that
+/// has to hold four of them, and thirty of those columns are how the run was tuned rather than
+/// what was run. The first words are the answer — `cargo test`, `git status`, `npm run build` — so
+/// the short form is the leading run of plain words and nothing else.
+///
+/// No ellipsis, for the same reason a path's last component does not wear one: the row it goes on
+/// is a summary of a stretch of the turn, everything on it is short for something, and three
+/// `git add…, git commit…, git push` is punctuation saying what the row already says. The whole
+/// command line is one `⇥` away, on the row this call gets when the stack is opened, and it is
+/// what the card says when the call is alone.
+///
+/// A leading `VAR=value` is not one of those words: it is how the command was set up, and a column
+/// of `NEOSH_STATE_DIR=…` says nothing about four different commands. Three words is the cap,
+/// because a fourth is already an argument in every shape this is trying to catch.
+fn short_command(command: &str) -> String {
+    let mut words: Vec<&str> = Vec::new();
+    for word in command.split_whitespace() {
+        // The environment a command was given is not the command.
+        if words.is_empty()
+            && word.split_once('=').is_some_and(|(k, _)| {
+                !k.is_empty() && k.chars().all(|c| c.is_ascii_uppercase() || c == '_')
+            })
+        {
+            continue;
+        }
+        if words.len() == 3 || word.starts_with('-') || !word.chars().all(is_word) {
+            break;
+        }
+        words.push(word);
+    }
+    // Nothing that reads as a name — a subshell, a pipeline, a `for` loop written out. Then the
+    // command is whatever it is, clipped, because guessing a name for it would be worse.
+    if words.is_empty() {
+        return clip(command.trim(), 24);
+    }
+    words.join(" ")
+}
+
+/// What may appear in the *name* of a command: a word, a path, a version. Anything else — a pipe,
+/// a redirect, a quote, an `&&` — is where the command stops being one thing.
+fn is_word(c: char) -> bool {
+    c.is_alphanumeric() || "._-/+@:".contains(c)
 }
 
 /// A path inside the conversation's directory, said the short way.
@@ -1026,7 +1207,7 @@ pub fn body(
         // Folded to the header alone. The count is already on it, and `⇥` opens this.
         Vec::new()
     } else {
-        result_rows(g, result, limits.output_lines, expanded, width)
+        result_rows(g, result, limits.output_lines, expanded, width, &g.margin())
     };
     attach(g, &mut rows);
     rows
@@ -1088,15 +1269,18 @@ fn trailer(g: &Glyphs, margin: &str, rest: usize, what: &str) -> Row {
 /// Tabs become spaces on the way in. A terminal advances to the next tab stop and a buffer line
 /// does not, so a `Read` whose output is `     1\thello` arrives on screen as `1hello` — the one
 /// place a tool's output is *deliberately* aligned is the one place it collapses.
+///
+/// `margin` is what every row of it starts with: a body's four columns, or eight for an output
+/// inside an [opened stack of commands](run_body), where four is the row the command itself is on.
 fn result_rows(
     g: &Glyphs,
     result: &neosh_proto::ToolResult,
     limit: usize,
     expanded: bool,
     width: usize,
+    margin: &str,
 ) -> Vec<Row> {
     let hl = if result.is_error { "Agent.ToolError" } else { "Agent.Usage" };
-    let margin = g.margin();
 
     let body = result.content.trim_end();
     if body.trim().is_empty() {
@@ -1149,7 +1333,7 @@ fn result_rows(
     }
     let kept: Vec<&str> =
         all[from..].iter().copied().filter(|l| says_something(l)).collect();
-    out.push(trailer(g, &margin, total - out.len() - kept.len(), "lines"));
+    out.push(trailer(g, margin, total - out.len() - kept.len(), "lines"));
     out.extend(kept.into_iter().map(|l| row(l)));
     out
 }
@@ -1514,6 +1698,7 @@ mod tests {
             took: Some(Duration::from_millis(4)),
             exit: None,
             output: None,
+            result: None,
         };
         let text = header_text(&g(), &quick, &root(), 80);
         assert_eq!(text, "  Read  a.rs", "{text:?}");
@@ -1552,6 +1737,7 @@ mod tests {
             took: Some(std::time::Duration::from_millis(120)),
             exit: Some(1),
             output: None,
+            result: None,
         };
         let text = header_text(&g(), &full, &root(), 90);
         assert!(text.ends_with("+1 -1  exit 1  120ms"), "{text:?}");
@@ -1567,7 +1753,7 @@ mod tests {
         input: &'a serde_json::Value,
         state: ToolState,
     ) -> Head<'a> {
-        Head { name, input, state, took: None, exit: None, output: None }
+        Head { name, input, state, took: None, exit: None, output: None, result: None }
     }
 
     fn header_text(g: &Glyphs, head: &Head, root: &std::path::Path, width: usize) -> String {
@@ -1709,14 +1895,155 @@ mod tests {
             Head { output: Some(120), ..head("Read", &a, ToolState::Done) },
             Head { output: Some(3), ..head("Grep", &b, ToolState::Done) },
         ];
-        assert!(group_body(&g(), &heads, &root(), false, 80).is_empty(), "folded, it is one row");
-        let rows = group_body(&g(), &heads, &root(), true, 80);
+        let limits = Limits { diff_lines: 12, output_lines: 3 };
+        assert!(
+            group_body(&g(), &heads, &root(), limits, false, 80).is_empty(),
+            "folded, it is one row"
+        );
+        let rows = group_body(&g(), &heads, &root(), limits, true, 80);
         // Opened, every call gets its own row with the *whole* subject: the short names on the
         // folded row are the loose answer, and this is where it is exact.
         assert_eq!(texts(&rows), vec![
             "  \u{2514} Read  deep/down/a.rs  120 lines",
             "    Searched  fn main  3 lines",
         ]);
+    }
+
+    /// A stretch of a turn spent running things is one row, and the answer is the last one's.
+    #[test]
+    fn a_stack_of_commands_keeps_the_last_answer() {
+        let limits = Limits { diff_lines: 12, output_lines: 3 };
+        let add = json!({ "command": "git add -A" });
+        let commit = json!({ "command": "git commit -m 'fix the thing'" });
+        let push = json!({ "command": "git push" });
+        let quiet = neosh_proto::ToolResult::ok("");
+        let said = neosh_proto::ToolResult::ok("[main 6759f10] fix the thing\n 1 file changed");
+        let sent = neosh_proto::ToolResult::ok("To github.com:neoswarm/neosh\n   6759f10..c280938");
+        let heads = [
+            Head { result: Some(&quiet), ..head("Bash", &add, ToolState::Done) },
+            Head { result: Some(&said), ..head("Bash", &commit, ToolState::Done) },
+            Head { result: Some(&sent), ..head("Bash", &push, ToolState::Done) },
+        ];
+        // The commands, named by what they are rather than by how they were spelled.
+        assert_eq!(
+            group_header(&g(), &heads, &root(), 80).text,
+            "  Ran  git add, git commit, git push"
+        );
+        // And under it the last one's output, and nothing from the two that got there.
+        assert_eq!(texts(&group_body(&g(), &heads, &root(), limits, false, 80)), vec![
+            "  \u{2514} To github.com:neoswarm/neosh",
+            "       6759f10..c280938",
+        ]);
+    }
+
+    /// The fold is a summary and the key is the detail — for a command that means its output.
+    #[test]
+    fn an_opened_stack_is_every_command_in_full_with_what_it_printed() {
+        let limits = Limits { diff_lines: 12, output_lines: 1 };
+        let fmt = json!({ "command": "cargo fmt --check" });
+        let test = json!({ "command": "cargo test -p neosh-core -- --test-threads 2" });
+        let ok = neosh_proto::ToolResult::ok("all good");
+        let ran = neosh_proto::ToolResult::ok("running 142 tests\ntest result: ok");
+        let heads = [
+            Head { result: Some(&ok), ..head("Bash", &fmt, ToolState::Done) },
+            Head { result: Some(&ran), ..head("Bash", &test, ToolState::Done) },
+        ];
+        // Every one of them, the whole command line, and the whole of what it said — one indent
+        // deeper, or the next command's name reads as another line of the output above it.
+        assert_eq!(texts(&group_body(&g(), &heads, &root(), limits, true, 80)), vec![
+            "  \u{2514} Ran  cargo fmt --check",
+            "        all good",
+            "    Ran  cargo test -p neosh-core -- --test-threads 2",
+            "        running 142 tests",
+            "        test result: ok",
+        ]);
+    }
+
+    /// A fold is about noise, and a failure is not noise — wherever in the stack it landed.
+    #[test]
+    fn a_stack_never_folds_a_failure_away() {
+        let limits = Limits { diff_lines: 12, output_lines: 3 };
+        let build = json!({ "command": "cargo build" });
+        let test = json!({ "command": "cargo test" });
+        let broke = neosh_proto::ToolResult::error("error[E0308]: mismatched types");
+        let ok = neosh_proto::ToolResult::ok("test result: ok");
+        let heads = [
+            Head { result: Some(&broke), ..head("Bash", &build, ToolState::Failed) },
+            Head { result: Some(&ok), ..head("Bash", &test, ToolState::Done) },
+        ];
+        // Two outputs, so each says whose it is. `Card::takes` is what makes this rare — a run
+        // does not continue past a failure — but calls made in parallel land in any order.
+        assert_eq!(texts(&group_body(&g(), &heads, &root(), limits, false, 80)), vec![
+            "  \u{2514} Ran  cargo build",
+            "        error[E0308]: mismatched types",
+            "    Ran  cargo test",
+            "        test result: ok",
+        ]);
+    }
+
+    /// While it is going, the row is a report of what is happening rather than an account of what
+    /// happened — so the name that must never be dropped is the one still out.
+    #[test]
+    fn a_live_stack_is_fitted_from_the_end() {
+        let inputs: Vec<serde_json::Value> = ["cargo fmt", "cargo build", "cargo clippy",
+            "cargo test", "cargo doc"]
+            .iter()
+            .map(|c| json!({ "command": c }))
+            .collect();
+        let mut heads: Vec<Head> =
+            inputs.iter().map(|i| head("Bash", i, ToolState::Done)).collect();
+        let last = heads.len() - 1;
+        heads[last].state = ToolState::Running;
+        let row = group_header(&g(), &heads, &root(), 44);
+        assert!(row.text.chars().count() <= 44, "{row:?}");
+        assert!(row.text.ends_with("cargo doc"), "the one being waited on: {row:?}");
+        assert!(row.text.contains("earlier"), "and a count of what it got there through: {row:?}");
+        // Finished, it reads from the beginning again: an account starts where the work did.
+        heads[last].state = ToolState::Done;
+        let row = group_header(&g(), &heads, &root(), 44);
+        assert!(row.text.starts_with("  Ran  cargo fmt"), "{row:?}");
+        assert!(row.text.ends_with("more"), "{row:?}");
+    }
+
+    #[test]
+    fn a_command_in_a_list_is_what_it_is_and_not_how_it_was_spelled() {
+        for (command, want) in [
+            ("cargo test -p neosh-core -- --test-threads 2", "cargo test"),
+            ("git status", "git status"),
+            ("npm run build", "npm run build"),
+            ("npm run build --silent", "npm run build"),
+            ("NEOSH_STATE_DIR=/tmp/x cargo run", "cargo run"),
+            ("ls -la /tmp", "ls"),
+            ("./scripts/shot.py --cols 110", "./scripts/shot.py"),
+            // Where it stops being one command, the name stops with it.
+            ("cd crates && cargo test", "cd crates"),
+            ("grep -rn foo | wc -l", "grep"),
+            ("for f in *.rs; do echo $f; done", "for f in"),
+            // And something with no name in it at all is itself, as much as fits.
+            ("(cd crates && ls)", "(cd crates && ls)"),
+            ("(cd crates && ls) | sort -u", "(cd crates && ls) | sor\u{2026}"),
+        ] {
+            let input = json!({ "command": command });
+            assert_eq!(short_subject_of(&input, &root()), want, "{command}");
+        }
+    }
+
+    /// Reads with reads and commands with commands. A run is a row saying what a stretch of the
+    /// turn was doing, and one verb over two kinds of activity is a verb that is not true.
+    #[test]
+    fn only_calls_of_one_kind_share_a_card() {
+        let read = json!({ "file_path": "/work/a.rs" });
+        let grep = json!({ "pattern": "fn main" });
+        let ran = json!({ "command": "cargo test" });
+        let edit = json!({ "file_path": "/work/a.rs", "old_string": "a", "new_string": "b" });
+        assert!(groups_with(&read, &grep));
+        assert!(
+            groups_with(&ran, &json!({ "command": "git status" })),
+            "ADR 0051: what a command printed is the answer, and the stack keeps the last one's"
+        );
+        assert!(!groups_with(&read, &ran), "one verb over two activities is a verb that is not true");
+        assert!(!groups_with(&read, &edit), "an edit's diff is the answer");
+        assert!(!groups_with(&edit, &edit), "a diff is the answer and does not summarise");
     }
 
     #[test]
@@ -1813,18 +2140,6 @@ mod tests {
         let glob = json!({ "pattern": "**/*.rs" });
         assert_eq!(short_subject_of(&glob, &root()), "**/*.rs");
         assert_eq!(short_subject_of(&json!({ "path": "/work/a/b/c.rs" }), &root()), "c.rs");
-    }
-
-    #[test]
-    fn only_calls_that_looked_at_something_share_a_card() {
-        let read = json!({ "file_path": "/work/a.rs" });
-        let grep = json!({ "pattern": "x" });
-        let run = json!({ "command": "ls" });
-        let edit = json!({ "file_path": "/work/a.rs", "old_string": "a", "new_string": "b" });
-        assert!(groups_with(&read, &grep));
-        assert!(!groups_with(&read, &run), "a command's output is the answer, not a name");
-        assert!(!groups_with(&read, &edit), "an edit's diff is the answer");
-        assert!(!groups_with(&run, &run));
     }
 
     #[test]

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -527,11 +527,11 @@ struct Leg {
 /// finished when the call comes back — without going looking for the call in the conversation,
 /// which for a running agent turn does not hold it yet.
 ///
-/// Usually one call. A *run* of calls that only looked at things — reads, greps, listings, one
-/// after another with nothing drawn between them — shares a card, and the card is one row saying
-/// what they all looked at. See [`cards::group_header`]. Nothing else ever shares: a command's
-/// output and an edit's diff are the answer, and there is no summarising them into a list of
-/// names.
+/// Usually one call. A *run* of calls of one kind, one after another with nothing drawn between
+/// them, shares a card: reads, greps and listings fold to one row saying what they all looked at,
+/// and commands fold to one row naming them with the last one's output under it. See
+/// [`cards::group_header`] and [`cards::groups_with`]. An edit never shares — its diff is the
+/// answer, and there is no summarising a diff into a list of names.
 struct Card {
     /// One, or a run of read-only calls, in the order they were made.
     legs: Vec<Leg>,
@@ -567,11 +567,17 @@ impl Card {
 
     /// Whether a call `input` could join this card.
     ///
-    /// Both sides have to be calls that only looked at something, and the card has to have room
-    /// for the idea — a card whose body is already on screen is a card the reader has opened, and
-    /// growing it under them would move what they were reading.
+    /// Both sides have to be the same kind of call — reads with reads, commands with commands —
+    /// and the card has to have room for the idea: a card whose body is already on screen is a
+    /// card the reader has opened, and growing it under them would move what they were reading.
+    ///
+    /// **A run does not continue past a failure.** A stack of commands shows the last one's
+    /// output, so a failed call that is not the last one is a failure whose output folded away —
+    /// and the fold is about noise. Ending the run there gives the failure its own card with its
+    /// own body, which is what it would have had alone.
     fn takes(&self, input: &serde_json::Value) -> bool {
         !self.expanded
+            && !self.legs.iter().any(|l| l.result.as_ref().is_some_and(|r| r.is_error))
             && self.legs.last().is_some_and(|l| cards::groups_with(&l.input, input))
     }
 }
@@ -4404,8 +4410,16 @@ impl Host {
         {
             self.cards[i].legs.push(leg);
             let row = self.cards[i].row;
-            let header = self.card_header(i);
-            self.replace_row(row, &header);
+            if self.cards[i].body > 0 {
+                // A stack of commands shows the *last* one's output, and the call that just
+                // started has not printed one yet — so its predecessor's rows come off here.
+                self.redraw_card(i);
+            } else {
+                // A run of reads has no body at all, and rewriting the header in place is what
+                // keeps a run from costing rows while it happens.
+                let header = self.card_header(i);
+                self.replace_row(row, &header);
+            }
             return Some(row);
         }
         let g = self.glyphs();
@@ -4418,6 +4432,7 @@ impl Host {
             took: None,
             exit: None,
             output: None,
+            result: None,
         };
         let card = cards::header(&g, &head, &root, width);
         // No blank row above it. Air used to go between one action and the next on the argument
@@ -4525,6 +4540,8 @@ impl Host {
                 took: leg.took.or_else(|| leg.started.map(|s| s.elapsed())),
                 exit: leg.exit,
                 output: leg.result.as_ref().map(|r| lines_in(&r.content)),
+                // Only a stack of commands draws one, and only that reads it back.
+                result: leg.result.as_ref(),
             })
             .collect()
     }
@@ -4580,10 +4597,11 @@ impl Host {
                 Some(r) => cards::body(&g, &leg.input, r, limits, card.expanded, width),
                 None => Vec::new(),
             },
-            // A run: nothing until it is opened, and then a row per call. What the fold exists to
-            // keep out of the transcript is the *contents* of the six files, so opening a run
-            // gives back the six names in full and stops there.
-            _ => cards::group_body(&g, &Self::card_heads(card), &root, card.expanded, width),
+            // A run of reads: nothing until it is opened, and then a row per call. What the fold
+            // exists to keep out of the transcript is the *contents* of the six files, so opening
+            // a run gives back the six names in full and stops there. A run of *commands* keeps
+            // the last one's output, because what a command printed is the answer — see ADR 0051.
+            _ => cards::group_body(&g, &Self::card_heads(card), &root, limits, card.expanded, width),
         };
         // Anything else writing into the transcript ends the answer: its rows are addressed by
         // range, and rows moving underneath it would make "the end of the answer" ambiguous. An
@@ -7708,6 +7726,35 @@ fn transcript(
             lines.insert(row as usize, r.text);
         }
     }
+    // What is under card `i`, replaced. A card acquires and loses a body while the conversation is
+    // being read — a stack of commands shows the last one's output, so every command that joins it
+    // takes the previous one's rows back off the screen — and the rows below it, the marks and the
+    // other cards all move with it.
+    #[allow(clippy::items_after_statements)]
+    fn set_body(
+        lines: &mut Vec<String>,
+        marks: &mut Vec<Mark>,
+        cards: &mut Vec<Card>,
+        i: usize,
+        rows: Vec<cards::Row>,
+    ) {
+        let at = cards[i].row + 1;
+        let old = cards[i].body;
+        if old > 0 {
+            lines.drain(at as usize..(at + old) as usize);
+            marks.retain(|m| m.row < at || m.row >= at + old);
+            for m in marks.iter_mut().filter(|m| m.row >= at + old) {
+                m.row -= old;
+            }
+            for c in cards.iter_mut().filter(|c| c.row >= at + old) {
+                c.row -= old;
+            }
+            cards[i].body = 0;
+        }
+        let n = rows.len() as u32;
+        insert(lines, marks, cards, at, rows);
+        cards[i].body = n;
+    }
     // A card's header, from what the conversation says about every call on it.
     //
     // The results are read out of `answered` rather than off the legs: a result block always comes
@@ -7720,7 +7767,20 @@ fn transcript(
         root: &std::path::Path,
         width: usize,
     ) -> cards::Row {
-        let heads: Vec<cards::Head> = card
+        let heads = heads_of(card, answered);
+        match heads.as_slice() {
+            [one] => cards::header(g, one, root, width),
+            many => cards::group_header(g, many, root, width),
+        }
+    }
+    // Every call on a card, as the renderer wants them. The live path's `card_heads`, for a card
+    // built out of the conversation rather than watched happening.
+    #[allow(clippy::items_after_statements)]
+    fn heads_of<'a>(
+        card: &'a Card,
+        answered: &std::collections::HashMap<&neosh_proto::ToolCallId, (bool, Option<i64>, usize)>,
+    ) -> Vec<cards::Head<'a>> {
+        card
             .legs
             .iter()
             .map(|leg| {
@@ -7736,12 +7796,29 @@ fn transcript(
                     took: None,
                     exit,
                     output,
+                    result: leg.result.as_ref(),
                 }
             })
-            .collect();
-        match heads.as_slice() {
-            [one] => cards::header(g, one, root, width),
-            many => cards::group_header(g, many, root, width),
+            .collect()
+    }
+    // What goes under a card, folded, from what the conversation says: one call's answer, or a
+    // stack's. The live path's [`Host::redraw_card`] arm, asked the same way — the two have to
+    // produce the same rows, or switching away and back re-draws the conversation.
+    #[allow(clippy::items_after_statements)]
+    fn body_of(
+        g: &Glyphs,
+        card: &Card,
+        answered: &std::collections::HashMap<&neosh_proto::ToolCallId, (bool, Option<i64>, usize)>,
+        root: &std::path::Path,
+        limits: cards::Limits,
+        width: usize,
+    ) -> Vec<cards::Row> {
+        match card.legs.as_slice() {
+            [leg] => match &leg.result {
+                Some(r) => cards::body(g, &leg.input, r, limits, false, width),
+                None => Vec::new(),
+            },
+            _ => cards::group_body(g, &heads_of(card, answered), root, limits, false, width),
         }
     }
     // A gap, unless there already is one: what came before was often a tool card, which has no
@@ -7845,6 +7922,12 @@ fn transcript(
                     let at = if open {
                         let i = cards.len() - 1;
                         cards[i].legs.push(leg);
+                        // A card that was one command with its output under it is now a stack of
+                        // them, and a stack shows the *last* one's output — which this call has
+                        // not produced yet. So its predecessor's rows come off the screen here,
+                        // exactly as the live path takes them off when it redraws the card.
+                        let rows = body_of(&g, &cards[i], &answered, root, limits, width);
+                        set_body(&mut lines, &mut marks, &mut cards, i, rows);
                         cards[i].row
                     } else {
                         // No gap, exactly as the live path draws it: the two have to produce the
@@ -7881,18 +7964,12 @@ fn transcript(
                             if !*is_error {
                                 cards::tally(&mut changes, &cards::edits_of(&cards[i].legs[k].input));
                             }
-                            // A run holds its calls' answers and shows none of them: it is one row
-                            // until somebody opens it, exactly as it is live.
-                            let rows = if cards[i].legs.len() > 1 {
-                                Vec::new()
-                            } else {
-                                cards::body(&g, &cards[i].legs[k].input, &result, limits, false, width)
-                            };
-                            let n = rows.len() as u32;
-                            let at = cards[i].row + 1;
-                            insert(&mut lines, &mut marks, &mut cards, at, rows);
+                            // The answer goes on the leg first, because what a card shows is a
+                            // question about the whole card: a run of reads shows none of them, a
+                            // stack of commands shows the last one's, and one call shows its own.
                             cards[i].legs[k].result = Some(result);
-                            cards[i].body = n;
+                            let rows = body_of(&g, &cards[i], &answered, root, limits, width);
+                            set_body(&mut lines, &mut marks, &mut cards, i, rows);
                         }
                         // No card to go under — cards are off and this is an error — so at the
                         // end, which is where the live path puts it too.

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -5251,6 +5251,150 @@ fn calls_that_only_looked_at_things_share_one_row_and_open_into_several() {
     );
 }
 
+/// A provider that runs three commands in one turn, and a `run` tool with canned output for each.
+///
+/// The shell neosh does not have: what matters to a card is that the call was handed a `command`,
+/// which is how a card decides what a call is in the first place — off the arguments, never off a
+/// list of tool names.
+const RUNNER: &str = r#"
+import type { PluginContext } from "@neosh/api";
+
+const SAID: Record<string, string> = {
+  "git add -A": "",
+  "git commit -m 'stack the cards'": "[main 6759f10] stack the cards\n 3 files changed",
+  "git push origin main": "To github.com:neoswarm/neosh\n   6759f10..c280938  main -> main",
+};
+
+export async function activate({ neosh }: PluginContext) {
+  await neosh.tool.register(
+    { name: "run", description: "Run", inputSchema: { type: "object" } },
+    async (input) => ({ content: SAID[(input as { command: string }).command] ?? "ran" }),
+  );
+  let turn = 0;
+  await neosh.provider.register("runner", [{
+    id: "runner", driver: "runner", display_name: "Runner",
+    models: [{ id: "runner", display_name: "Runner" }],
+  }], async (_req, emit) => {
+    emit({ type: "message_start", model: "runner", usage: {} });
+    turn += 1;
+    if (turn === 1) {
+      Object.keys(SAID).forEach((command, i) => {
+        emit({ type: "block_start", index: i, block: { kind: "tool_use", id: `r${i}`, name: "run" } });
+        emit({ type: "tool_input_delta", index: i, partial_json: JSON.stringify({ command }) });
+        emit({ type: "block_stop", index: i });
+      });
+      emit({ type: "message_delta", stop_reason: { kind: "tool_use" }, usage: {} });
+      emit({ type: "message_stop" });
+      return;
+    }
+    emit({ type: "block_start", index: 0, block: { kind: "text" } });
+    emit({ type: "text_delta", index: 0, text: "Pushed." });
+    emit({ type: "block_stop", index: 0 });
+    emit({ type: "message_delta", stop_reason: { kind: "end_turn" }, usage: {} });
+    emit({ type: "message_stop" });
+  });
+  neosh.notify("runner ready");
+}
+"#;
+
+fn install_runner(sb: &Sandbox) {
+    let dir = sb.root.join("config/plugins/runner");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    std::fs::write(
+        dir.join("plugin.toml"),
+        "name = \"runner\"\nversion = \"0.1.0\"\nentry = \"main.ts\"\npermissions = [\"providers\", \"tools\"]\n",
+    )
+    .expect("manifest");
+    std::fs::write(dir.join("main.ts"), RUNNER).expect("plugin");
+}
+
+/// ADR 0051. A stretch of a turn spent running things is one row, and the answer is the last one's.
+#[test]
+fn a_run_of_commands_is_one_row_that_keeps_the_last_answer() {
+    let sb = Sandbox::new("stack");
+    install_runner(&sb);
+    sb.write_config(
+        "[options]\n\"agent.model\" = \"runner/runner\"\n\"ui.confirm_destructive\" = false\n",
+    );
+    let mut s = sb.start_letting_config_choose();
+    // The splash names the active model, and the model the config asked for only becomes active
+    // once the plugin that provides it has finished loading. "runner ready" is the plugin saying
+    // it registered; this is the host saying it took.
+    s.wait_for("runner/runner");
+    s.type_text("go");
+    s.enter();
+    assert!(
+        s.pump(|s| {
+            let rows = s.chat_now();
+            rows.iter().any(|l| l.contains("Pushed."))
+                && !rows.iter().any(|l| l.contains("esc to interrupt"))
+        }),
+        "the turn finished\n{:?}",
+        s.chat_now()
+    );
+    let rows = s.chat_now();
+    let run = rows
+        .iter()
+        .position(|l| l.starts_with("  Ran  "))
+        .unwrap_or_else(|| panic!("the stack is one row\n{rows:?}"));
+    assert_eq!(
+        rows[run], "  Ran  git add, git commit, git push origin",
+        "each command named by what it is rather than how it was spelled\n{rows:?}"
+    );
+    // The last one's output, because that is the one the other two were getting to.
+    assert!(
+        rows.iter().any(|l| l.contains("6759f10..c280938")),
+        "the answer is under it\n{rows:?}"
+    );
+    assert!(
+        !rows.iter().any(|l| l.contains("3 files changed")),
+        "and the ones before it folded into their names\n{rows:?}"
+    );
+
+    // Opened, every command in full with the whole of what it printed.
+    s.ctrl("s");
+    s.key("g");
+    s.key("g");
+    for _ in 0..run {
+        s.key("j");
+    }
+    s.special("tab");
+    assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("3 files changed"))),
+        "open, nothing the fold hid is out of reach\n{:?}",
+        s.chat_now()
+    );
+    let open = s.chat_now();
+    assert!(
+        open.iter().any(|l| l.contains("Ran  git commit -m 'stack the cards'")),
+        "and every command is there in full\n{open:?}"
+    );
+    assert_eq!(open[run], rows[run], "the header did not move or change\n{open:?}");
+
+    // And the replay folds it exactly as the live stream did, which is the whole reason the two
+    // go through one renderer.
+    s.special("tab");
+    s.special("esc");
+    s.send(&command("session.new"));
+    assert!(s.pump(|s| !s.chat_now().iter().any(|l| l.contains("Pushed."))), "somewhere else");
+    s.send(&command("session.close"));
+    assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("Pushed."))),
+        "and back\n{:?}",
+        s.chat_now()
+    );
+    let back = s.chat_now();
+    assert!(
+        back.iter().any(|l| l == "  Ran  git add, git commit, git push origin"),
+        "one row again\n{back:?}"
+    );
+    assert!(
+        back.iter().any(|l| l.contains("6759f10..c280938"))
+            && !back.iter().any(|l| l.contains("3 files changed")),
+        "with the last answer and no other\n{back:?}"
+    );
+}
+
 #[test]
 fn a_folded_card_opens_with_tab_while_reading_and_folds_again() {
     // A card shows enough to know what happened. The whole of it is one key away, in the place

--- a/docs/adr/0000-index.md
+++ b/docs/adr/0000-index.md
@@ -56,3 +56,4 @@ implementation — and in two cases (0005, 0008) it did not, which is itself rec
 | [0048](0048-a-key-every-terminal-sends.md) | A default binding is a key every terminal sends | Accepted |
 | [0049](0049-a-list-is-a-place-you-move-in.md) | A list is a place you move in | Accepted |
 | [0050](0050-a-card-is-attached-to-what-it-did.md) | A card is attached to what it did | Accepted |
+| [0051](0051-a-stack-of-commands.md) | A stack of commands, and the answer is the last one's | Accepted |

--- a/docs/adr/0051-a-stack-of-commands.md
+++ b/docs/adr/0051-a-stack-of-commands.md
@@ -1,0 +1,119 @@
+# 0051 — A stack of commands
+
+**Status:** accepted
+
+## Context
+
+ADR 0040 made a run of reads one row. A turn that reads three files, greps twice and lists a
+directory is one line naming what it looked at, and `⇥` opens it into a row per call. The argument
+was that the answer to a read is "yes, and it was what you would expect", so the six bodies were
+six answers nobody had asked for and the six headers were the thing you actually wanted.
+
+It explicitly stopped there: *"Only calls that looked at something ever share. A command's output
+is the answer and an edit's diff is the answer; there is no summarising either into a list of
+names."*
+
+Half of that is still true. The other half turns out to describe a card, not a run of them. A real
+turn does this:
+
+```text
+  Ran  git add -A                     1 line
+  └ done
+  Ran  git commit -m 'fix the thing'  4 lines
+  └ [main 6759f10] fix the thing
+     1 file changed, 2 insertions(+)
+  Ran  git push                       3 lines
+  └ To github.com:neoswarm/neosh
+     6759f10..c280938  main -> main
+```
+
+Eight rows, of which the last two are the answer and the first six are the sound of somebody
+getting there. And `git add` printing `done` under its own header is the same complaint ADR 0040
+opened with, one kind of call along: a body that says what you would have guessed, drawn at full
+price, holding apart the headers that were the information.
+
+What is different about a command is that *one* of those outputs is load-bearing, and it is almost
+always the last one: the earlier commands are how you arrive at the one you were waiting for.
+`cargo fmt`, `cargo build`, `cargo test` — the test result is the answer and the other two are
+setup. So a stack of commands cannot fold to nothing the way a stack of reads does, and it does not
+have to keep everything either.
+
+## Decision
+
+**A run of commands shares a card, the same way a run of reads does — and it keeps the last one's
+output.**
+
+```text
+  Ran  git add, git commit, git push
+  └ To github.com:neoswarm/neosh
+     6759f10..c280938  main -> main
+```
+
+The same rule for what a run *is*: calls with nothing drawn between them, asked the same way by the
+live path and the replay. The same fold: `⇥` opens it.
+
+**Reads with reads, commands with commands, and never one of each.** A run is a row saying what a
+stretch of the turn was doing, and `Explored  a.rs, cargo test` is two activities wearing one verb.
+`groups_with` now asks whether both calls are the same kind and that kind is one that folds — read
+off the arguments, as ever, so a shell a plugin registers tomorrow stacks for the same reason it
+gets a colour.
+
+**A command's name in the list is what it *is*, without its flags.** `cargo test -p neosh-core --
+--test-threads 2` is forty-two columns of a row that has to hold four of them, and thirty of them
+are how the run was tuned. So the folded row says `cargo test`: the leading run of plain words, up
+to three, dropping a `VAR=value` prefix. No ellipsis — everything on that row is short for
+something, and `git add…, git commit…, git push` is punctuation saying what the row already says.
+It is loose on purpose and it is safe to be loose — the whole command line is on the row this call gets when the
+stack is opened, and on the card it gets when it is alone. This is [`short_subject_of`]'s existing
+job (a path folds to its last component there) and it is the same trade.
+
+**A run in flight is fitted from the back.** ADR 0040 fills the row from the front and counts what
+did not fit. That is right for a run that is over — it is an account of what the turn did, and an
+account starts at the beginning — and wrong for one still going, where the row is a report of what
+is *happening*: nine commands in, the front-fitted row named what the model was doing forty seconds
+ago and `+4 more`. So while any call on the card is still out, the list is fitted from the end and
+what fell off the front is `+N earlier`. The one being waited on is the one name that can never be
+the name that did not fit.
+
+**`⇥` opens the stack into a row per command with the whole of its output**, which is exactly what
+each of them would have had as a card of its own:
+
+```text
+  └ Ran  cargo fmt --check
+        all good
+    Ran  cargo test -p neosh-core -- --test-threads 2
+        running 142 tests
+        test result: ok. 142 passed
+```
+
+One indent deeper than the command it belongs to, because at the same indent the next command's
+name reads as another line of the output above it. This is where a stack differs from a run of
+reads, which stops at the names: the *contents* of six files is what that fold existed to keep out
+of the transcript, and the output of three commands is what this one is holding.
+
+**A run does not continue past a failure.** A stack shows the last output, so a failed call in the
+middle of one would be a failure that folded away — and the fold is about noise, which a failure is
+not. `Card::takes` refuses to grow a card that already holds a failure, so the failed call is the
+last leg on its card and its output is the one showing, and whatever came next starts a new card.
+Calls made in parallel can still land out of order, so the fold shows any failed output wherever it
+sits, and names each one when there is more than one thing to name.
+
+## Consequences
+
+- `cards::Head` gains the `ToolResult` it came back with. Only a stack of commands reads it; a
+  header is a sentence about a call and never about its output, which is why the line count stayed
+  a separate field.
+- `group_body` takes `Limits`. The replay grew `set_body`, because a card now *loses* a body as
+  well as gaining one: the moment a second command joins, the first one's output comes off the
+  screen. The live path already redrew the whole card and needed nothing.
+- **A folded stack costs two or three rows for a stretch of the turn that used to cost eight.** The
+  `git add`/`git commit`/`git push` example above goes from eight rows to three.
+- The verb on a stack is coloured by its kind, so `Ran` is `Agent.ToolRun` where `Explored` is
+  `Agent.ToolRead`. The old code hard-coded the read colour, which nobody had noticed because
+  nothing but reads could get there.
+- A command whose output you were reading can be folded away by the *next* command starting. That
+  is the cost, it is one `⇥` away, and it is the same bargain ADR 0040 struck for reads: the run is
+  a summary and the key is the detail. What it is not allowed to do is hide a failure, which is
+  what the two rules above are for.
+- A stack of one is not a stack. A single command is an ordinary card with an ordinary body, and
+  nothing about it changed.


### PR DESCRIPTION
ADR 0040 made a run of reads one row and stopped there, on the grounds that a command's output is
the answer. Half of that describes a card and not a run of them: `git add`, `git commit`, `git push`
is eight rows, of which two are the answer and six are the sound of getting there.

So a run of commands shares a card the way a run of reads does:

```
  Ran  git add, git commit, git push origin
  └ To github.com:neoswarm/neosh
       6759f10..c280938  main -> main
```

`⇥` opens it into every command in full, with the whole of what each printed — which is exactly what
each would have had as a card of its own:

```
  Ran  git add, git commit, git push origin
  └ Ran  git add -A
        done
    Ran  git commit -m 'stack the cards'
        [main 6759f10] stack the cards
         3 files changed
    Ran  git push origin main
        To github.com:neoswarm/neosh
           6759f10..c280938  main -> main
```

## The decisions

- **It keeps the last one's output.** The ones before it are how you arrive at the one you were
  waiting for: `cargo fmt`, `cargo build`, `cargo test`.
- **A command is named by what it *is*** — `cargo test`, not
  `cargo test -p neosh-core -- --test-threads 2`. The leading run of plain words, up to three,
  dropping a `VAR=value` prefix. No ellipsis, for the same reason a path's last component does not
  wear one.
- **A run never continues past a failure**, so a failed command is the last call on its card and its
  output is the one showing. The fold is about noise, and a failure is not noise.
- **A live run is fitted from the end** — `+3 earlier, cargo test, cargo doc`. Front-fitted, a run
  of nine commands says what it was doing forty seconds ago and `+4 more`; the call being waited on
  is the one name that must never be the name that did not fit.
- **Reads with reads and commands with commands**, never one of each, and never an edit: a diff does
  not summarise into a list of names.

The replay grew `set_body`, because a card now *loses* a body as well as gaining one — the moment a
second command joins, the first one's output comes off the screen.

`docs/adr/0051-a-stack-of-commands.md` records the reasoning. The CLAUDE.md rule that said commands
never share a card is rewritten rather than quietly contradicted.

## Verification

- `cards` unit tests: 52 passed, six of them new
- bin unit tests 225, `sessions` 29, `reading` 25 — all pass
- a new end-to-end test through the real binary: the live path, `⇥`, and a switch-away-and-back
  replay
- two screenshots of the real terminal confirm the folded and opened forms

`builtin_plugins` is 143 passed / 2 failed on a quiet machine. Both failures reproduce on `main`:
`the_plan_row_keeps_the_providers_own_colour`, and `a_turn_that_has_already_said_something...`,
which times out at exactly 30s on the first run after a rebuild and passes in 0.13s on the next two.

## The cost, stated plainly

A command's output you were reading can be folded away by the *next* command starting. It is one `⇥`
away, and it is the same bargain ADR 0040 struck for reads — but it is a real change to what the
transcript shows by default.