### PR TITLE
Stop a workspace running two agents for one conversation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,16 @@ per decision, and records the *reasoning*, not the choice.
 - **An agent driver keeps one process per conversation, keyed by `TurnRequest::conversation`.** Not
   per turn, and never one per driver — several conversations run at once, and a driver holding a
   single session id resumes the second into the first one's history. (ACP is the exception and says
-  why: its session lives on the agent's side.)
+  why: its session lives on the agent's side.) **And exactly one process, which means a turn that
+  belongs to no conversation has to be *asked about* rather than keyed on.** A branch name, a
+  thread title, a commit message — `Agent::complete` — sends an empty `conversation`, and empty is
+  an ordinary map key: every one of them shared a slot that nothing ever emptied, so a workspace
+  ran a second `claude` beside the one you were talking to, with the same flags and the same
+  access, answering nobody, for as long as it lived. `TurnRequest::is_one_shot` is the question,
+  and the answer is a slot nobody else can find and a process closed when the turn is. The other
+  half is that an *interrupt* must not cost a conversation its process either: `<Esc>` asks the CLI
+  to stop, and a CLI that stops is one to keep — the deadline the closing context question arms is
+  not the deadline the interrupt armed, however much they share a timer.
 - **What a driver calls a conversation is the conversation's, not the process's.** A vendor CLI
   keeps the history and hands back a handle; a driver that only remembers it in memory remembers it
   until the workspace stops, and then reopening a conversation starts an agent that has never heard

--- a/crates/neosh-proto/src/provider.rs
+++ b/crates/neosh-proto/src/provider.rs
@@ -628,6 +628,20 @@ pub struct TurnRequest {
     pub max_output_tokens: Option<u64>,
 }
 
+impl TurnRequest {
+    /// Whether this turn belongs to no conversation at all.
+    ///
+    /// A branch name, a commit message, a thread title: the caller borrows the model, takes one
+    /// answer and leaves nothing behind. [`Self::conversation`] says so by being empty, and a
+    /// driver that keeps a process per conversation has to *ask*, because an empty id is an
+    /// ordinary map key and keying by it is how one of these came to hold a whole agent session
+    /// open for the life of the workspace — a second `claude` beside the one you were talking to,
+    /// answering nobody, in a slot nothing ever emptied.
+    pub fn is_one_shot(&self) -> bool {
+        self.conversation.0.is_empty()
+    }
+}
+
 /// How a step of a plan is going.
 #[derive(TS, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]

--- a/crates/neosh-provider/src/drivers/claude_cli.rs
+++ b/crates/neosh-provider/src/drivers/claude_cli.rs
@@ -507,7 +507,16 @@ impl Provider for ClaudeCliProvider {
     ) -> ProviderStream {
         let (tx, rx) = mpsc::channel::<ProviderEvent>(256);
         let program = self.program.clone();
-        let slot = self.slot(&request.conversation);
+        // A one-shot belongs to nobody, so it gets a slot nobody else can find and the process is
+        // let go of at the end of it. Keyed into the map instead — which is what an empty id does
+        // if you do not ask — every branch name and thread title in the workspace shared one CLI,
+        // and that CLI was never closed: a second `claude` running beside the conversation you
+        // were in, holding a full-access session open for as long as the workspace lived.
+        let one_shot = request.is_one_shot();
+        let slot = match one_shot {
+            true => Arc::new(Conversation::default()),
+            false => self.slot(&request.conversation),
+        };
         let mode = *self.mode.lock().expect("mode lock poisoned");
         let asker = self.asker.lock().expect("asker lock poisoned").clone();
         let questioner = self.questioner.lock().expect("questioner lock poisoned").clone();
@@ -542,6 +551,11 @@ impl Provider for ClaudeCliProvider {
                 // whose other end has gone.
                 *guard = None;
                 let _ = tx.send(ProviderEvent::Error { message, retryable: false }).await;
+            }
+            // Nothing is coming back to this one, so it is asked to stop rather than left holding
+            // a login and a JS heap until the workspace ends.
+            if one_shot && let Some(live) = guard.take() {
+                live.close().await;
             }
             drop(attached);
         });
