### PR TITLE
A turn is something you can watch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,6 +340,19 @@ per decision, and records the *reasoning*, not the choice.
   (`└`) at a four-column indent rather than a rule down the whole left side. Air between every two
   actions and a wall beside every diff were both structure said twice — the header is at column
   zero, the body is indented, and that is already a list. See ADR 0040 and ADR 0050.
+- **A turn is something you can watch, not only something you read back.** A command is named by
+  what it *does* and never by how it got there: a leading `cd /home/you/projects/thing &&` is the
+  one part of that row you already knew — the conversation has a directory — and clipped to a
+  header it is the only part that fits, so it comes off before the command is named and a stack of
+  six folds to what was run rather than to `cd, cd, cd`. Reading is a place, and a turn writes
+  below it: parked on the **last row** you are carried along with what arrives, anywhere else you
+  stay exactly where you are, and neither happens while a selection or a search is holding two
+  positions. And **the card the cursor is in is open** — ADR 0049's rule one surface along, bounded
+  by `chat.preview_lines` because nine hundred rows appearing under `j` is what the fold exists to
+  prevent, and never fewer rows than the folded card showed. `⇥` stops meaning "open this" and
+  starts meaning "keep it", `c`/`C` step call to call because `[`/`]` is a whole turn and `{`/`}`
+  is one block for a run of nine cards, and a preview never fires while the tail is carrying you:
+  following is watching, and a redraw settles the answer streaming above it. See ADR 0057.
 - **A terminal cannot paste a picture, so pasting one is a key.** Bracketed paste is a text
   protocol: a screenshot arrives as nothing, and a dragged file arrives as its path. `^V` asks the
   system clipboard through whichever of `wl-paste`/`xclip`/`pngpaste`/`osascript`/`powershell` is
@@ -582,8 +595,9 @@ on it, which after wrapping is not the window's height. See ADR 0051.
 | `H` `M` `L` | The top, middle and bottom row **of the window** |
 | `zz` `zt` `zb` | Put the cursor's line in the middle, at the top, at the bottom |
 | `[` `]` | Previous / next **turn** |
+| `c` `C` | Next / previous **tool call**. A count first: `3c`. The card you land on opens itself |
 | `{` `}` | Previous / next **block** |
-| `⇥` `za` | Open or fold the **tool card** under the cursor — the whole diff, the whole output |
+| `⇥` `za` | *Keep* the **tool card** under the cursor open — all of it, and it stays that way when you move off |
 | `/` `?` then `n` `N` | Search, and step through the matches. `n` is *onwards*, so after `?` it goes up |
 | `*` `#` | Search for the word under the cursor, forwards or back |
 | `v` | Start a selection that motions extend. Again, or on a `V` selection, gives it up |
@@ -604,7 +618,14 @@ on it, which after wrapping is not the window's height. See ADR 0051.
 
 There is no `^V`: a blockwise selection is a rectangle rather than a range, and every consumer of a
 selection would have to grow a case for it. The key says so rather than doing nothing. Nothing here
-edits, either — no `d`, `c`, `x` or `p`. The transcript is an artefact you take pieces out of.
+edits, either — no `d`, `x` or `p`, and `c` is a motion here rather than a change. The transcript
+is an artefact you take pieces out of.
+
+**The card you are standing on is open.** Everything a fold hides, up to `chat.preview_lines`, for
+as long as the cursor is in it — so `c c c` walks a turn's work one call at a time and the rows go
+back as you leave. `⇥` is how you keep one. And **reading the last row keeps reading it**: a turn
+still running writes below you, and if you are parked at the end you are carried along with it.
+Anywhere else you stay exactly where you are — `G` starts following again. See ADR 0057.
 
 ## Answering a question — the panel over the composer
 

