### PR TITLE
Give the sidebar back the columns the star was holding

### DIFF
--- a/crates/neosh-core/src/palette.rs
+++ b/crates/neosh-core/src/palette.rs
@@ -80,14 +80,16 @@ struct Roles {
     plan: Color,
     /// The one hue used for emphasis that is not a state.
     accent: Color,
-    /// The favourite marker. Not a fourth state hue: the star glyph carries the whole meaning,
-    /// and the world has already decided what colour a favourite star is — painting it anything
-    /// else reads as a decision the user has to decode.
+    /// The favourite marker. Not a state hue: the star glyph carries the whole meaning, and a
+    /// favourite is not a condition the workspace is in — it is a thing you said about a project.
     ///
-    /// It sits in the same family as `attention` and is deliberately warmer, because the two are
-    /// told apart by shape rather than by hue: `attention` is only ever a word, a count or a
-    /// pulsing state, and this is only ever `★` in the sidebar's leftmost column. Nothing else in
-    /// the workspace draws a star, so there is no row on which the two can be confused.
+    /// Red, and therefore next door to `danger`, which is the obvious objection and is answered
+    /// the same way the old amber answered its collision with `attention`: these are told apart by
+    /// **shape**, never by hue. `danger` is only ever a `✗`, a word or a whole row it has taken
+    /// over; this is only ever the `★` after a project's name in the sidebar, and nothing else in
+    /// the workspace draws a star. It is also the more saturated of the two in both themes — the
+    /// error red is deliberately pale on dark and dark on light, because it lands on text you
+    /// still have to read, and this lands on one glyph that is nothing but itself.
     favorite: Color,
     /// The faces of the logo, top row first: bright at the lit edge, falling away downward.
     logo: [Color; 6],
@@ -136,7 +138,7 @@ const DARK: Roles = Roles {
     success: rgb(0x6e, 0xe7, 0xb7),
     plan: rgb(0xc4, 0xb5, 0xfd),
     accent: rgb(0xa5, 0xb4, 0xfc),
-    favorite: rgb(0xf5, 0xa5, 0x24),
+    favorite: rgb(0xef, 0x44, 0x44),
     logo: [
         rgb(0xf8, 0xfa, 0xfc),
         rgb(0xe2, 0xe8, 0xf0),
@@ -173,7 +175,7 @@ const LIGHT: Roles = Roles {
     success: rgb(0x05, 0x96, 0x69),
     plan: rgb(0x7c, 0x3a, 0xed),
     accent: rgb(0x4f, 0x46, 0xe5),
-    favorite: rgb(0xa1, 0x62, 0x07),
+    favorite: rgb(0xdc, 0x26, 0x26),
     // Reversed against a light background: the lit edge is the dark one, as a steel letter on
     // paper is darkest where it stands up.
     logo: [

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -230,7 +230,7 @@ impl Session {
         let virt = self.sidebar_virt_now();
         text.iter()
             .zip(virt.iter())
-            .filter(|(l, v)| l.starts_with("    ") && !v.trim().is_empty())
+            .filter(|(l, v)| l.starts_with(CONVERSATION_INDENT) && !v.trim().is_empty())
             .count()
     }
 
@@ -2073,6 +2073,12 @@ fn a_running_turn_says_how_long_it_has_been_running() {
 /// an emoji, so a terminal with a colour-emoji font draws it from there and hands back an outline.
 const STAR: char = '\u{2605}';
 
+/// What a conversation's row is indented by, and therefore what tells one from a project's.
+///
+/// A project sits one column in and a conversation three, which is the same two-column step a
+/// worktree takes from the repository it is a tree of.
+const CONVERSATION_INDENT: &str = "   ";
+
 /// Project rows carrying the favourite mark.
 ///
 /// Scoped to rows naming a project, because the hint strip also prints a star — that is the point
@@ -2424,7 +2430,11 @@ fn a_worktree_nests_under_the_repository_it_belongs_to() {
             match (repo, tree) {
                 // Below its repository, indented past the repository's own arrow, and the branch
                 // alone — `work · sideline` is the flat list this replaced.
-                (Some(r), Some(t)) => t > r && rows[t].starts_with("    ") && !rows[t].contains('\u{b7}'),
+                (Some(r), Some(t)) => {
+                    t > r
+                        && rows[t].starts_with(CONVERSATION_INDENT)
+                        && !rows[t].contains('\u{b7}')
+                }
                 _ => false,
             }
         }),
@@ -2474,7 +2484,7 @@ fn an_emptied_worktree_is_still_inside_its_repository() {
             let repo = rows.iter().position(|l| l.contains("work") && !l.contains("sideline"));
             let tree = rows.iter().position(|l| l.contains("sideline"));
             match (repo, tree) {
-                (Some(r), Some(t)) => t > r && rows[t].starts_with("    "),
+                (Some(r), Some(t)) => t > r && rows[t].starts_with(CONVERSATION_INDENT),
                 _ => false,
             }
         }),

--- a/docs/config.md
+++ b/docs/config.md
@@ -619,10 +619,10 @@ await neosh.status.set("model", { text: "opus", keys: "^P", align: "right", prio
 ```
  PLAN
 ─────────────────────────────────
-   ██████░░  75% Session      27m
-   ████████  96% Weekly        8h
-   ████████ 100% Weekly ·…     8h
-   extra usage off
+ ██████░░  75% Session        27m
+ ████████  96% Weekly          8h
+ ████████ 100% Weekly ·…       8h
+ extra usage off
 ```
 
 At the foot of the sidebar, because unlike the context meter it is not about the conversation you
@@ -780,10 +780,10 @@ A conversation that is working says so wherever it appears. In the panel it carr
 its turn has been running; the one you are in gets the spinner:
 
 ```
- ★ ▾ neosh                        3
-     ▸ the flaky test in ci     1m 4s
-       ◍ rename the extmark api    22s
-       a question from yesterday   3h
+ ▾ neosh ★                       3
+   ▸ the flaky test in ci     1m 4s
+   ◍ rename the extmark api      22s
+   a question from yesterday      3h
 ```
 
 Switching back puts you in the middle of the answer rather than before it: what the turn has already

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -2469,7 +2469,7 @@ async function collect(
       p.sessions.length === 0 && p.worktrees.length === 0 &&
       (remote.get(p.key) ?? []).length === 0
     ) {
-      rows.push({ text: "       nothing here yet", hl: "Sidebar.Dim", inert: true });
+      rows.push({ text: "     nothing here yet", hl: "Sidebar.Dim", inert: true });
     }
   }
 
@@ -2480,7 +2480,7 @@ async function collect(
     const first = list[0];
     if (!first) continue;
     rows.push({
-      text: `   ${opts.ascii ? "~" : "▹"} ${clip(first.agent.project_name, opts.width - 12)}`,
+      text: ` ${opts.ascii ? "~" : "▹"} ${clip(first.agent.project_name, opts.width - 10)}`,
       hl: "Sidebar.Remote",
       right: { text: `${clip((hosts.get(key) ?? []).join(" "), 12)} `, hl: "Sidebar.Remote" },
       inert: true,
@@ -2490,7 +2490,7 @@ async function collect(
 
   rows.push(blank());
   rows.push({
-    text: "   + Add project",
+    text: " + Add project",
     hl: "Accent",
     value: { kind: "add" },
   });
@@ -2501,7 +2501,7 @@ async function collect(
   // that it goes away; a door is the most this panel should spend on saying where.
   if (archived.length > 0) {
     rows.push({
-      text: `   ${opts.ascii ? "-" : "┈"} Archived`,
+      text: ` ${opts.ascii ? "-" : "┈"} Archived`,
       hl: "Sidebar.Dim",
       right: { text: `${archived.length} `, hl: "Sidebar.Dim" },
       value: { kind: "browse", count: archived.length },
@@ -2546,20 +2546,24 @@ function sectionRows(
         ...heading(clip(c.item.title, opts.width - 2), opts.width, hint),
       );
     }
+    // One column, the same as this panel's own headings and top-level rows — a section is a
+    // section, not something indented under one. The three it used to be were three columns of a
+    // gauge, on every row of the strip, saying nothing.
+    const margin = " ";
     for (const r of contributed) {
       if (typeof r?.text !== "string") continue;
-      const text = `   ${clip(r.text, Math.max(4, opts.width - 6))}`;
+      const text = `${margin}${clip(r.text, Math.max(4, opts.width - 2 - margin.length))}`;
       rows.push({
         text,
         // A third party's row gets the same treatment ours do: we have no idea how long its text
         // is, and a plugin's row cut at our column is our bug rather than theirs.
-        full: `   ${r.text}`,
-        indent: 3,
+        full: `${margin}${r.text}`,
+        indent: margin.length,
         hl: typeof r.hl === "string" ? r.hl : undefined,
         // Shifted by our indent and clamped to what survived the clip. Checked rather than
         // trusted, like every other field here: a span running off the end of a row this panel
         // shortened is a mark on a column that is not there.
-        spans: shift(r.spans, byteLength("   "), byteLength(text)),
+        spans: shift(r.spans, byteLength(margin), byteLength(text)),
         right: typeof r.right?.text === "string"
           ? { text: `${r.right.text} `, hl: r.right.hl }
           : undefined,
@@ -2646,10 +2650,14 @@ function projectRow(
       ? { text: `${within.length} `, hl: "Sidebar.Dim" }
       : { text: "" };
 
-  // The star sits before the fold arrow rather than after the name: it is what you scan the
-  // column for, and a marker at the ragged right edge is not a column. It gets its own highlight
-  // because the world has already decided what colour a favourite is — a grey star is a star you
-  // have to decode.
+  // The star sits directly after the name, and costs nothing on a project that has not got one.
+  // It used to be a fixed column *before* the fold arrow, which meant every project name in the
+  // narrowest panel in the workspace paid two columns, permanently, for a mark on three or four
+  // rows — and the right-hand edge is not the answer either: that column already belongs to the
+  // count and the elapsed time, which is a number you read against the rows above and below it.
+  // Attached to the name it is a property of the thing it is beside, which is what it is. It keeps
+  // its own highlight because the world has already decided what colour a favourite is — a grey
+  // star is a star you have to decode.
   //
   // A star rather than a heart, and the reason is font fallback: `♥` is U+2665, which Unicode
   // classifies as an emoji even though its default presentation is text. A terminal that has a
@@ -2657,7 +2665,7 @@ function projectRow(
   // at somebody else's weight — commonly an outline, which is what a filled glyph is not. Every
   // heart codepoint has that problem. `★` is U+2605, `Emoji=No`, so no terminal has any reason to
   // leave the font it is drawing the rest of the row in.
-  const star = p.favorite ? (opts.ascii ? "*" : "★") : " ";
+  const star = p.favorite ? (opts.ascii ? " *" : " ★") : "";
 
   // Which other computers have this project. The whole reason a project key is a normalised git
   // remote rather than a path: on two machines the path is different and this is the same.
@@ -2707,24 +2715,33 @@ function projectRow(
     : ` ${dot}${count}`;
   const markHl = folded && waiting ? "Status.Pending" : dotHl;
 
+  // The star's two columns come off the name that is about to carry it, so a favourite and the
+  // project under it still end in the same place — clipping the name is what a panel this narrow
+  // does, and letting the mark run two columns past everything else is not.
   const name = clip(
     p.name,
-    Math.max(6, opts.width - 8 - byteLength(mark) - (elsewhere.length ? 8 : 0)),
+    Math.max(
+      6,
+      opts.width - 8 - byteLength(mark) - byteLength(star) - (elsewhere.length ? 8 : 0),
+    ),
   );
   const spans: Array<{ from: number; to: number; hl: string }> = [];
-  if (p.favorite) spans.push({ from: 1, to: 1 + byteLength(star), hl: "Sidebar.Favorite" });
+  if (star !== "") {
+    const from = byteLength(` ${arrow} ${name}`);
+    spans.push({ from, to: from + byteLength(star), hl: "Sidebar.Favorite" });
+  }
   if (mark !== "") {
-    const from = byteLength(` ${star} ${arrow} ${name}`);
+    const from = byteLength(` ${arrow} ${name}${star}`);
     spans.push({ from, to: from + byteLength(mark), hl: markHl });
   }
   return {
-    text: ` ${star} ${arrow} ${name}${mark}`,
+    text: ` ${arrow} ${name}${star}${mark}`,
     // A project's name is a directory name, and directory names are long. Clipped it is the same
     // eight characters as the three others you have open beside it, which is the panel failing at
-    // the one thing it is for. The unread dot is left off deliberately: it survived the clip and
-    // is already on the row.
-    full: ` ${star} ${arrow} ${p.name}`,
-    indent: 5,
+    // the one thing it is for. The star and the unread dot are left off deliberately: they
+    // survived the clip and are already on the row.
+    full: ` ${arrow} ${p.name}`,
+    indent: 3,
     hl: here ? "Directory" : "Sidebar.Dim",
     spans: spans.length > 0 ? spans : undefined,
     right: elsewhere.length > 0
@@ -2773,10 +2790,13 @@ function worktreeRow(
   // The branch glyph, in the branch colour — what says "this row is a checkout" at a glance, so
   // the name can be just the branch. No ASCII stand-in earns its column, so ASCII goes without.
   const glyph = opts.ascii ? "" : "⎇ ";
-  const pad = "    ";
+  // One step in from its repository's arrow, and the step is two columns — the same one a
+  // conversation takes from the project it is in. Three, when the star was on the left, made the
+  // nesting read as two levels where there is one.
+  const pad = "   ";
   const name = clip(
     p.name,
-    Math.max(6, opts.width - 9 - byteLength(glyph) - byteLength(mark)),
+    Math.max(6, opts.width - 8 - byteLength(glyph) - byteLength(mark)),
   );
   const spans: Array<{ from: number; to: number; hl: string }> = [];
   if (glyph !== "") {
@@ -2818,9 +2838,9 @@ function remoteRow(r: SwarmAgent, opts: DrawOptions, now: number): ListRow<Targe
     const host = clip(r.node.name, 12);
     const width = Math.max(8, opts.width - 8 - host.length);
     return {
-      text: `    ${glyph} ${clip(r.agent.label, width)}`,
-      full: `    ${glyph} ${r.agent.label}`,
-      indent: 6,
+      text: `   ${glyph} ${clip(r.agent.label, width)}`,
+      full: `   ${glyph} ${r.agent.label}`,
+      indent: 5,
       hl: working ? "Status.Monitoring" : "Sidebar.Remote",
       right: { text: `${host} `, hl: "Sidebar.Remote" },
       value: {
@@ -2896,7 +2916,7 @@ function sessionRow(
     : s.updated_at > 0 ? ago(now / 1000 - s.updated_at) : "";
   // Two more columns per level: a conversation inside a worktree sits inside the worktree's row
   // the way the worktree sits inside its repository's.
-  const pad = "    " + "  ".repeat(depth);
+  const pad = "   " + "  ".repeat(depth);
   // What is left for the title, counted rather than guessed at. The indent, the glyph and the
   // space after it come off the front; the age column and the space keeping it off the panel edge
   // come off the end, plus one column of air so a title cannot run into a timestamp. The old

--- a/plugins/builtin/usage/main.ts
+++ b/plugins/builtin/usage/main.ts
@@ -305,9 +305,9 @@ function section(
   style: Style,
 ) {
   const rows: StripRow[] = [];
-  // What the sidebar leaves for the text (`   ` and its own margin), less the widest countdown and
-  // a space to keep it off the label.
-  const room = Math.max(14, width - 6 - 5);
+  // What the sidebar leaves for the text (its one-column margin at each edge), less the widest
+  // countdown and a space to keep it off the label.
+  const room = Math.max(14, width - 2 - 5);
   const accounts = quotas.filter((q) => q.windows.length > 0);
 
   for (const q of accounts) {


### PR DESCRIPTION
The favourite marker was a fixed column *before* the fold arrow, so every project name in the narrowest panel in the workspace paid two columns, permanently, for a mark on three or four rows. It goes after the name, where it is a property of the thing it is beside, and costs nothing on a project that has not got one — its two columns come off the name that carries it, so a favourite and the project under it still end in the same place.

That freed the indents everything else was built around:

```
 ▾ neosh ★                      1
   ▾ ⎇ refactor/sidebar-row-…   1
     ▸ New conversation       now
```

A project's arrow is at column 1, a worktree and a conversation at 3, a conversation inside a worktree at 5 — two columns per level, where the project-to-worktree step used to be three and read as two levels where there is one. `+ Add project`, `┈ Archived` and the remote-project rows move up beside the project rows.

Contributed sections lose two more. They sat at a three-column indent under a heading at one; a section is a section, not something indented under one. The plan strip is the only one that ships, and it gets four columns back — its text budget goes 23 → 27 at the default width, which is the difference between an eight-cell bar and the full ten:

```
 PLAN                          ^L
──────────────────────────────────
 ✳ Claude ████░░░░░░  37%      6d
```

**The star is red** (`#ef4444` dark, `#dc2626` light). Next door to `danger`, which is the obvious objection and is answered the way the old amber answered its collision with `attention`: these are told apart by shape, never by hue — `danger` is only ever a `✗`, a word or a row it has taken over, and nothing else in the workspace draws a star. It is also the more saturated of the two in both themes, because the error red lands on text you still have to read and this lands on one glyph that is nothing but itself.

## Verification

Driven on screen with `scripts/shot.py`, including `--color` to confirm the star keeps `Sidebar.Favorite` rather than inheriting the dim colour beside it.

- `cargo test -p neosh --test builtin_plugins -- --test-threads 2` — 153/153
- `cargo test -p neosh --test workspace -- --test-threads 2` — 19/19
- `cargo test -p neosh-core -- --test-threads 2` — 145
- `cargo test -p neosh-proto export_bindings` + `git diff --exit-code plugins/api/src/generated` — no drift
- `tsc --noEmit` in `plugins/api` and `plugins/builtin`

Two test helpers were reading the geometry: the four-space literal that told a conversation's row from a project's is now a named `CONVERSATION_INDENT`.