@@ -806,12 +820,15 @@ async fn run_turn(
             // the context question: nothing at all went wrong — the turn is already finished and
             // that was an extra — so it is simply given up on.
             () = &mut giveup, if interrupted || ending => {
-                if interrupted {
-                    let _ = live.child.start_kill();
-                    *slot = None;
-                    return Ok(Outcome::Done);
+                // `ending` is asked first, because it is armed *last* and only by a turn that has
+                // already finished. Reading `interrupted` first meant the two-second wait for one
+                // number was answered by killing a process that had done everything asked of it.
+                if ending {
+                    break;
                 }
-                break;
+                let _ = live.child.start_kill();
+                *slot = None;
+                return Ok(Outcome::Done);
             }
             line = async {
                 // What a previous turn read past its own ending comes first, in the order it was
@@ -973,7 +990,15 @@ async fn run_turn(
                     // Not when it has been abandoned: there is nobody to tell, and asking would
                     // re-arm the deadline that an interrupt has already pointed at killing the
                     // process — which is the one thing draining exists to avoid.
+                    //
+                    // And not when it has been interrupted, which is the same sentence about the
+                    // same deadline and was the half that was missing. `<Esc>` on a turn the CLI
+                    // then stopped politely still left `interrupted` set; this asked one last
+                    // question, re-armed the deadline at two seconds, and the branch below read
+                    // that expiry as "asked to stop and did not" — so every interrupt ended with
+                    // the conversation's CLI killed and the next turn resuming into a fresh one.
                     if !abandoned
+                        && !interrupted
                         && !ending
                         && live.control(&json!({"subtype": "get_context_usage"})).await.is_ok()
                     {
@@ -1910,4 +1935,270 @@ done
             "`--effort` and nothing else"
         );
     }
+
+    /// The user's sequence: a turn is interrupted mid-answer, and the next question is asked on
+    /// the same conversation.
+    ///
+    /// Two things have to hold, and only one of them used to. Whatever the CLI was still writing
+    /// must not arrive under the new question — that is the drain, and it worked. And the
+    /// conversation must still be *the same CLI*: an interrupt asks the process to stop, it stops,
+    /// and a turn that stopped politely is not a turn to kill. It was killed, every time, because
+    /// the last thing an ending turn does is ask for one more number and the deadline that arms is
+    /// the same one the interrupt armed.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_interrupted_answer_does_not_arrive_under_the_next_question() {
+        use futures::StreamExt;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join(format!("neosh-cut-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("dirs");
+        let script = dir.join("fake-claude");
+        // A CLI that answers slowly, in a writer of its own, so a control request can arrive in
+        // the middle of an answer the way it does against the real one. `interrupt` stops the
+        // writer, and the turn is closed with a `result` — which is what `claude` does.
+        std::fs::write(
+            &script,
+            r#"#!/bin/sh
+d=`dirname "$0"`
+echo "$$" >> "$d/spawns"
+n=0
+while IFS= read -r line; do
+  case "$line" in
+    *'"subtype":"interrupt"'*)
+      : > "$d/stop"
+      id=`printf '%s' "$line" | sed 's/.*"request_id":"\([^"]*\)".*/\1/'`
+      printf '{"type":"control_response","response":{"subtype":"success","request_id":"%s","response":{}}}\n' "$id"
+      continue
+      ;;
+    *control_request*)
+      id=`printf '%s' "$line" | sed 's/.*"request_id":"\([^"]*\)".*/\1/'`
+      printf '{"type":"control_response","response":{"subtype":"success","request_id":"%s","response":{"totalTokens":10,"maxTokens":100}}}\n' "$id"
+      continue
+      ;;
+  esac
+  n=`expr $n + 1`
+  rm -f "$d/stop"
+  printf '{"type":"system","subtype":"init","session_id":"s","slash_commands":[]}\n'
+  m=$n
+  (
+    i=1
+    while [ $i -le 6 ]; do
+      if [ -f "$d/stop" ]; then break; fi
+      printf '{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"T%s-%s "}}}\n' "$m" "$i"
+      sleep 1
+      i=`expr $i + 1`
+    done
+    printf '{"type":"result","subtype":"success","is_error":false,"session_id":"s","result":""}\n'
+  ) &
+done
+"#,
+        )
+        .expect("script");
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+        let p = ClaudeCliProvider::new(script.display().to_string());
+        let said = |evs: &[ProviderEvent]| {
+            evs.iter()
+                .filter_map(|e| match e {
+                    ProviderEvent::TextDelta { text, .. } => Some(text.clone()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("")
+        };
+
+        // Turn one, cut off the way `<Esc>` cuts one off: the token is cancelled and the consumer
+        // lets go of the stream at once.
+        let cancel = CancellationToken::new();
+        let mut first = p.stream(&inst(), req("claude-opus-5"), cancel.clone());
+        let mut got = Vec::new();
+        while let Some(ev) = first.next().await {
+            let stop = matches!(&ev, ProviderEvent::TextDelta { text, .. } if text.starts_with("T1-2"));
+            got.push(ev);
+            if stop {
+                break;
+            }
+        }
+        assert!(said(&got).contains("T1-1"), "the first turn said something: {:?}", said(&got));
+        cancel.cancel();
+        drop(first);
+
+        // Long enough for the interrupted turn to have been drained, and for anything it was
+        // still writing to have been written.
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        // Turn two, on the same conversation and therefore the same process.
+        let second: Vec<_> =
+            p.stream(&inst(), req("claude-opus-5"), CancellationToken::new()).collect().await;
+        let text = said(&second);
+        assert!(
+            !text.contains("T1-"),
+            "the interrupted answer arrived under the next question: {text:?}"
+        );
+        assert!(text.contains("T2-"), "and the next question was answered: {text:?}");
+        let spawned = std::fs::read_to_string(dir.join("spawns")).unwrap_or_default();
+        assert_eq!(
+            spawned.lines().count(),
+            1,
+            "the conversation kept the CLI it started with: {spawned:?}"
+        );
+
+        p.shutdown(&neosh_proto::SessionId::from("test"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Interrupting a turn does not cost the conversation its agent.
+    ///
+    /// The last thing an ending turn does is ask the CLI how full its context is, on a two-second
+    /// deadline — an extra, and one an install is perfectly entitled to answer with nothing useful
+    /// or not at all. On an *interrupted* turn that deadline was the same timer the interrupt had
+    /// armed, and its expiry was read as "asked to stop and did not": the process was killed, and
+    /// the next question in that conversation started a second `claude` and resumed into it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_interrupt_does_not_kill_a_cli_that_stopped_when_it_was_asked() {
+        use futures::StreamExt;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join(format!("neosh-keepcli-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("dirs");
+        let script = dir.join("fake-claude");
+        // It stops the moment it is asked to and says so — and it answers control requests without
+        // token counts, which is all an install that does not report context usage can do. That is
+        // what leaves the closing question unanswered and the deadline to expire.
+        std::fs::write(
+            &script,
+            r#"#!/bin/sh
+d=`dirname "$0"`
+echo "$$" >> "$d/spawns"
+n=0
+while IFS= read -r line; do
+  case "$line" in
+    *'"subtype":"interrupt"'*)
+      : > "$d/stop"
+      id=`printf '%s' "$line" | sed 's/.*"request_id":"\([^"]*\)".*/\1/'`
+      printf '{"type":"control_response","response":{"subtype":"success","request_id":"%s","response":{}}}\n' "$id"
+      continue
+      ;;
+    *control_request*)
+      id=`printf '%s' "$line" | sed 's/.*"request_id":"\([^"]*\)".*/\1/'`
+      printf '{"type":"control_response","response":{"subtype":"success","request_id":"%s","response":{}}}\n' "$id"
+      continue
+      ;;
+  esac
+  n=`expr $n + 1`
+  rm -f "$d/stop"
+  printf '{"type":"system","subtype":"init","session_id":"s","slash_commands":[]}\n'
+  m=$n
+  (
+    i=1
+    while [ $i -le 40 ]; do
+      if [ -f "$d/stop" ]; then break; fi
+      printf '{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"T%s-%s "}}}\n' "$m" "$i"
+      sleep 0.2
+      i=`expr $i + 1`
+    done
+    printf '{"type":"result","subtype":"success","is_error":false,"session_id":"s","result":""}\n'
+  ) &
+done
+"#,
+        )
+        .expect("script");
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+        let p = ClaudeCliProvider::new(script.display().to_string());
+        let cancel = CancellationToken::new();
+        let mut first = p.stream(&inst(), req("claude-opus-5"), cancel.clone());
+        while let Some(ev) = first.next().await {
+            if matches!(&ev, ProviderEvent::TextDelta { text, .. } if text.starts_with("T1-1")) {
+                break;
+            }
+        }
+        // `<Esc>`: the token is cancelled and the consumer lets go, exactly as the turn loop does.
+        cancel.cancel();
+        drop(first);
+
+        // Longer than either deadline the turn can arm, so a process that was going to be killed
+        // has been.
+        tokio::time::sleep(Duration::from_secs(6)).await;
+
+        let second: Vec<_> =
+            p.stream(&inst(), req("claude-opus-5"), CancellationToken::new()).collect().await;
+        assert!(
+            second.iter().any(|e| matches!(e, ProviderEvent::TextDelta { text, .. } if text.starts_with("T2-"))),
+            "the next question is answered by the CLI that already knows this conversation"
+        );
+        let spawned = std::fs::read_to_string(dir.join("spawns")).unwrap_or_default();
+        assert_eq!(
+            spawned.lines().count(),
+            1,
+            "and it is the same one: {spawned:?}"
+        );
+
+        p.shutdown(&neosh_proto::SessionId::from("test"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A one-shot generation borrows the model and gives it back.
+    ///
+    /// A branch name or a thread title is nobody's conversation — [`TurnRequest::conversation`] is
+    /// empty and says so. Keyed into the live map by that empty id, every one of them shared a
+    /// process that nothing ever closed: a second `claude`, with the same flags as the one
+    /// answering you, running for as long as the workspace did.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_one_shot_generation_does_not_leave_a_cli_behind() {
+        use futures::StreamExt;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join(format!("neosh-oneshot-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("dirs");
+        let script = dir.join("fake-claude");
+        // It answers, and then reports when its stdin is closed — which is how a `--print` session
+        // is told there are no more messages coming, and the only way to see that it was told.
+        std::fs::write(
+            &script,
+            r#"#!/bin/sh
+d=`dirname "$0"`
+while IFS= read -r line; do
+  case "$line" in
+    *control_request*)
+      id=`printf '%s' "$line" | sed 's/.*"request_id":"\([^"]*\)".*/\1/'`
+      printf '{"type":"control_response","response":{"subtype":"success","request_id":"%s","response":{"totalTokens":10,"maxTokens":100}}}\n' "$id"
+      continue
+      ;;
+  esac
+  printf '{"type":"system","subtype":"init","session_id":"s","slash_commands":[]}\n'
+  printf '{"type":"result","subtype":"success","is_error":false,"session_id":"s","result":"a-name"}\n'
+done
+echo done > "$d/closed"
+"#,
+        )
+        .expect("script");
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+        let p = ClaudeCliProvider::new(script.display().to_string());
+        let mut one_shot = req("claude-opus-5");
+        one_shot.conversation = neosh_proto::SessionId::from("");
+        assert!(one_shot.is_one_shot(), "that is what an empty conversation means");
+        let evs: Vec<_> = p.stream(&inst(), one_shot, CancellationToken::new()).collect().await;
+        assert!(
+            evs.iter().any(|e| matches!(e, ProviderEvent::TextDelta { text, .. } if text == "a-name")),
+            "it still answers"
+        );
+
+        for _ in 0..200 {
+            if dir.join("closed").exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        assert!(dir.join("closed").exists(), "and the process it borrowed was given back");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
 }

--- a/crates/neosh-provider/src/drivers/codex_cli.rs
+++ b/crates/neosh-provider/src/drivers/codex_cli.rs
@@ -807,7 +807,14 @@ impl Provider for CodexCliProvider {
     ) -> ProviderStream {
         let (tx, rx) = mpsc::channel::<ProviderEvent>(256);
         let program = self.program.clone();
-        let slot = self.slot(&request.conversation);
+        // A one-shot — a branch name, a thread title — belongs to no conversation, so it gets a
+        // slot nobody else can find and the app-server is let go of at the end of it. Keyed into
+        // the map instead, every one of them shared a process that nothing ever closed.
+        let one_shot = request.is_one_shot();
+        let slot = match one_shot {
+            true => Arc::new(Conversation::default()),
+            false => self.slot(&request.conversation),
+        };
         let mode = *self.mode.lock().expect("mode lock poisoned");
         let asker = self.asker.lock().expect("asker lock poisoned").clone();
 
@@ -821,6 +828,10 @@ impl Provider for CodexCliProvider {
                 // has gone.
                 *guard = None;
                 let _ = tx.send(ProviderEvent::Error { message, retryable: false }).await;
+            }
+            // Nothing is coming back to this one.
+            if one_shot && let Some(live) = guard.take() {
+                live.close().await;
             }
         });
 

--- a/crates/neosh/tests/fixtures/two_answers.jsonl
+++ b/crates/neosh/tests/fixtures/two_answers.jsonl
@@ -1,0 +1,36 @@
+{"type": "message_start", "model": "mock", "usage": {}}
+{"type": "block_start", "index": 0, "block": {"kind": "text"}}
+{"type": "text_delta", "index": 0, "text": "ANSWER"}
+{"type": "text_delta", "index": 0, "text": "-"}
+{"type": "text_delta", "index": 0, "text": "ONE"}
+{"type": "block_stop", "index": 0}
+{"type": "message_delta", "stop_reason": {"kind": "end_turn"}, "usage": {"output_tokens": 3}}
+{"type": "message_stop"}
+
+{"type": "message_start", "model": "mock", "usage": {}}
+{"type": "block_start", "index": 0, "block": {"kind": "text"}}
+{"type": "text_delta", "index": 0, "text": "ANSWER-LATER"}
+{"type": "block_stop", "index": 0}
+{"type": "message_delta", "stop_reason": {"kind": "end_turn"}, "usage": {"output_tokens": 3}}
+{"type": "message_stop"}
+
+{"type": "message_start", "model": "mock", "usage": {}}
+{"type": "block_start", "index": 0, "block": {"kind": "text"}}
+{"type": "text_delta", "index": 0, "text": "ANSWER-LATER"}
+{"type": "block_stop", "index": 0}
+{"type": "message_delta", "stop_reason": {"kind": "end_turn"}, "usage": {"output_tokens": 3}}
+{"type": "message_stop"}
+
+{"type": "message_start", "model": "mock", "usage": {}}
+{"type": "block_start", "index": 0, "block": {"kind": "text"}}
+{"type": "text_delta", "index": 0, "text": "ANSWER-LATER"}
+{"type": "block_stop", "index": 0}
+{"type": "message_delta", "stop_reason": {"kind": "end_turn"}, "usage": {"output_tokens": 3}}
+{"type": "message_stop"}
+
+{"type": "message_start", "model": "mock", "usage": {}}
+{"type": "block_start", "index": 0, "block": {"kind": "text"}}
+{"type": "text_delta", "index": 0, "text": "ANSWER-LATER"}
+{"type": "block_stop", "index": 0}
+{"type": "message_delta", "stop_reason": {"kind": "end_turn"}, "usage": {"output_tokens": 3}}
+{"type": "message_stop"}

--- a/crates/neosh/tests/workspace.rs
+++ b/crates/neosh/tests/workspace.rs
@@ -772,3 +772,226 @@ fn asking_again_clears_the_mark_a_killed_turn_left() {
         "a finished turn left the previous turn's mark behind:\n{after}"
     );
 }
+
+/// The whole sequence from the report: interrupt mid-answer, close the terminal, open it again,
+/// ask something else. What comes back must answer the new question and not finish the old one.
+#[test]
+fn what_an_interrupted_turn_was_saying_does_not_arrive_under_the_next_question() {
+    let sb = Sandbox::new("crossed");
+    let ws = sb.serve_paced("two_answers.jsonl", 900);
+
+    let mut first = Client::attach(&ws.socket, neosh_proto::PROTOCOL_VERSION);
+    first.ready();
+    first.ask("question one");
+    first.until("the first answer to start arriving", |c| c.shows("ANSWER"));
+    // `^C` on a running turn interrupts it, which is the first rung of that key and not the last.
+    first.ctrl('c');
+    first.until("the turn to stop", |c| !c.shows("esc to interrupt"));
+    first.leave();
+    first.until("the first terminal to go", |c| c.ended.is_some());
+
+    let mut second = Client::attach(&ws.socket, neosh_proto::PROTOCOL_VERSION);
+    second.ready();
+    second.until("the conversation to come back", |c| c.shows("question one"));
+    second.ask("question two");
+    second.until("an answer to it", |c| c.shows("ANSWER-LATER"));
+    second.until("the turn to be over", |c| !c.shows("esc to interrupt"));
+
+    // Long enough for anything the interrupted turn was still writing to have been written.
+    std::thread::sleep(Duration::from_millis(2000));
+    second.pump_once();
+    let t = second.transcript();
+    let at = t.iter().position(|l| l.contains("question two")).expect("the second question");
+    assert!(
+        !t.iter().skip(at).any(|l| l.contains("ANSWER-ONE")),
+        "the interrupted turn finished itself under the new question: {t:#?}"
+    );
+}
+
+#[test]
+fn reattaching_while_a_turn_runs_shows_it_still_running() {
+    // "I want to see the running ones when I open it again." A terminal that goes away mid-answer
+    // and comes back has to find the turn where it left it — the question, what has been said so
+    // far, and a working line that is still working — rather than a transcript that ends on a
+    // question nothing appears to be answering.
+    let sb = Sandbox::new("stillrunning");
+    let ws = sb.serve_paced("two_answers.jsonl", 900);
+
+    let mut first = Client::attach(&ws.socket, neosh_proto::PROTOCOL_VERSION);
+    first.ready();
+    first.ask("keep at it");
+    first.until("the first answer to start arriving", |c| c.shows("ANSWER"));
+    first.leave();
+    first.until("the first terminal to go", |c| c.ended.is_some());
+
+    let mut second = Client::attach(&ws.socket, neosh_proto::PROTOCOL_VERSION);
+    second.ready();
+    second.until("the question to be back", |c| c.shows("keep at it"));
+    second.until("what it had already said", |c| c.shows("ANSWER-"));
+    second.until("and a turn that still looks like one", |c| c.shows("esc to interrupt"));
+    second.until("which then finishes here", |c| !c.shows("esc to interrupt"));
+}
+
+/// A sandbox whose `claude` is a stand-in that logs every time it is started.
+///
+/// The real failure is a *process* count, so nothing short of a real program on `PATH` can see it:
+/// a mock provider is one object and cannot be spawned twice. Every line it says names the process
+/// that said it, which is what tells one CLI answering twice from two CLIs answering once each.
+const FAKE_CLAUDE: &str = r#"#!/bin/sh
+L="$NEOSH_FAKE_LOG"
+case "$1" in
+  --version) echo "2.2.0 (Claude Code)"; exit 0 ;;
+esac
+echo "`date +%s.%N` $$ $*" >> "$L/spawns"
+n=0
+while IFS= read -r line; do
+  case "$line" in
+    *interrupt*)
+      : > "$L/stop.$$"
+      id=`printf '%s' "$line" | sed 's/.*"request_id":"\([^"]*\)".*/\1/'`
+      printf '{"type":"control_response","response":{"subtype":"success","request_id":"%s","response":{}}}\n' "$id"
+      continue ;;
+    *control_request*)
+      id=`printf '%s' "$line" | sed 's/.*"request_id":"\([^"]*\)".*/\1/'`
+      printf '{"type":"control_response","response":{"subtype":"success","request_id":"%s","response":{"totalTokens":10,"maxTokens":100}}}\n' "$id"
+      continue ;;
+  esac
+  n=`expr $n + 1`
+  rm -f "$L/stop.$$"
+  printf '{"type":"system","subtype":"init","session_id":"s%s","slash_commands":[]}\n' "$$"
+  m=$n
+  p=$$
+  (
+    i=1
+    while [ $i -le 8 ]; do
+      if [ -f "$L/stop.$p" ]; then break; fi
+      printf '{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"<p%s.q%s.%s>"}}}\n' "$p" "$m" "$i"
+      sleep 1
+      i=`expr $i + 1`
+    done
+    printf '{"type":"result","subtype":"success","is_error":false,"session_id":"s%s","result":""}\n' "$p"
+  ) &
+done
+"#;
+
+/// Install the stand-in and start a workspace pointed at it. Returns the workspace and its log.
+fn serve_with_fake_claude(sb: &Sandbox) -> (Workspace, PathBuf) {
+    let bin = sb.root.join("bin");
+    let log = sb.root.join("log");
+    std::fs::create_dir_all(&bin).expect("bin");
+    std::fs::create_dir_all(&log).expect("log");
+    let script = bin.join("claude");
+    // Written by a child, never through a descriptor this process holds open: a writable fd on a
+    // program a sibling test is about to `execve` is how `ETXTBSY` happens.
+    let wrote = Command::new("/bin/sh")
+        .args(["-c", r#"printf '%s' "$1" > "$2" && chmod 755 "$2""#, "neosh-test-write"])
+        .arg(FAKE_CLAUDE)
+        .arg(&script)
+        .status()
+        .expect("a shell to write the stand-in");
+    assert!(wrote.success(), "writing the stand-in failed");
+
+    let child = sb
+        .neosh(&["--serve", "--model", "claude-cli/claude-opus-5"])
+        .env("PATH", format!("{}:{}", bin.display(), std::env::var("PATH").unwrap_or_default()))
+        .env("NEOSH_FAKE_LOG", &log)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn workspace");
+    let socket = sb.socket();
+    let deadline = Instant::now() + PATIENCE;
+    while Instant::now() < deadline && UnixStream::connect(&socket).is_err() {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    (Workspace { child, socket }, log)
+}
+
+/// Every CLI the stand-in was asked to be, as (pid, argv).
+fn spawns(log: &Path) -> Vec<(String, String)> {
+    std::fs::read_to_string(log.join("spawns"))
+        .map(|s| {
+            s.lines()
+                .filter_map(|l| {
+                    let mut parts = l.splitn(3, ' ');
+                    let _when = parts.next()?;
+                    Some((parts.next()?.to_string(), parts.next().unwrap_or("").to_string()))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Which of them are still running. The whole symptom is a process count, so this is the assertion.
+fn still_alive(log: &Path) -> Vec<String> {
+    spawns(log)
+        .into_iter()
+        .map(|(pid, _)| pid)
+        .filter(|pid| {
+            Command::new("kill")
+                .args(["-0", pid])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+/// Which process said the last thing in the transcript. Every line the stand-in emits names it.
+fn answering_pid(t: &[String], after: &str) -> Option<String> {
+    let at = t.iter().position(|l| l.contains(after))?;
+    let line = t.iter().skip(at + 1).find(|l| l.contains("<p"))?;
+    let start = line.find("<p")? + 2;
+    let end = line[start..].find('.')? + start;
+    Some(line[start..end].to_string())
+}
+
+/// One conversation is one agent, and interrupting it does not start another.
+///
+/// The report this comes from: `^C` mid-answer, quit, reopen, ask again — and two `claude`
+/// processes running under one workspace with one conversation in it. Both halves are here because
+/// they were two separate faults that looked like one: a one-shot generation (the thread's title)
+/// took a slot in the map keyed by conversation and held a whole agent session open forever, and
+/// an interrupt ended by killing the CLI it had already stopped politely.
+#[test]
+fn one_conversation_runs_one_agent_across_an_interrupt() {
+    let sb = Sandbox::new("oneagent");
+    let (ws, log) = serve_with_fake_claude(&sb);
+
+    let mut c = Client::attach(&ws.socket, neosh_proto::PROTOCOL_VERSION);
+    c.ready();
+    c.ask("question one");
+    c.until("the first answer to start arriving", |c| c.shows(".q1.1>"));
+    let first = answering_pid(&c.transcript(), "question one").expect("somebody answered");
+
+    c.ctrl('c');
+    std::thread::sleep(Duration::from_millis(2000));
+    c.leave();
+    c.until("the terminal to go", |c| c.ended.is_some());
+
+    let mut back = Client::attach(&ws.socket, neosh_proto::PROTOCOL_VERSION);
+    back.ready();
+    back.ask("question two");
+    back.until("an answer to the second question", |c| {
+        answering_pid(&c.transcript(), "question two").is_some()
+    });
+    let second = answering_pid(&back.transcript(), "question two").expect("somebody answered");
+    assert_eq!(second, first, "the interrupt threw the conversation's agent away and started another");
+
+    // Everything a one-shot borrowed is given back when it is finished with, so what is left is
+    // the conversation's own agent and nothing else. Waited for rather than sampled: a one-shot is
+    // a turn like any other and takes as long as the model does.
+    let deadline = Instant::now() + PATIENCE;
+    while Instant::now() < deadline && still_alive(&log).len() > 1 {
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    assert_eq!(
+        still_alive(&log),
+        vec![first],
+        "one conversation, one agent — spawned {:?}",
+        spawns(&log)
+    );
+}


### PR DESCRIPTION
A conversation had two `claude` processes under it, spawned milliseconds apart with identical
arguments, both held open by the workspace for as long as it lived. Reported as "two agents
running", and confirmed against a live workspace: one conversation, one running turn, two children.

```
neosh --serve
  ├─ claude --print … --effort high   cwd=…/wily-zephyr
  └─ claude --print … --effort high   cwd=…/wily-zephyr   ← 3 ms later, same argv
```

Two separate faults that looked like one.

### A one-shot generation kept a whole agent

A branch name, a thread title, a commit message — `Agent::complete` — names no conversation.
`TurnRequest::conversation` says so by being empty, and the field's own documentation says a driver
keying state by it must treat that as "keep nothing". Both vendor-CLI drivers keyed on it anyway,
and empty is a perfectly ordinary map key: every one-shot in the workspace shared one slot, and
nothing ever emptied it. So the first title generated in a session left a whole agent running —
same flags, same access as the one answering you — until the workspace stopped.

`TurnRequest::is_one_shot` is now the question both drivers ask, and a one-shot gets a slot nobody
else can find and a process closed when its turn ends.

### An interrupt killed a CLI that had stopped when it was asked

The last thing an ending turn does is ask the CLI how full its context is, on a two-second
deadline. On an interrupted turn that was the same timer the interrupt had armed five seconds
earlier, and its expiry was read as "asked to stop and did not" — so a CLI that stopped exactly
when it was asked to was killed anyway, and the next question in that conversation started a
second one and resumed into it. An install that answers the closing question without token counts,
or not at all, took that path every time.

The question is not asked after an interrupt now, and the deadline is read as whatever armed it
last.

### Tests

Three, each verified to fail without the fix it names:

- `a_one_shot_generation_does_not_leave_a_cli_behind`
- `an_interrupt_does_not_kill_a_cli_that_stopped_when_it_was_asked`
- `one_conversation_runs_one_agent_across_an_interrupt` — the whole reported sequence, against a
  real workspace over a real socket: ask, `^C` mid-answer, close the terminal, reopen, ask again.
  Asserts that what is still running at the end is one agent and that it is the one the
  conversation started with.

The two driver-level tests drive a real stand-in `claude` on `PATH` and count processes: the
symptom is a *process count*, and a mock provider is one object that cannot be spawned twice.

Also `reattaching_while_a_turn_runs_shows_it_still_running`, which locks down the half that already
worked — reopening a terminal mid-answer finds the question, what had been said, and a live working
line.

### Verification

Green: `neosh-provider` (186), `workspace` (19), `neosh-core`, `neosh-agent`, `builtin_plugins`
(153), `plugin_manager`, `sessions`, `approvals`, `questions`, `reading`, `editing`, `user_config`.
TS bindings regenerated and unchanged. `npx tsc --noEmit` could not run here — TypeScript is not
installed in `plugins/api` — and no TypeScript changed.

### Not covered

The crossed answers in the original report could not be reproduced on their own: the drain that
stops an abandoned turn's output landing under the next question tested clean on both the mock and
the CLI path. The likeliest explanation is the second fault above — a CLI killed mid-answer, with
the replacement resuming into a session whose last turn was cut off.