--- a/crates/neosh/src/cards.rs
+++ b/crates/neosh/src/cards.rs
@@ -183,6 +183,60 @@ pub struct Limits {
     pub diff_lines: usize,
     /// Lines of any other result.
     pub output_lines: usize,
+    /// Rows the card the cursor is in gets instead, while reading. See [`Open::Preview`].
+    pub preview_lines: usize,
+}
+
+/// How much of a card's body is on screen, and why.
+///
+/// Three states rather than two, because the two answers a transcript needs are not the same
+/// question. *How much does a card cost when nobody is looking at it* is a setting — the
+/// [`Limits`] — and the answer has to be small, or a turn that read six files fills a screen with
+/// the parts of them nobody asked about. *How much does the card I am looking at right now show*
+/// is the cursor's question, it is asked about exactly one card, and the answer costs nothing that
+/// moving off the card does not give straight back.
+///
+/// Which is [ADR 0049](../../../docs/adr/0049-a-list-is-a-place-you-move-in.md)'s rule, one surface
+/// along: the row you are *in* stays unfolded, and only ever one row. A transcript is a list you
+/// move in as much as the project panel is.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum Open {
+    /// What every card is when the cursor is somewhere else: the header, and whatever a fold
+    /// keeps under it — an edit's diff, the last output of a stack of commands.
+    #[default]
+    Folded,
+    /// The card the cursor is in. Everything a fold hides, up to [`Limits::preview_lines`].
+    ///
+    /// Bounded on purpose. A card that read a nine-hundred-line file would otherwise drop nine
+    /// hundred rows under the cursor on the way past, and `j` would stop being a key you can
+    /// predict — which is the whole reason the fold exists.
+    Preview,
+    /// All of it, and it stays that way when the cursor leaves. `\u{21e5}`.
+    Full,
+}
+
+impl Limits {
+    /// How many rows of a result a card in this state pays for. [`usize::MAX`] is all of them.
+    ///
+    /// Never *fewer* than the folded card showed. A preview is what the cursor buys you and a
+    /// setting is the floor it buys on top of: with `chat.tool_output_lines = 40`, stepping onto a
+    /// card must not take thirty rows away.
+    fn output(self, open: Open) -> usize {
+        match open {
+            Open::Folded => self.output_lines,
+            Open::Preview => self.preview_lines.max(self.output_lines),
+            Open::Full => usize::MAX,
+        }
+    }
+
+    /// The same, for the rows of a diff.
+    fn diff(self, open: Open) -> usize {
+        match open {
+            Open::Folded => self.diff_lines,
+            Open::Preview => self.preview_lines.max(self.diff_lines),
+            Open::Full => usize::MAX,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -774,14 +828,17 @@ pub fn group_body(
     heads: &[Head],
     root: &std::path::Path,
     limits: Limits,
-    expanded: bool,
+    open: Open,
     width: usize,
 ) -> Vec<Row> {
     // A stack of commands is the other kind of run, and it keeps an output. See [`run_body`].
     if heads.first().is_some_and(|h| runs_a_command(h.input)) {
-        return run_body(g, heads, root, limits, expanded, width);
+        return run_body(g, heads, root, limits, open, width);
     }
-    if !expanded {
+    // A preview is the same as an opening here, and deliberately: what this fold keeps out of the
+    // transcript is the *contents* of the six files, and the names it gives back instead are one
+    // row each however you asked for them.
+    if open == Open::Folded {
         return Vec::new();
     }
     let margin = g.margin();
@@ -838,9 +895,16 @@ fn run_body(
     heads: &[Head],
     root: &std::path::Path,
     limits: Limits,
-    expanded: bool,
+    open: Open,
     width: usize,
 ) -> Vec<Row> {
+    // **A preview is a bigger budget, not an opening.** Opening a stack means a row per command
+    // *and* an output under each one, and at `preview_lines` apiece a nine-command stack would
+    // drop a hundred and fifty rows under the cursor on the way past — which is exactly what the
+    // bound exists to prevent. So the cursor buys more of the one output that was already showing,
+    // and `\u{21e5}` is what buys the other eight. A run of reads is not this: a row per call is
+    // one row per call, and that is bounded by the card. See ADR 0057.
+    let opened = open == Open::Full;
     let margin = g.margin();
     let deeper = format!("{margin}    ");
     let mut rows: Vec<Row> = Vec::new();
@@ -849,12 +913,12 @@ fn run_body(
     // failed, wherever it is in the stack: a run does not usually continue past a failure, but
     // calls made in parallel land in whatever order they land in, and a fold is about noise.
     let shown: Vec<usize> = (0..heads.len())
-        .filter(|&i| expanded || i + 1 == heads.len() || heads[i].state == ToolState::Failed)
+        .filter(|&i| opened || i + 1 == heads.len() || heads[i].state == ToolState::Failed)
         .collect();
     // Whose output this is only has to be said when more than one of them is saying anything.
     // Folded to the last command alone, the stack above it is the header's list and a row naming
     // it again is a row spent repeating the line above.
-    let named = expanded || shown.len() > 1;
+    let named = opened || shown.len() > 1;
     let room = width.saturating_sub(margin.chars().count()).max(8);
 
     for i in shown {
@@ -871,7 +935,7 @@ fn run_body(
         }
         if let Some(result) = h.result {
             let under = if named { &deeper } else { &margin };
-            rows.extend(result_rows(g, result, limits.output_lines, expanded, width, under));
+            rows.extend(result_rows(g, result, limits.output(open), width, under));
         }
     }
     attach(g, &mut rows);
@@ -1085,9 +1149,64 @@ fn subject(input: &serde_json::Value) -> Option<(&'static str, String)> {
     let map = input.as_object()?;
     KEYS.iter().find_map(|key| {
         let v = map.get(*key)?.as_str()?;
+        // A command is named by what it does, never by how it got there.
+        let v = if *key == "command" { without_leading_cd(v) } else { v };
         let one = v.lines().next().unwrap_or(v).trim();
         (!one.is_empty()).then(|| (*key, one.to_string()))
     })
+}
+
+/// A command with the getting-there taken off the front.
+///
+/// A vendor CLI that cannot keep a working directory between calls writes every one of them as
+/// `cd /home/you/projects/thing && cargo test`, and the card is then forty columns of the one
+/// part you already knew: the conversation has a directory, the sidebar says which, and every
+/// path on every other card is drawn relative to it. Clipped to the row a header actually has,
+/// it is *all* you can see — a column of `Ran  cd /home/you/projects/th\u{2026}`, six of them in a
+/// row, saying nothing about the six different things that were run. Folded into a stack it is
+/// worse: [`short_command`] stops at the `&&`, so `cd, cd, cd` is the summary of a stretch of the
+/// turn.
+///
+/// So the name is whatever comes after. Only a leading `cd` with one argument and a `&&` or a `;`
+/// behind it — that shape is unambiguously somebody arriving somewhere, and it repeats, because
+/// `cd a && cd b && make` is the same sentence said twice. Everything else is the command: `cd
+/// src` on its own is genuinely a `cd` and says so, `cd x || y` is a decision rather than a
+/// preamble, and a `cd` anywhere but the front is part of what was run.
+///
+/// The whole line is never lost — an opened stack gives every command back in full, which is
+/// where you go when the question is *which* directory.
+fn without_leading_cd(command: &str) -> &str {
+    let mut rest = command;
+    while let Some(after) = strip_cd(rest) {
+        rest = after;
+    }
+    rest
+}
+
+/// One `cd <somewhere> &&` off the front, or `None` if that is not what this starts with.
+fn strip_cd(command: &str) -> Option<&str> {
+    let after_cd = command.trim_start().strip_prefix("cd")?;
+    // `cdrom/build.sh` is not a `cd`. The word has to end.
+    if !after_cd.starts_with([' ', '\t']) {
+        return None;
+    }
+    let arg = after_cd.trim_start();
+    // The directory: one word, or one quoted run. Anything cleverer — a `$(…)`, a glob — is not
+    // the shape this is here for, and guessing at it is how a `cd` that mattered disappears.
+    // Sliced at the delimiter rather than split on it, and the delimiter kept: `cd /work;make`
+    // and `cd /work && make` are the same sentence with different spacing, and a `split_once` that
+    // eats the first `&` leaves a separator that no longer reads as one. An empty argument —
+    // `cd && make` — falls out of this for free, at index zero.
+    let after_arg = match arg.chars().next()? {
+        q @ ('"' | '\'') => arg[1..].find(q).map(|i| &arg[i + 2..])?,
+        _ => &arg[arg.find([' ', '\t', ';', '&', '|']).unwrap_or(arg.len())..],
+    };
+    let sep = after_arg.trim_start();
+    // `&&` and never a bare `&`: one is "and then", the other backgrounds what came before it.
+    let rest = sep.strip_prefix("&&").or_else(|| sep.strip_prefix(';'))?;
+    let rest = rest.trim_start();
+    // A `cd` with nothing behind it is the whole command, whatever the separator promised.
+    (!rest.is_empty()).then_some(rest)
 }
 
 /// What a call is about, in as little room as a list of them can spare.
@@ -1220,16 +1339,16 @@ pub fn body(
     input: &serde_json::Value,
     result: &neosh_proto::ToolResult,
     limits: Limits,
-    expanded: bool,
+    open: Open,
     width: usize,
 ) -> Vec<Row> {
     let mut rows = if !result.is_error && !edits_of(input).is_empty() {
-        diff_rows(g, &edits_of(input), limits.diff_lines, expanded, width)
-    } else if !result.is_error && !expanded && looks_at_something(input) {
+        diff_rows(g, &edits_of(input), limits.diff(open), open == Open::Full, width)
+    } else if !result.is_error && open == Open::Folded && looks_at_something(input) {
         // Folded to the header alone. The count is already on it, and `⇥` opens this.
         Vec::new()
     } else {
-        result_rows(g, result, limits.output_lines, expanded, width, &g.margin())
+        result_rows(g, result, limits.output(open), width, &g.margin())
     };
     attach(g, &mut rows);
     rows
@@ -1298,7 +1417,6 @@ fn result_rows(
     g: &Glyphs,
     result: &neosh_proto::ToolResult,
     limit: usize,
-    expanded: bool,
     width: usize,
     margin: &str,
 ) -> Vec<Row> {
@@ -1312,13 +1430,9 @@ fn result_rows(
 
     let all: Vec<&str> = body.lines().collect();
     let total = all.len();
-    let limit = if expanded {
-        total
-    } else if result.is_error {
-        limit.max(1)
-    } else {
-        limit
-    };
+    // An error ignores a limit of zero: a failure nobody can see is a debugging session, and the
+    // setting is about noise rather than about hiding failures.
+    let limit = if result.is_error { limit.max(1) } else { limit };
     if limit == 0 {
         let word = if total == 1 { "line" } else { "lines" };
         return vec![Row::plain(format!("{margin}{total} {word}"), hl)];
@@ -1395,7 +1509,7 @@ fn diff_rows(
     g: &Glyphs,
     changes: &[Change],
     limit: usize,
-    expanded: bool,
+    full: bool,
     width: usize,
 ) -> Vec<Row> {
     // The rows to show: every line of every change, with the unchanged stretches folded away
@@ -1405,7 +1519,7 @@ fn diff_rows(
         if c > 0 {
             pieces.push(Piece::Break);
         }
-        if expanded {
+        if full {
             pieces.extend((0..change.diff.lines.len()).map(|at| Piece::Line { change: c, at }));
             continue;
         }
@@ -1430,10 +1544,10 @@ fn diff_rows(
             }
         }
     }
-    if !expanded && limit == 0 {
+    if limit == 0 {
         return Vec::new();
     }
-    let shown = if expanded { pieces.len() } else { limit.min(pieces.len()) };
+    let shown = limit.min(pieces.len());
 
     let painted: Vec<Option<Vec<neosh_syntax::Spans>>> = changes.iter().map(paint).collect();
     // One width for the whole card, from every change in it, so the sign column does not step
@@ -1664,6 +1778,12 @@ mod tests {
 
     fn g() -> Glyphs {
         Glyphs::new(false)
+    }
+
+    /// A `Limits` for a test that is not about the preview: the cursor's budget is the folded
+    /// one, so `Open::Folded` and `Open::Preview` draw the same rows and the test can say either.
+    fn caps(diff_lines: usize, output_lines: usize) -> Limits {
+        Limits { diff_lines, output_lines, preview_lines: output_lines }
     }
 
     fn root() -> std::path::PathBuf {
@@ -1917,12 +2037,12 @@ mod tests {
             Head { output: Some(120), ..head("Read", &a, ToolState::Done) },
             Head { output: Some(3), ..head("Grep", &b, ToolState::Done) },
         ];
-        let limits = Limits { diff_lines: 12, output_lines: 3 };
+        let limits = caps(12, 3);
         assert!(
-            group_body(&g(), &heads, &root(), limits, false, 80).is_empty(),
+            group_body(&g(), &heads, &root(), limits, Open::Folded, 80).is_empty(),
             "folded, it is one row"
         );
-        let rows = group_body(&g(), &heads, &root(), limits, true, 80);
+        let rows = group_body(&g(), &heads, &root(), limits, Open::Full, 80);
         // Opened, every call gets its own row with the *whole* subject: the short names on the
         // folded row are the loose answer, and this is where it is exact.
         assert_eq!(texts(&rows), vec![
@@ -1934,7 +2054,7 @@ mod tests {
     /// A stretch of a turn spent running things is one row, and the answer is the last one's.
     #[test]
     fn a_stack_of_commands_keeps_the_last_answer() {
-        let limits = Limits { diff_lines: 12, output_lines: 3 };
+        let limits = caps(12, 3);
         let add = json!({ "command": "git add -A" });
         let commit = json!({ "command": "git commit -m 'fix the thing'" });
         let push = json!({ "command": "git push" });
@@ -1952,7 +2072,7 @@ mod tests {
             "  Ran  git add, git commit, git push"
         );
         // And under it the last one's output, and nothing from the two that got there.
-        assert_eq!(texts(&group_body(&g(), &heads, &root(), limits, false, 80)), vec![
+        assert_eq!(texts(&group_body(&g(), &heads, &root(), limits, Open::Folded, 80)), vec![
             "  \u{2514} To github.com:neoswarm/neosh",
             "       6759f10..c280938",
         ]);
@@ -1961,7 +2081,7 @@ mod tests {
     /// The fold is a summary and the key is the detail — for a command that means its output.
     #[test]
     fn an_opened_stack_is_every_command_in_full_with_what_it_printed() {
-        let limits = Limits { diff_lines: 12, output_lines: 1 };
+        let limits = caps(12, 1);
         let fmt = json!({ "command": "cargo fmt --check" });
         let test = json!({ "command": "cargo test -p neosh-core -- --test-threads 2" });
         let ok = neosh_proto::ToolResult::ok("all good");
@@ -1972,7 +2092,7 @@ mod tests {
         ];
         // Every one of them, the whole command line, and the whole of what it said — one indent
         // deeper, or the next command's name reads as another line of the output above it.
-        assert_eq!(texts(&group_body(&g(), &heads, &root(), limits, true, 80)), vec![
+        assert_eq!(texts(&group_body(&g(), &heads, &root(), limits, Open::Full, 80)), vec![
             "  \u{2514} Ran  cargo fmt --check",
             "        all good",
             "    Ran  cargo test -p neosh-core -- --test-threads 2",
@@ -1984,7 +2104,7 @@ mod tests {
     /// A fold is about noise, and a failure is not noise — wherever in the stack it landed.
     #[test]
     fn a_stack_never_folds_a_failure_away() {
-        let limits = Limits { diff_lines: 12, output_lines: 3 };
+        let limits = caps(12, 3);
         let build = json!({ "command": "cargo build" });
         let test = json!({ "command": "cargo test" });
         let broke = neosh_proto::ToolResult::error("error[E0308]: mismatched types");
@@ -1995,7 +2115,7 @@ mod tests {
         ];
         // Two outputs, so each says whose it is. `Card::takes` is what makes this rare — a run
         // does not continue past a failure — but calls made in parallel land in any order.
-        assert_eq!(texts(&group_body(&g(), &heads, &root(), limits, false, 80)), vec![
+        assert_eq!(texts(&group_body(&g(), &heads, &root(), limits, Open::Folded, 80)), vec![
             "  \u{2514} Ran  cargo build",
             "        error[E0308]: mismatched types",
             "    Ran  cargo test",
@@ -2037,8 +2157,9 @@ mod tests {
             ("NEOSH_STATE_DIR=/tmp/x cargo run", "cargo run"),
             ("ls -la /tmp", "ls"),
             ("./scripts/shot.py --cols 110", "./scripts/shot.py"),
+            // Getting there is not what it did. See [`without_leading_cd`].
+            ("cd crates && cargo test", "cargo test"),
             // Where it stops being one command, the name stops with it.
-            ("cd crates && cargo test", "cd crates"),
             ("grep -rn foo | wc -l", "grep"),
             ("for f in *.rs; do echo $f; done", "for f in"),
             // And something with no name in it at all is itself, as much as fits.
@@ -2048,6 +2169,94 @@ mod tests {
             let input = json!({ "command": command });
             assert_eq!(short_subject_of(&input, &root()), want, "{command}");
         }
+    }
+
+    /// A vendor CLI that cannot keep a working directory writes one on the front of every command
+    /// it runs, and the card is then forty columns of the directory the conversation is already
+    /// in. The name is what comes *after* it.
+    #[test]
+    fn a_command_is_named_by_what_it_did_and_not_by_how_it_got_there() {
+        for (command, want) in [
+            ("cd /work && cargo test -p neosh-core", "cargo test -p neosh-core"),
+            ("cd /work; cargo test", "cargo test"),
+            // Said twice is still one preamble.
+            ("cd /work && cd crates && make", "make"),
+            ("cd '/work/my project' && ls", "ls"),
+            ("cd \"/work/my project\" && ls", "ls"),
+            // Not a `cd`, and each for its own reason: a word that only starts with one, a
+            // decision rather than a preamble, one in the middle of what was run, and a `cd`
+            // that really is the whole of what happened.
+            ("cdrom/mount.sh && ls", "cdrom/mount.sh && ls"),
+            ("cd /work || exit 1", "cd /work || exit 1"),
+            ("make && cd /out && ls", "make && cd /out && ls"),
+            ("cd /work", "cd /work"),
+            ("cd /work &&", "cd /work &&"),
+        ] {
+            let input = json!({ "command": command });
+            assert_eq!(subject_of(&input, &root(), 200), want, "{command}");
+        }
+        // And the same answer on the row a folded stack gets, which is where it was worst: three
+        // commands under one `cd` used to fold to `cd /work, cd /work, cd /work`.
+        assert_eq!(
+            short_subject_of(&json!({ "command": "cd /work && cargo test -p neosh" }), &root()),
+            "cargo test"
+        );
+    }
+
+    /// The cursor's card shows more than a folded one and less than an opened one — and never
+    /// fewer rows than the folded card it replaced, whatever the settings say. See ADR 0057.
+    #[test]
+    fn the_card_the_cursor_is_in_is_worth_more_rows_than_the_ones_it_is_not() {
+        let input = json!({ "file_path": "/work/a.rs" });
+        let result = neosh_proto::ToolResult::ok(
+            (1..=40).map(|n| format!("line {n}")).collect::<Vec<_>>().join("\n"),
+        );
+        let limits = Limits { diff_lines: 12, output_lines: 3, preview_lines: 10 };
+        assert!(
+            body(&g(), &input, &result, limits, Open::Folded, 80).is_empty(),
+            "a read nobody is looking at is its header and the count on it"
+        );
+        // Ten lines of it and the row that says how many were left out.
+        let rows = body(&g(), &input, &result, limits, Open::Preview, 80);
+        let preview = texts(&rows);
+        assert_eq!(preview.len(), 11, "the cursor buys `preview_lines` of it: {preview:?}");
+        assert!(preview[1].contains("+30 lines"), "and says what it is still holding back");
+        assert_eq!(
+            body(&g(), &input, &result, limits, Open::Full, 80).len(),
+            40,
+            "and Tab buys all of it, with no trailer left to press"
+        );
+        // A stack of commands previews *more of the last output*, not every output: nine commands
+        // at `preview_lines` apiece is the flood the bound exists to stop. `\u{21e5}` is what opens
+        // the stack.
+        let one = neosh_proto::ToolResult::ok("first");
+        let two = neosh_proto::ToolResult::ok("second");
+        let (fmt, test) = (json!({ "command": "cargo fmt" }), json!({ "command": "cargo test" }));
+        let heads = [
+            Head { result: Some(&one), ..head("Bash", &fmt, ToolState::Done) },
+            Head { result: Some(&two), ..head("Bash", &test, ToolState::Done) },
+        ];
+        let rows = group_body(&g(), &heads, &root(), limits, Open::Preview, 80);
+        let stack = texts(&rows);
+        assert!(
+            stack.iter().any(|r| r.contains("second")) && !stack.iter().any(|r| r.contains("first")),
+            "the last one's output, with more room: {stack:?}"
+        );
+        let rows = group_body(&g(), &heads, &root(), limits, Open::Full, 80);
+        let stack = texts(&rows);
+        assert!(
+            stack.iter().any(|r| r.contains("first")),
+            "and Tab is every command in it: {stack:?}"
+        );
+
+        // A preview is a floor on top of the setting, never a ceiling under it.
+        let generous = Limits { diff_lines: 12, output_lines: 25, preview_lines: 10 };
+        let ran = json!({ "command": "cargo test" });
+        assert_eq!(
+            body(&g(), &ran, &result, generous, Open::Preview, 80).len(),
+            body(&g(), &ran, &result, generous, Open::Folded, 80).len(),
+            "stepping onto a card must not take rows away from it"
+        );
     }
 
     /// Reads with reads and commands with commands. A run is a row saying what a stretch of the
@@ -2140,7 +2349,7 @@ mod tests {
                    test cards::header ... ok\n\ntest result: ok. 12 passed";
         let result = neosh_proto::ToolResult::ok(out);
         let input = json!({ "command": "cargo test" });
-        let rows = body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 3 }, false, 90);
+        let rows = body(&g(), &input, &result, caps(12, 3), Open::Folded, 90);
         let t = texts(&rows);
         assert!(t[0].ends_with("Compiling neosh v0.1.0"), "one line of head: {t:?}");
         assert!(t[1].contains("\u{2026} +"), "then what was dropped: {t:?}");
@@ -2188,7 +2397,7 @@ mod tests {
         let new = old.replace("l10\n", "L10\n");
         let input = json!({ "file_path": "/work/a.rs", "old_string": old, "new_string": new });
         let result = neosh_proto::ToolResult::ok("ok");
-        let rows = body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 3 }, false, 80);
+        let rows = body(&g(), &input, &result, caps(12, 3), Open::Folded, 80);
         let t = texts(&rows);
         assert_eq!(t[0], "  \u{2514}   l8", "context first, no gap row at the top: {t:?}");
         assert!(t.iter().any(|r| r.ends_with("- l10")), "{t:?}");
@@ -2202,7 +2411,7 @@ mod tests {
         assert_eq!(rows.iter().filter(|r| r.band.is_some()).count(), 2, "context is not banded");
 
         // Cut by the limit, and the trailer counts exactly what the limit cut.
-        let rows = body(&g(), &input, &result, Limits { diff_lines: 3, output_lines: 3 }, false, 80);
+        let rows = body(&g(), &input, &result, caps(3, 3), Open::Folded, 80);
         let t = texts(&rows);
         assert_eq!(t.len(), 4, "{t:?}");
         assert!(t[3].contains("+3 lines"), "{t:?}");
@@ -2215,11 +2424,11 @@ mod tests {
         let new = old.replace("l5\n", "L5\n").replace("l25\n", "L25\n");
         let input = json!({ "file_path": "/work/a.rs", "old_string": old, "new_string": new });
         let result = neosh_proto::ToolResult::ok("ok");
-        let rows = body(&g(), &input, &result, Limits { diff_lines: 50, output_lines: 3 }, false, 80);
+        let rows = body(&g(), &input, &result, caps(50, 3), Open::Folded, 80);
         let t = texts(&rows);
         assert!(t.iter().any(|r| r.ends_with("\u{22ee} 15 unchanged")), "{t:?}");
         // Folded at the first change: the gap and everything after it are what is left.
-        let rows = body(&g(), &input, &result, Limits { diff_lines: 5, output_lines: 3 }, false, 80);
+        let rows = body(&g(), &input, &result, caps(5, 3), Open::Folded, 80);
         let t = texts(&rows);
         assert!(t.last().unwrap().contains("+22 lines"), "{t:?}");
     }
@@ -2230,7 +2439,7 @@ mod tests {
         let new = old.replace("l10\n", "L10\n");
         let input = json!({ "file_path": "/work/a.rs", "old_string": old, "new_string": new });
         let result = neosh_proto::ToolResult::ok("ok");
-        let rows = body(&g(), &input, &result, Limits { diff_lines: 2, output_lines: 3 }, true, 80);
+        let rows = body(&g(), &input, &result, caps(2, 3), Open::Full, 80);
         assert_eq!(rows.len(), 21, "{:?}", texts(&rows));
         assert!(!texts(&rows).iter().any(|r| r.contains("lines")));
     }
@@ -2239,7 +2448,7 @@ mod tests {
     fn a_short_edit_body_fits_and_says_nothing_about_more() {
         let input = json!({ "file_path": "/work/a.rs", "old_string": "a\nb", "new_string": "a\nc" });
         let result = neosh_proto::ToolResult::ok("ok");
-        let rows = body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 3 }, false, 80);
+        let rows = body(&g(), &input, &result, caps(12, 3), Open::Folded, 80);
         assert_eq!(texts(&rows), vec!["  \u{2514}   a", "    - b", "    + c"]);
     }
 
@@ -2247,7 +2456,7 @@ mod tests {
     fn a_failed_edit_shows_its_error_not_a_diff() {
         let input = json!({ "file_path": "/work/a.rs", "old_string": "a", "new_string": "b" });
         let result = neosh_proto::ToolResult::error("old_string not found");
-        let rows = body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 0 }, false, 80);
+        let rows = body(&g(), &input, &result, caps(12, 0), Open::Folded, 80);
         assert_eq!(texts(&rows), vec!["  \u{2514} old_string not found"]);
         assert_eq!(rows[0].spans[0].2, "Agent.ToolError");
     }
@@ -2256,7 +2465,7 @@ mod tests {
     fn a_result_folds_to_the_limit_and_expands_past_it() {
         let result = neosh_proto::ToolResult::ok("one\ntwo\nthree\nfour");
         let input = json!({ "command": "seq" });
-        let folded = body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 2 }, false, 80);
+        let folded = body(&g(), &input, &result, caps(12, 2), Open::Folded, 80);
         let t = texts(&folded);
         // One line of head, then what was dropped, then the end — which for a command is the
         // answer. Folding from the end would keep `one` and `two` and throw away the result.
@@ -2265,7 +2474,7 @@ mod tests {
             "    \u{2026} +2 lines (^S \u{21e5} to expand)",
             "    four",
         ]);
-        let open = body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 2 }, true, 80);
+        let open = body(&g(), &input, &result, caps(12, 2), Open::Full, 80);
         assert_eq!(texts(&open).len(), 4);
     }
 
@@ -2279,7 +2488,7 @@ mod tests {
             "new_string": "// two\nlet x = \"two\";",
         });
         let result = neosh_proto::ToolResult::ok("ok");
-        let rows = body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 3 }, false, 80);
+        let rows = body(&g(), &input, &result, caps(12, 3), Open::Folded, 80);
         let groups: Vec<&str> = rows.iter().flat_map(|r| &r.spans).map(|s| s.2).collect();
         assert!(groups.contains(&"Syntax.Keyword"), "`let` is a keyword: {groups:?}");
         assert!(groups.contains(&"Syntax.Comment"), "`// two` is a comment: {groups:?}");
@@ -2299,7 +2508,7 @@ mod tests {
                 json!({ "file_path": path, "old_string": "alpha", "new_string": "beta" });
             let result = neosh_proto::ToolResult::ok("ok");
             let rows =
-                body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 3 }, false, 80);
+                body(&g(), &input, &result, caps(12, 3), Open::Folded, 80);
             let t = texts(&rows);
             assert!(t.iter().any(|r| r.ends_with("- alpha")), "{path:?}: {t:?}");
             assert!(t.iter().any(|r| r.ends_with("+ beta")), "{path:?}: {t:?}");
@@ -2313,7 +2522,7 @@ mod tests {
             "diff": "@@ -142,3 +142,3 @@\n fn f() {\n-    let x = 1;\n+    let x = 2;\n",
         });
         let result = neosh_proto::ToolResult::ok("ok");
-        let rows = body(&g(), &patch, &result, Limits { diff_lines: 12, output_lines: 3 }, false, 80);
+        let rows = body(&g(), &patch, &result, caps(12, 3), Open::Folded, 80);
         let t = texts(&rows);
         assert!(t.iter().any(|r| r.contains("142   fn f() {")), "{t:?}");
         assert!(t.iter().any(|r| r.contains("143 - ")), "the removed line is numbered in the old file: {t:?}");
@@ -2327,7 +2536,7 @@ mod tests {
             "new_string": "    let x = 2;",
         });
         let rows =
-            body(&g(), &strings, &result, Limits { diff_lines: 12, output_lines: 3 }, false, 80);
+            body(&g(), &strings, &result, caps(12, 3), Open::Folded, 80);
         assert_eq!(texts(&rows), vec!["  \u{2514} -     let x = 1;", "    +     let x = 2;"]);
     }
 
@@ -2338,7 +2547,7 @@ mod tests {
         let long = format!("let s = \"{}\";", "x".repeat(120));
         let input = json!({ "file_path": "/work/a.rs", "old_string": "", "new_string": long });
         let result = neosh_proto::ToolResult::ok("ok");
-        let rows = body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 3 }, true, 60);
+        let rows = body(&g(), &input, &result, caps(12, 3), Open::Full, 60);
         assert!(rows.len() > 1, "it wrapped: {:?}", texts(&rows));
         assert!(rows.iter().all(|r| r.band == Some("Diff.AddLine")), "every row of it is added");
         assert!(rows.iter().all(|r| r.text.chars().count() <= 60), "{:?}", texts(&rows));
@@ -2363,7 +2572,7 @@ mod tests {
         let line = "    /// Run one turn to completion, steering it if a message arrives here.";
         let input = json!({ "file_path": "/work/a.rs", "old_string": "", "new_string": line });
         let result = neosh_proto::ToolResult::ok("ok");
-        let rows = body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 3 }, true, 50);
+        let rows = body(&g(), &input, &result, caps(12, 3), Open::Full, 50);
         let t = texts(&rows);
         assert!(t.len() > 1, "{t:?}");
         for row in &t[..t.len() - 1] {
@@ -2380,7 +2589,7 @@ mod tests {
         // Opened, because a read folds to its header alone and the body under test is the part you
         // get by pressing `⇥`.
         let rows = body(&g(), &json!({"file_path": "/work/a.rs"}), &result,
-            Limits { diff_lines: 12, output_lines: 3 }, true, 80);
+            caps(12, 3), Open::Full, 80);
         assert_eq!(texts(&rows), vec!["  \u{2514}      1    impl Session {"]);
     }
 
@@ -2389,9 +2598,9 @@ mod tests {
     fn a_call_that_only_looked_at_something_folds_to_its_header_and_says_how_much() {
         let input = json!({"file_path": "/work/a.rs"});
         let result = neosh_proto::ToolResult::ok("one\ntwo\nthree\nfour\n");
-        let limits = Limits { diff_lines: 12, output_lines: 3 };
+        let limits = caps(12, 3);
         assert!(
-            body(&g(), &input, &result, limits, false, 80).is_empty(),
+            body(&g(), &input, &result, limits, Open::Folded, 80).is_empty(),
             "nothing under it"
         );
         // The count is what says there is anything to open, and it counts what a person would:
@@ -2400,7 +2609,7 @@ mod tests {
         assert!(header_text(&g(), &head, &root(), 80).ends_with("  4 lines"));
 
         // And `⇥` still gives you the whole thing.
-        let open = body(&g(), &input, &result, limits, true, 80);
+        let open = body(&g(), &input, &result, limits, Open::Full, 80);
         assert_eq!(open.len(), 4, "{:?}", texts(&open));
     }
 
@@ -2409,7 +2618,7 @@ mod tests {
     fn a_look_that_failed_still_shows_what_it_said() {
         let input = json!({"path": "/work/gone.rs"});
         let result = neosh_proto::ToolResult::error("no such file");
-        let rows = body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 3 }, false, 80);
+        let rows = body(&g(), &input, &result, caps(12, 3), Open::Folded, 80);
         assert_eq!(texts(&rows), vec!["  \u{2514} no such file"]);
     }
 
@@ -2419,7 +2628,7 @@ mod tests {
     fn a_command_keeps_what_it_printed() {
         let input = json!({"command": "cargo test"});
         let result = neosh_proto::ToolResult::ok("running 2 tests\nok\nok");
-        let rows = body(&g(), &input, &result, Limits { diff_lines: 12, output_lines: 3 }, false, 80);
+        let rows = body(&g(), &input, &result, caps(12, 3), Open::Folded, 80);
         assert_eq!(rows.len(), 3, "{:?}", texts(&rows));
         let head = Head { output: Some(3), ..head("Bash", &input, ToolState::Done) };
         let text = header_text(&g(), &head, &root(), 80);
@@ -2429,10 +2638,10 @@ mod tests {
     #[test]
     fn a_limit_of_zero_counts_a_result_and_hides_a_diff() {
         let result = neosh_proto::ToolResult::ok("one\ntwo");
-        let rows = body(&g(), &json!({}), &result, Limits { diff_lines: 0, output_lines: 0 }, false, 80);
+        let rows = body(&g(), &json!({}), &result, caps(0, 0), Open::Folded, 80);
         assert_eq!(texts(&rows), vec!["  \u{2514} 2 lines"]);
         let input = json!({ "file_path": "/work/a.rs", "old_string": "a", "new_string": "b" });
-        let rows = body(&g(), &input, &result, Limits { diff_lines: 0, output_lines: 3 }, false, 80);
+        let rows = body(&g(), &input, &result, caps(0, 3), Open::Folded, 80);
         assert!(rows.is_empty(), "the header already has the stats: {:?}", texts(&rows));
     }
 
@@ -2527,7 +2736,7 @@ mod tests {
     fn ascii_glyphs_name_the_key_in_words() {
         let g = Glyphs::new(true);
         let result = neosh_proto::ToolResult::ok("one\ntwo");
-        let rows = body(&g, &json!({}), &result, Limits { diff_lines: 12, output_lines: 1 }, false, 80);
+        let rows = body(&g, &json!({}), &result, caps(12, 1), Open::Folded, 80);
         assert_eq!(texts(&rows), vec!["  \\ ... +1 line (^S Tab to expand)", "    two"]);
     }
 }

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -643,8 +643,12 @@ struct Card {
     row: u32,
     /// How many rows the body takes under it.
     body: u32,
-    /// Whether the body is the whole of it or the first few rows.
-    expanded: bool,
+    /// How much of the body is on screen: folded, previewed under the cursor, or opened.
+    ///
+    /// Two of the three are the *cursor's*, not the card's — see [`cards::Open`] and
+    /// [`Host::refresh_preview`]. Kept here anyway, because this is what draws the card and
+    /// because a run must not grow into a card somebody is looking at.
+    open: cards::Open,
     /// Whether this card has already had its moment.
     ///
     /// A landing is an event, and an event happens once. Without this the row would light up again
@@ -656,7 +660,7 @@ struct Card {
 
 impl Card {
     fn new(leg: Leg, row: u32) -> Self {
-        Self { legs: vec![leg], row, body: 0, expanded: false, flashed: false }
+        Self { legs: vec![leg], row, body: 0, open: cards::Open::Folded, flashed: false }
     }
 
     /// Whether this card holds a call answering to `id`, and which one.
@@ -680,7 +684,7 @@ impl Card {
     /// and the fold is about noise. Ending the run there gives the failure its own card with its
     /// own body, which is what it would have had alone.
     fn takes(&self, input: &serde_json::Value) -> bool {
-        !self.expanded
+        self.open == cards::Open::Folded
             && !self.legs.iter().any(|l| l.result.as_ref().is_some_and(|r| r.is_error))
             && self.legs.last().is_some_and(|l| cards::groups_with(&l.input, input))
     }
@@ -3081,7 +3085,7 @@ impl Host {
             .card_at(self.chat_cursor().0)
             .map(|i| &self.cards[i])
             .filter(|c| c.settled())
-            .map(|c| c.expanded);
+            .map(|c| c.open == cards::Open::Full);
         let tab = self.glyphs().tab;
         let mut pairs: Vec<(&str, &str)> = match self.reading_pending {
             Some(Pending::Yank) => vec![
@@ -3118,6 +3122,7 @@ impl Host {
                 ("v", "select"),
                 ("[ ]", "turn"),
                 ("{ }", "block"),
+                ("c", "call"),
                 ("/", "find"),
                 ("i", "write"),
                 ("esc", "leave"),
@@ -3128,7 +3133,9 @@ impl Host {
             && !self.chat_anchored()
             && let Some(open) = card
         {
-            pairs.insert(0, (tab, if open { "fold" } else { "expand" }));
+            // `\u{21e5}` no longer *opens* a card the cursor is already in — the cursor did that.
+            // What it does is keep it: all of it, and still there when you move off.
+            pairs.insert(0, (tab, if open { "fold" } else { "keep open" }));
         }
         let mut out: Vec<neosh_proto::VirtChunk> = Vec::new();
         let mut used = 0usize;
@@ -3959,6 +3966,7 @@ impl Host {
             return;
         }
         self.reading = false;
+        self.drop_preview();
         self.reading_pending = None;
         self.reading_count.clear();
         self.reading_shape = SelectShape::Exclusive;
@@ -4168,6 +4176,11 @@ impl Host {
             (_, "[") => self.reading_to_turn(-1),
             (_, "}") => self.reading_to_block(1),
             (_, "{") => self.reading_to_block(-1),
+            // And the third: what the turn actually did. `c` rather than a bracket pair because
+            // both of those are spent, and it is free here — nothing in this mode edits, so Vim's
+            // `c` has nothing to collide with. The card opens as you land on it.
+            (_, "c") => self.reading_to_card(1, count),
+            (_, "C") => self.reading_to_card(-1, count),
 
             // Where the window is, rather than where the text is.
             (_, "H") => self.reading_screen_row(count.saturating_sub(1)),
@@ -4388,6 +4401,12 @@ impl Host {
             row: at.0,
             col: at.1,
         });
+        // The card the cursor arrived in opens, and the one it left folds. Not while selecting: a
+        // selection is two positions with rows between them, and a body appearing in the middle of
+        // it would change what `y` copies without anything on screen having been aimed at.
+        if !self.chat_anchored() {
+            self.refresh_preview();
+        }
         self.follow_cursor();
         // The hint row says what the row under the cursor can do, so it moves with it.
         self.refresh_composer();
@@ -5247,6 +5266,7 @@ impl Host {
         cards::Limits {
             diff_lines: self.option_usize("chat.diff_lines"),
             output_lines: self.option_usize("chat.tool_output_lines"),
+            preview_lines: self.option_usize("chat.preview_lines"),
         }
     }
 
@@ -5372,7 +5392,8 @@ impl Host {
                 let g = self.glyphs();
                 let limits = self.limits();
                 let width = self.chat_width();
-                let rows = cards::body(&g, &serde_json::Value::Null, result, limits, false, width);
+                let nothing = serde_json::Value::Null;
+                let rows = cards::body(&g, &nothing, result, limits, cards::Open::Folded, width);
                 for r in rows {
                     let row = self.chat_push(vec![r.text.clone()]);
                     self.chat_row(row, &r);
@@ -5471,14 +5492,14 @@ impl Host {
         let body = match card.legs.as_slice() {
             // One call: whatever it came back with, folded or opened.
             [leg] => match &leg.result {
-                Some(r) => cards::body(&g, &leg.input, r, limits, card.expanded, width),
+                Some(r) => cards::body(&g, &leg.input, r, limits, card.open, width),
                 None => Vec::new(),
             },
             // A run of reads: nothing until it is opened, and then a row per call. What the fold
             // exists to keep out of the transcript is the *contents* of the six files, so opening
             // a run gives back the six names in full and stops there. A run of *commands* keeps
             // the last one's output, because what a command printed is the answer — see ADR 0051.
-            _ => cards::group_body(&g, &Self::card_heads(card), &root, limits, card.expanded, width),
+            _ => cards::group_body(&g, &Self::card_heads(card), &root, limits, card.open, width),
         };
         // Anything else writing into the transcript ends the answer: its rows are addressed by
         // range, and rows moving underneath it would make "the end of the answer" ambiguous. An
@@ -5553,11 +5574,122 @@ impl Host {
             self.editor_message(MessageLevel::Info, "still running \u{2014} nothing to show yet");
             return;
         }
-        self.cards[i].expanded = !self.cards[i].expanded;
+        // Between "all of it, and it stays" and whatever the cursor was already buying. Folding a
+        // card the cursor is still in back to nothing would be answering `\u{21e5}` with a card
+        // that shows *less* than it did before anybody pressed anything.
+        self.cards[i].open = match self.cards[i].open {
+            cards::Open::Full => cards::Open::Preview,
+            _ => cards::Open::Full,
+        };
         self.redraw_card(i);
         let row = self.cards[i].row;
         self.reading_jump((row, 0));
         self.refresh_composer();
+    }
+
+    /// Open the card the cursor is in, and fold the one it has left.
+    ///
+    /// [ADR 0049](../../../docs/adr/0049-a-list-is-a-place-you-move-in.md)'s rule, on the
+    /// transcript: the row you are *in* stays unfolded, and only ever one row — the cursor is what
+    /// asks, everywhere else. A turn that ran nine commands is nine rows you walk down, each one
+    /// showing what it printed as you arrive and giving the rows back as you leave, and none of it
+    /// is a key you have to know about.
+    ///
+    /// Only when the card actually changes, which is what makes this safe to call on every motion:
+    /// moving *within* a card redraws nothing, and a redraw is not free — it settles the answer
+    /// that is streaming above it.
+    ///
+    /// A card pinned open with `\u{21e5}` is left alone in both directions. That is what pinning
+    /// is for: you opened it to keep it, and walking off it is not changing your mind.
+    fn refresh_preview(&mut self) {
+        if !self.reading {
+            return;
+        }
+        let (mut row, col) = self.chat_cursor();
+        let want = self.card_at(row).filter(|i| self.cards[*i].settled());
+        let leaving: Vec<usize> = self
+            .cards
+            .iter()
+            .enumerate()
+            .filter(|(i, c)| c.open == cards::Open::Preview && Some(*i) != want)
+            .map(|(i, _)| i)
+            .collect();
+        for i in leaving {
+            let (at, before) = (self.cards[i].row, self.cards[i].body);
+            self.cards[i].open = cards::Open::Folded;
+            self.redraw_card(i);
+            // Everything below a card that just lost rows moved up, and the cursor is one of the
+            // things below it: stepping off the bottom of a nine-row body lands you on the row
+            // after it, and that row is now nine higher than where the cursor is pointing.
+            if row > at {
+                row = row.saturating_sub(before.saturating_sub(self.cards[i].body));
+            }
+        }
+        if let Some(i) = want.filter(|i| self.cards[*i].open == cards::Open::Folded) {
+            self.cards[i].open = cards::Open::Preview;
+            self.redraw_card(i);
+        }
+        if row != self.chat_cursor().0 {
+            let at = vim::clamp(&self.chat_lines(), (row, col));
+            let _ = self.editor.apply(&PluginId::from(BUILTIN), ApiCall::WinSetCursor {
+                win: self.chat_win,
+                row: at.0,
+                col: at.1,
+            });
+            self.follow_cursor();
+        }
+    }
+
+    /// Fold whatever the cursor was previewing, without moving it.
+    ///
+    /// What leaving reading has to do: a preview is the cursor's, and there is no cursor once you
+    /// are back in the composer. A card pinned with `\u{21e5}` stays open, because that one is
+    /// yours rather than the cursor's.
+    fn drop_preview(&mut self) {
+        let previewed: Vec<usize> = self
+            .cards
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| c.open == cards::Open::Preview)
+            .map(|(i, _)| i)
+            .collect();
+        for i in previewed {
+            self.cards[i].open = cards::Open::Folded;
+            self.redraw_card(i);
+        }
+    }
+
+    /// `c` and `C`: the next tool call, or the one before it.
+    ///
+    /// The transcript's own structure, which neither of the other two stepping keys can find.
+    /// `[`/`]` is a whole turn — far too coarse to inspect what a turn *did* — and `{`/`}` is a
+    /// blank-line block, which since ADR 0050 took the blank row off the top of a card means a run
+    /// of nine cards is one block. So walking
+    /// what happened, one call at a time, was nine presses of `j` per row of body and no way to
+    /// skip a long one.
+    ///
+    /// The cursor lands on the header, which is where a card opens from — and the card opens
+    /// itself on arrival, so `c c c` is the whole of a turn's work read one call at a time. A
+    /// count works like every other motion here: `3c` is three calls on.
+    fn reading_to_card(&mut self, dir: i32, count: u32) {
+        let from = self.chat_cursor().0;
+        for _ in 0..count.max(1) {
+            let here = self.chat_cursor().0;
+            // By header row alone, so `C` from half way down a body goes to the top of the card
+            // you are in before it goes to the one before it — which is what every other backwards
+            // motion here does, and the row you would have to reach anyway to fold it.
+            let next = match dir > 0 {
+                true => self.cards.iter().map(|c| c.row).filter(|r| *r > here).min(),
+                false => self.cards.iter().map(|c| c.row).filter(|r| *r < here).max(),
+            };
+            match next {
+                Some(row) => self.reading_jump((row, 0)),
+                None => break,
+            }
+        }
+        if self.chat_cursor().0 == from && self.cards.is_empty() {
+            self.editor_message(MessageLevel::Info, "nothing in this conversation ran a tool");
+        }
     }
 
     /// What the turn changed, under its answer.
@@ -6397,7 +6529,66 @@ impl Host {
     /// whatever is on screen. *Drawing* happens only when the event came from the conversation you
     /// are looking at. That split is what lets several turns run at once without one of them
     /// writing into another's transcript.
+    /// Whatever the agent just said, and then the reader taken along with it if it was at the end.
+    ///
+    /// A turn that is still going writes rows below wherever you are reading, and reading is a
+    /// place *in* the transcript: the scroll offset is pinned by every motion, so an answer
+    /// arriving while `^S` is on lands off the bottom of the window. Which made watching a turn a
+    /// matter of leaving reading, seeing what had happened, and going back in — for every call.
+    ///
+    /// **At the end means following, anywhere else means anchored.** The same distinction the
+    /// unscrolled window makes and for the same reason: parked on the last row you are watching,
+    /// and half way up a diff you are reading, and the second one must not be dragged away from
+    /// what it is looking at. Nothing to turn on, and one `G` to start following again.
+    ///
+    /// Not while selecting or searching — both of those are two positions, and moving one of them
+    /// on the agent's behalf changes what the reader is holding.
     fn handle_agent_event(&mut self, ev: AgentEvent) {
+        let following = self.reading_at_tail();
+        self.on_agent_event(ev);
+        if following {
+            self.reading_follow();
+        }
+    }
+
+    /// Whether the reader is parked on the last row of the transcript.
+    fn reading_at_tail(&self) -> bool {
+        self.reading
+            && self.search.is_none()
+            && !self.chat_anchored()
+            && self.chat_cursor().0 + 1 >= self.chat_len()
+    }
+
+    /// How many rows the transcript has, without copying every one of them to find out.
+    fn chat_len(&self) -> u32 {
+        self.editor.buffer(self.chat).map(|b| b.lines().len() as u32).unwrap_or(0)
+    }
+
+    /// Take the reader down to the newest row.
+    ///
+    /// Deliberately not [`Self::place_cursor`]: following is *watching*, and a card that opened
+    /// itself under a cursor the agent is dragging is a body nobody aimed at — several of them a
+    /// second, each one settling the answer streaming above it. Arriving somewhere by yourself is
+    /// what asks a card to open.
+    fn reading_follow(&mut self) {
+        let lines = self.chat_lines();
+        let last = lines.len().saturating_sub(1) as u32;
+        if self.chat_cursor().0 == last {
+            return;
+        }
+        let col = vim::first_non_blank(lines.last().map(String::as_str).unwrap_or(""));
+        let at = vim::clamp(&lines, (last, col));
+        self.reading_goal = None;
+        let _ = self.editor.apply(&PluginId::from(BUILTIN), ApiCall::WinSetCursor {
+            win: self.chat_win,
+            row: at.0,
+            col: at.1,
+        });
+        self.follow_cursor();
+        self.refresh_composer();
+    }
+
+    fn on_agent_event(&mut self, ev: AgentEvent) {
         let on_screen = &self.active_session() == ev.session();
         match ev {
             AgentEvent::TurnStarted { session, turn } => {
@@ -8334,6 +8525,18 @@ impl Host {
                 ),
             },
             OptionSpec {
+                name: "chat.preview_lines".into(),
+                ty: OptionType::Int { min: Some(0), max: Some(500) },
+                default: OptionValue::Int(16),
+                description: Some(
+                    "How much of a tool card the cursor is in shows while reading the transcript \
+                     with `^S`. The card opens as you arrive and folds as you leave, so this is a \
+                     budget per card rather than per transcript. Never less than the folded card \
+                     showed. Tab opens one all the way and keeps it open."
+                        .into(),
+                ),
+            },
+            OptionSpec {
                 name: "chat.diff_lines".into(),
                 ty: OptionType::Int { min: Some(0), max: Some(500) },
                 default: OptionValue::Int(12),
@@ -9257,10 +9460,10 @@ fn transcript(
     ) -> Vec<cards::Row> {
         match card.legs.as_slice() {
             [leg] => match &leg.result {
-                Some(r) => cards::body(g, &leg.input, r, limits, false, width),
+                Some(r) => cards::body(g, &leg.input, r, limits, card.open, width),
                 None => Vec::new(),
             },
-            _ => cards::group_body(g, &heads_of(card, answered), root, limits, false, width),
+            _ => cards::group_body(g, &heads_of(card, answered), root, limits, card.open, width),
         }
     }
     // A gap, unless there already is one: what came before was often a tool card, which has no
@@ -9421,7 +9624,7 @@ fn transcript(
                                 &serde_json::Value::Null,
                                 &result,
                                 limits,
-                                false,
+                                cards::Open::Folded,
                                 width,
                             );
                             for r in rows {

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -5756,13 +5756,20 @@ fn a_run_of_commands_is_one_row_that_keeps_the_last_answer() {
     );
 }
 
+/// The three states a card can be in, and the two things that move it between them. See ADR 0057.
+///
+/// Folded is what a card costs when nobody is looking at it. The card the *cursor* is in shows
+/// more — bounded, because nine hundred rows appearing under `j` is what the fold exists to
+/// prevent — and `\u{21e5}` is all of it. The trailer says which key at every step where something
+/// is still being held back.
 #[test]
-fn a_folded_card_opens_with_tab_while_reading_and_folds_again() {
-    // A card shows enough to know what happened. The whole of it is one key away, in the place
-    // you go to read — and the trailer says which key.
+fn a_card_opens_as_the_cursor_arrives_and_folds_as_it_leaves() {
     let sb = Sandbox::new("cardfold");
     install_editor(&sb);
-    sb.write_config("[options]\n\"agent.model\" = \"editor/editor\"\n\"chat.diff_lines\" = 2\n");
+    sb.write_config(
+        "[options]\n\"agent.model\" = \"editor/editor\"\n\"chat.diff_lines\" = 2\n\
+         \"chat.preview_lines\" = 4\n",
+    );
     let mut s = sb.start_letting_config_choose();
     s.wait_for("editor ready");
     s.type_text("go");
@@ -5779,13 +5786,24 @@ fn a_folded_card_opens_with_tab_while_reading_and_folds_again() {
     assert!(!rows.iter().any(|l| l.ends_with("+ i")), "the end of the diff is folded away\n{rows:?}");
     let header = rows.iter().position(|l| l.starts_with("  Edited  ")).expect("the header");
 
-    // Into the transcript, to the top, and down onto the card.
+    // Into the transcript, to the top, and down onto the card. Arriving is what opens it — no key.
     s.ctrl("s");
     s.key("g");
     s.key("g");
     for _ in 0..header {
         s.key("j");
     }
+    assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("+4 lines"))),
+        "the card the cursor is in is worth more rows, and still bounded\n{:?}",
+        s.chat_now()
+    );
+    assert!(
+        !s.chat_now().iter().any(|l| l.ends_with("+ i")),
+        "a preview is a budget, not an opening\n{:?}",
+        s.chat_now()
+    );
+
     s.special("tab");
     assert!(
         s.pump(|s| s.chat_now().iter().any(|l| l.ends_with("+ i"))),
@@ -5799,10 +5817,20 @@ fn a_folded_card_opens_with_tab_while_reading_and_folds_again() {
         "what was below the card is still below it\n{rows:?}"
     );
 
+    // `\u{21e5}` again gives back what the cursor was already buying — never less than that, which
+    // would be a key that answers "show me more" with a smaller card.
     s.special("tab");
     assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("+4 lines"))),
+        "back to the preview\n{:?}",
+        s.chat_now()
+    );
+
+    // And off the card entirely, which is the only thing that folds it.
+    s.key("k");
+    assert!(
         s.pump(|s| s.chat_now().iter().any(|l| l.contains("+6 lines"))),
-        "and it folds again\n{:?}",
+        "the rows go back when the cursor does\n{:?}",
         s.chat_now()
     );
 }

--- a/crates/neosh/tests/fixtures/tool_cards.jsonl
+++ b/crates/neosh/tests/fixtures/tool_cards.jsonl
@@ -1,0 +1,26 @@
+{"type": "message_start", "model": "mock", "usage": {}}
+{"type": "block_start", "index": 0, "block": {"kind": "text"}}
+{"type": "text_delta", "index": 0, "text": "Looking at the first one."}
+{"type": "block_stop", "index": 0}
+{"type": "block_start", "index": 1, "block": {"kind": "tool_use", "id": "c1", "name": "read_file"}}
+{"type": "tool_input_delta", "index": 1, "partial_json": "{\"path\":\"one.txt\"}"}
+{"type": "block_stop", "index": 1}
+{"type": "message_delta", "stop_reason": {"kind": "tool_use"}, "usage": {}}
+{"type": "message_stop"}
+
+{"type": "message_start", "model": "mock", "usage": {}}
+{"type": "block_start", "index": 0, "block": {"kind": "text"}}
+{"type": "text_delta", "index": 0, "text": "And now the second one."}
+{"type": "block_stop", "index": 0}
+{"type": "block_start", "index": 1, "block": {"kind": "tool_use", "id": "c2", "name": "read_file"}}
+{"type": "tool_input_delta", "index": 1, "partial_json": "{\"path\":\"two.txt\"}"}
+{"type": "block_stop", "index": 1}
+{"type": "message_delta", "stop_reason": {"kind": "tool_use"}, "usage": {}}
+{"type": "message_stop"}
+
+{"type": "message_start", "model": "mock", "usage": {}}
+{"type": "block_start", "index": 0, "block": {"kind": "text"}}
+{"type": "text_delta", "index": 0, "text": "All done."}
+{"type": "block_stop", "index": 0}
+{"type": "message_delta", "stop_reason": {"kind": "end_turn"}, "usage": {"output_tokens": 3}}
+{"type": "message_stop"}

--- a/crates/neosh/tests/reading.rs
+++ b/crates/neosh/tests/reading.rs
@@ -249,6 +249,53 @@ impl Session {
     fn buffer(&self, name: &str) -> Vec<String> {
         self.buffer_named(name).map(|b| self.lines_of(b)).unwrap_or_default()
     }
+
+    /// How many rows of the transcript are lines of `file`, which is what a read's card shows
+    /// when it is showing anything at all.
+    fn showing(&self, file: &str) -> usize {
+        self.chat().iter().filter(|l| l.contains(&format!("{file} line "))).count()
+    }
+}
+
+/// A conversation with two tool cards in it, with an answer between them so they are two cards
+/// rather than one run of reads.
+impl Sandbox {
+    fn with_cards(&self) -> Session {
+        self.cards_at(None)
+    }
+
+    /// The same, with the mock answering slowly enough that the turn is still going while keys
+    /// are being pressed — which is the only way to arrange "something arrived while you were
+    /// reading" without a real model and a real wait.
+    fn with_slow_cards(&self) -> Session {
+        self.cards_at(Some("120"))
+    }
+
+    fn cards_at(&self, pace: Option<&str>) -> Session {
+        for (name, n) in [("one.txt", 40), ("two.txt", 40)] {
+            let body: String =
+                (1..=n).map(|i| format!("{name} line {i}\n")).collect::<Vec<_>>().concat();
+            std::fs::write(self.root.join("work").join(name), body).expect("fixture file");
+        }
+        let fixture =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/tool_cards.jsonl");
+        let child = Command::new(env!("CARGO_BIN_EXE_neosh"))
+            .args(["--ui-protocol", "stdio"])
+            .arg("--config-dir")
+            .arg(self.root.join("config"))
+            .arg("--cwd")
+            .arg(self.root.join("work"))
+            .args(["--mock-script", &fixture.display().to_string()])
+            .args(["--model", "mock/mock"])
+            .env("NEOSH_STATE_DIR", self.root.join("state"))
+            .envs(pace.map(|ms| ("NEOSH_MOCK_DELAY_MS", ms)))
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("start");
+        Session::wrap(child)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1392,4 +1439,175 @@ impl Session {
             self.chat_cursor()
         );
     }
+}
+
+
+// ---------------------------------------------------------------------------
+// Watching what a turn did — ADR 0057
+// ---------------------------------------------------------------------------
+
+/// `c` steps to the next tool call, and the card you land on opens itself.
+///
+/// The transcript's third structure, after the turn and the block: `[`/`]` is a whole turn and
+/// `{`/`}` is one block for a whole run of cards, so before this there was no way to walk what a
+/// turn *did* one call at a time. And a card the cursor is in shows what came back — ADR 0049's
+/// rule, one surface along — so `c c c` reads the work rather than the headers over it.
+#[test]
+fn c_steps_call_to_call_and_the_card_you_are_on_opens_itself() {
+    let sb = Sandbox::new("cards-step");
+    let mut s = sb.with_cards();
+    s.ready();
+    s.keys("go");
+    s.special("enter");
+    assert!(
+        s.pump(|s| s.chat().iter().any(|l| l.contains("All done."))),
+        "the whole turn landed\n{:?}",
+        s.chat()
+    );
+    s.press(json!({"kind": "char", "c": "s"}), &["ctrl"]);
+    assert!(s.pump(|s| s.buffer("[status]").iter().any(|l| l.contains("reading"))));
+
+    // Folded, a read is its header and the count on it. Nothing of either file is on screen.
+    assert_eq!((s.showing("one.txt"), s.showing("two.txt")), (0, 0), "{:?}", s.chat());
+
+    // `C` goes back to the last card, which is the second one.
+    s.ch("C");
+    assert!(
+        s.pump(|s| s.showing("two.txt") > 0),
+        "the card the cursor arrived in shows what came back\n{:?}",
+        s.chat()
+    );
+    assert_eq!(s.showing("one.txt"), 0, "and only that one — the cursor is what asks");
+
+    // And back one more, which folds the one it left.
+    s.ch("C");
+    assert!(
+        s.pump(|s| s.showing("one.txt") > 0 && s.showing("two.txt") == 0),
+        "stepping off gives the rows back\n{:?}",
+        s.chat()
+    );
+}
+
+/// A preview is bounded, and `⇥` is how you say you want the rest of it — and want to keep it.
+///
+/// The two halves are one decision: before this, `⇥` was the only way to see a body at all, so
+/// "show me" and "keep it" could not be told apart. Now the cursor says the first and the key says
+/// the second.
+#[test]
+fn tab_keeps_a_card_open_after_the_cursor_has_gone() {
+    let sb = Sandbox::new("cards-pin");
+    let mut s = sb.with_cards();
+    s.ready();
+    s.keys("go");
+    s.special("enter");
+    assert!(s.pump(|s| s.chat().iter().any(|l| l.contains("All done."))));
+    s.press(json!({"kind": "char", "c": "s"}), &["ctrl"]);
+    assert!(s.pump(|s| s.buffer("[status]").iter().any(|l| l.contains("reading"))));
+
+    s.ch("C");
+    assert!(s.pump(|s| s.showing("two.txt") > 0), "{:?}", s.chat());
+    let previewed = s.showing("two.txt");
+    assert!(previewed < 40, "a preview is bounded: {previewed} of 40 rows");
+
+    s.special("tab");
+    assert!(
+        s.pump(|s| s.showing("two.txt") == 40),
+        "and Tab is all of it: {}\n{:?}",
+        s.showing("two.txt"),
+        s.chat()
+    );
+
+    // Off it, and it stays. That is what pinning is for.
+    s.ch("C");
+    assert!(
+        s.pump(|s| s.showing("one.txt") > 0),
+        "the first card opened on arrival\n{:?}",
+        s.chat()
+    );
+    assert_eq!(s.showing("two.txt"), 40, "and the pinned one is still open behind us");
+}
+
+/// Leaving reading folds what the cursor was previewing, and keeps what you pinned.
+///
+/// A preview is the cursor's, and there is no cursor in the composer.
+#[test]
+fn leaving_reading_folds_the_preview_and_keeps_the_pin() {
+    let sb = Sandbox::new("cards-leave");
+    let mut s = sb.with_cards();
+    s.ready();
+    s.keys("go");
+    s.special("enter");
+    assert!(s.pump(|s| s.chat().iter().any(|l| l.contains("All done."))));
+    s.press(json!({"kind": "char", "c": "s"}), &["ctrl"]);
+    assert!(s.pump(|s| s.buffer("[status]").iter().any(|l| l.contains("reading"))));
+
+    s.ch("C");
+    assert!(s.pump(|s| s.showing("two.txt") > 0));
+    s.special("esc");
+    assert!(
+        s.pump(|s| s.showing("two.txt") == 0),
+        "the rows go back when the cursor does\n{:?}",
+        s.chat()
+    );
+}
+
+
+/// A turn writes below where you are reading, and reading the last row means reading what arrives.
+///
+/// Reading is a place *in* the transcript — the scroll offset is pinned by every motion — so
+/// before this an answer produced while `^S` was on landed off the bottom of the window with
+/// nothing saying so, and watching a turn meant leaving reading and coming back for every call.
+/// See ADR 0057.
+#[test]
+fn reading_the_last_row_keeps_reading_it() {
+    let sb = Sandbox::new("cards-tail");
+    let mut s = sb.with_slow_cards();
+    s.ready();
+    s.keys("go");
+    s.special("enter");
+    // In while the turn is still going: `^S` starts at the newest row, which is the end.
+    assert!(
+        s.pump(|s| s.chat().iter().any(|l| l.contains("Looking at the first one"))),
+        "the turn started\n{:?}",
+        s.chat()
+    );
+    s.press(json!({"kind": "char", "c": "s"}), &["ctrl"]);
+    assert!(s.pump(|s| s.buffer("[status]").iter().any(|l| l.contains("reading"))));
+
+    assert!(
+        s.pump(|s| s.chat().iter().any(|l| l.contains("All done."))),
+        "the rest of it arrived\n{:?}",
+        s.chat()
+    );
+    let last = s.chat().len().saturating_sub(1) as u64;
+    assert!(
+        s.pump(|s| s.chat_cursor() == Some(s.chat().len().saturating_sub(1) as u64)),
+        "the reader was carried to the end: at {:?} of {last}",
+        s.chat_cursor()
+    );
+    assert!(s.buffer("[status]").iter().any(|l| l.contains("reading")), "and is still reading");
+}
+
+/// And reading anywhere else does not move, however much arrives below it.
+///
+/// The other half, and the one that makes the first half safe: half way up a diff you are reading
+/// is exactly where you must still be when the next tool call lands.
+#[test]
+fn reading_anywhere_else_stays_exactly_where_it_is() {
+    let sb = Sandbox::new("cards-anchor");
+    let mut s = sb.with_slow_cards();
+    s.ready();
+    s.keys("go");
+    s.special("enter");
+    assert!(s.pump(|s| s.chat().iter().any(|l| l.contains("Looking at the first one"))));
+    s.press(json!({"kind": "char", "c": "s"}), &["ctrl"]);
+    assert!(s.pump(|s| s.buffer("[status]").iter().any(|l| l.contains("reading"))));
+    s.to_top();
+
+    assert!(
+        s.pump(|s| s.chat().iter().any(|l| l.contains("All done."))),
+        "the rest of it arrived\n{:?}",
+        s.chat()
+    );
+    assert_eq!(s.chat_cursor(), Some(0), "and it left the reader where the reader was");
 }

--- a/docs/adr/0057-a-turn-is-something-you-can-watch.md
+++ b/docs/adr/0057-a-turn-is-something-you-can-watch.md
@@ -1,0 +1,99 @@
+# 0057 — A turn is something you can watch
+
+**Status:** accepted
+
+## Context
+
+ADR 0033 made a card a row until you ask for more. ADR 0040 made a run of calls of one kind one
+row. ADR 0051 made a stack of commands keep the last one's output. Every one of them was about the
+same thing — a transcript you read *afterwards*, where the turn is over and the question is "what
+did it do", and the answer is the shortest true account of it.
+
+None of them is about the other half, which is a turn that is still going and a person watching it.
+Three things go wrong there, and they compound:
+
+**Every command names the directory it is already in.** A vendor CLI that cannot keep a working
+directory between calls writes each of them as `cd /home/you/projects/thing && cargo test`.
+`subject_of` takes the first line and clips it to whatever the header has left, so the card reads
+`Ran  cd /home/you/projects/th…`. Folded into a stack it is worse: `short_command` stops at the
+`&&`, so a stretch of the turn that ran six different things folds to `cd, cd, cd`. The one part of
+that row the reader already knows — the conversation has a directory, the sidebar names it, and
+every path on every other card is drawn relative to it — is the only part that fits.
+
+**Reading is a place, and the agent walks away from it.** `^S` is a cursor in the transcript and
+`reading_jump` pins `top_line` on every motion, which is what makes it a place. A turn still
+running writes rows below that place: they land off the bottom of the window and nothing says so.
+So watching a turn while reading it was `^S`, `Esc`, look, `^S` again — per tool call.
+
+**Nothing steps card to card.** `[`/`]` is a whole turn, which is far too coarse to inspect what a
+turn *did*. `{`/`}` is a blank-line block, and since ADR 0050 took the blank row off the top of a
+card, a run of nine cards is one block. That leaves `j`, and `⇥` on each one, and `⇥` again to put
+it back.
+
+Together those are a transcript that reports a turn accurately and cannot be used to *follow* one.
+
+## Decision
+
+**A command is named by what it does, never by how it got there.** A leading `cd <somewhere> &&`
+— or `;`, and repeated, because `cd a && cd b && make` is the same preamble said twice — is taken
+off before the command is named, everywhere a command is named. Only that shape: `cd src` on its
+own is genuinely a `cd` and says so, `cd x || y` is a decision rather than a preamble, and a `cd`
+anywhere but the front is part of what was run. Nothing is lost — an opened stack gives every
+command back in full, which is where you go when the question is *which* directory.
+
+**Reading at the end follows the end; reading anywhere else does not move.** The same distinction
+an unscrolled window already makes, and for the same reason: parked on the last row you are
+watching, half way up a diff you are reading, and the second one must not be dragged away from what
+it is looking at. There is nothing to turn on and one `G` to start following again. Not while
+selecting or searching — both of those are two positions, and moving one of them on the agent's
+behalf changes what the reader is holding without anything on screen having been aimed at.
+
+**The card the cursor is in is open.** ADR 0049's rule, one surface along: the row you are *in*
+stays unfolded, and only ever one row — the cursor is what asks, everywhere else. A turn that ran
+nine commands is nine rows you walk down, each showing what it printed as you arrive and giving the
+rows back as you leave. `⇥` still exists and now means something it could not mean before: *keep*
+this one, all of it, when the cursor goes.
+
+Which needs a third state rather than a second one, and `cards::Open` is it — `Folded`, `Preview`,
+`Full`. *How much does a card cost when nobody is looking at it* is a setting and the answer has to
+be small. *How much does the card I am looking at right now show* is the cursor's question, it is
+asked about exactly one card, and the answer costs nothing that moving off the card does not give
+straight back.
+
+**A preview is bounded.** `chat.preview_lines`, default 16. A card that read a nine-hundred-line
+file would otherwise drop nine hundred rows under the cursor on the way past, and `j` would stop
+being a key you can predict — which is the whole reason the fold exists. And never *fewer* rows
+than the folded card showed: a preview is a floor on top of the setting rather than a ceiling under
+it, so `chat.tool_output_lines = 40` does not lose thirty rows the moment you step onto the card.
+
+**A preview is a bigger budget, not an opening.** Which is the difference between a card and a
+*stack* of them. Opening a stack of commands means a row per command *and* an output under each
+one, and at `preview_lines` apiece a nine-command stack would drop a hundred and fifty rows under
+the cursor on the way past — the flood the bound exists to stop. So the cursor buys more of the one
+output that was already showing, which by ADR 0051 is the one that is the answer, and `⇥` buys the
+other eight. A run of *reads* is not this and does open: a row per call is one row per call, and
+that is bounded by the card.
+
+**`c` and `C` step to the next tool call and the one before it.** The transcript's third structure,
+after the turn and the block, and the one that says what the turn actually *did*. `c` because both
+bracket pairs are spent and it is free here — nothing in this mode edits, so Vim's `c` has nothing
+to collide with — and it takes a count like every other motion, so `3c` is three calls on. It lands
+on the header, which opens the card, so `c c c` reads a turn's work one call at a time.
+
+## Consequences
+
+- `cards::body`, `group_body`, `run_body` and `diff_rows` take `Open` where they took
+  `expanded: bool`, and `result_rows` takes a plain limit with `usize::MAX` for "all of it". The
+  replay path draws `Open::Folded` explicitly, which is what `false` meant there.
+- `Card::takes` refuses to grow a card that is previewed as well as one that is opened, for the
+  reason it already refused the second: growing a card under the person reading it moves what they
+  were reading.
+- **A preview redraws, and a redraw settles the streaming answer.** So it fires only when the card
+  under the cursor actually *changes* — moving within a card redraws nothing — and never while the
+  reader is being carried by the tail, because following is watching and a body nobody aimed at is
+  not something to open. That is the one place the two halves of this ADR had to be told apart.
+- Leaving reading folds the preview and leaves a pinned card open. A preview is the cursor's and
+  there is no cursor in the composer; a pin is yours.
+- `cd crates && cargo test` folds to `cargo test` rather than `cd crates`, which is a change to a
+  documented example in ADR 0051. It is the same rule that ADR said it was applying — the name is
+  what a command *is* — arriving at the case that ADR did not have in front of it.


### PR DESCRIPTION
The transcript reported a turn accurately and could not be used to *follow* one. Three faults that
compound into one complaint — the cards say `cd` over and over, you cannot see what came back, and
watching a running turn means leaving the reader and coming back for every call.

### A command is named by what it does, not how it got there

A vendor CLI that cannot keep a working directory writes every call as `cd /home/you/projects/thing
&& cargo test`, and the header clips to the one part you already knew:

```
before   ✗ Ran  cd /tmp/nsh-shot-cards/work && cargo test -p neos…
after    ✗ Ran  cargo test -p neosh-core -- --test-threads 2
```

Folded into a stack it was worse — `short_command` stops at the `&&`, so six different things folded
to `cd, cd, cd`. Only that exact shape comes off, repeated: `cd src` alone is genuinely a `cd`,
`cd x || y` is a decision rather than a preamble, and a `cd` anywhere but the front is part of what
ran. The whole line is still on the row an opened stack gives it.

### Reading the last row keeps reading it

`^S` pins `top_line` on every motion, which is what makes reading a place; a running turn writes
below that place and it lands off the bottom of the window with nothing saying so. Parked at the end
you are carried along; anywhere else you do not move at all, which is the half that matters — half
way up a diff you are reading is exactly where you must still be when the next call lands. Not while
selecting or searching, both of which are two positions. `G` starts following again.

### The card the cursor is in is open

ADR 0049's rule, one surface along. `cards::Open` is three states rather than two: *how much does a
card cost when nobody is looking at it* is a setting, and *how much does the card I am looking at
show* is the cursor's question — asked about exactly one card, and given back the moment the cursor
leaves. Bounded at `chat.preview_lines` (16), never fewer rows than the folded card showed, and a
stack of commands previews more of the *last* output rather than opening every one of them. `⇥`
stops meaning "open this" and starts meaning "keep it".

`c`/`C` step call to call with a count, because `[`/`]` is a whole turn and — since ADR 0050 took the
blank row off the top of a card — `{`/`}` is one block for a run of nine of them.

### Verification

- `reading` 39 (5 new, driving the real binary over the stdio protocol)
- `builtin_plugins` 153 — the fold test rewritten to walk all three states
- 251 bin unit tests, `editing` 23, `sessions` 32, `questions` 17, `approvals` 7
- no TS drift
- checked on a real screen with `scripts/shot.py`: the `cd` header, `C` stepping and opening, `20j`
  walking out of one preview and into the next with the cursor landing right

One existing assertion changed on purpose: `⇥` twice returns to the preview rather than to the fold,
because answering "show me more" with a smaller card is not a key anyone can predict.

Recorded as ADR 0057.

### Not in this change

Live tool output while a call is still running. `ProviderEvent` has no partial `ToolResult`, so a
card stays a spinner until the call comes back — streaming it would need a new event family and
driver support on both `claude` and `codex`.