### PR TITLE
A request nobody answers is a turn that never ends

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,19 @@ per decision, and records the *reasoning*, not the choice.
   so a generated id is an answer to nothing — and **nobody answering is a denial with a sentence in
   it**, never an `allow` with an empty map, because the empty map is what the agent reads as
   "ignored me". See ADR 0043.
+- **A request nobody answers is a turn that never ends.** The control protocol blocks: the CLI waits
+  for a `control_response` carrying the id it sent, for as long as that takes. So the two
+  classifiers over one pipe must never both stand aside — `can_use_tool` asks *"would
+  `ask_user_question` claim this?"* rather than testing the flag itself, because
+  `requires_user_interaction` says *somebody has to see this*, not *this is a question*.
+  `ExitPlanMode` sets it and carries a **plan**, so the permission path stood aside for the question
+  path and the question path declined it for want of a question, and a conversation sat under
+  `Running ExitPlanMode… 93m 15s` — a spinner nothing on screen could tell from work. Leaving plan
+  mode is an ordinary permission, asked even under `--dangerously-skip-permissions`, and full access
+  says yes to it. The other half is that a line reaching the bottom of the reader is **refused out
+  loud** by request id rather than dropped: a refusal ends a turn badly and in the transcript,
+  silence does not end it at all, and only one of the two is recoverable from the keyboard. See ADR
+  0057.
 - **Everything irreversible asks, and nothing reversible does.** No exceptions on either side: a
   dialog that appears for some deletes and not others is a key whose behaviour you cannot predict
   from the row it is pointed at, and one charged for an action you can undo is what teaches people

--- a/crates/neosh-provider/src/drivers/claude_cli.rs
+++ b/crates/neosh-provider/src/drivers/claude_cli.rs
@@ -930,6 +930,16 @@ async fn run_turn(
                     }
                     continue;
                 }
+                // Anything else the CLI asked for and is now waiting on. Last, so every handler
+                // above has had its go, and unconditional, so there is no line it can send that
+                // leaves the turn hanging. See [`claude_control::unhandled`].
+                if let Some(reply) = claude_control::unhandled(&v) {
+                    if write_line(&mut live.stdin, &reply).await.is_err() {
+                        *slot = None;
+                        break;
+                    }
+                    continue;
+                }
                 // How full the context is. Matched by *shape* rather than by request id: several
                 // of these are asked over a long turn, they all answer the same question, and the
                 // only one that matters is the newest.

--- a/crates/neosh-provider/src/drivers/claude_control.rs
+++ b/crates/neosh-provider/src/drivers/claude_control.rs
@@ -71,8 +71,15 @@ pub fn can_use_tool(v: &Value, cwd: &Path) -> Option<CanUseTool> {
     // A question is not a permission, and reading one as a permission is how it stops working:
     // policy answers it — `full access` says yes before anyone is asked — and the bare yes that
     // comes back carries no answers, so the CLI tells its own model "The user did not answer the
-    // questions". [`ask_user_question`] claims these; this refuses them.
-    if is_question(req) {
+    // questions".
+    //
+    // Asked as *"would [`ask_user_question`] claim this?"* rather than decided over again here.
+    // The two used to test different things — this one a flag, that one a shape — so a request
+    // that set the flag without carrying the shape was refused by both and answered by neither.
+    // The CLI blocks until something replies, which makes that a turn with no end: `ExitPlanMode`
+    // sets `requires_user_interaction` and carries a `plan` rather than `questions`, and hung for
+    // as long as the workspace stayed up. One parse, one owner, and the two cannot drift apart.
+    if ask_user_question(v).is_some() {
         return None;
     }
     let request_id = v.get("request_id").and_then(Value::as_str)?.to_string();
@@ -172,6 +179,33 @@ pub fn response(ask: &CanUseTool, answer: &PermissionAnswer) -> Value {
     })
 }
 
+/// The reply to a `control_request` nothing above understood.
+///
+/// The CLI blocks on every request it sends until a response carrying that id comes back, so a
+/// line no handler claimed is not an event that was ignored — it is a turn that stops, with a
+/// spinner over it, until the workspace is restarted. Silence is the one answer there is no
+/// recovering from, so whatever is left over is refused out loud: the CLI unblocks, its model is
+/// told the call failed, and the turn goes on to say so.
+///
+/// Deliberately last and deliberately dumb. It exists for the subtype this was not written
+/// against — the one the next release of the CLI invents — and the fix for any particular one of
+/// them is a handler above, not a better sentence here.
+pub fn unhandled(v: &Value) -> Option<Value> {
+    if v.get("type").and_then(Value::as_str) != Some("control_request") {
+        return None;
+    }
+    let request_id = v.get("request_id").and_then(Value::as_str)?;
+    let subtype = v.pointer("/request/subtype").and_then(Value::as_str).unwrap_or("unknown");
+    Some(json!({
+        "type": "control_response",
+        "response": {
+            "subtype": "error",
+            "request_id": request_id,
+            "error": format!("neosh does not handle {subtype}"),
+        },
+    }))
+}
+
 /// One `can_use_tool` that is really a question, read into something a person can be asked.
 ///
 /// The CLI's `AskUserQuestion` arrives down the same pipe as a permission request and is not one.
@@ -192,12 +226,19 @@ pub struct AskUser {
     pub raw: Value,
 }
 
-/// Whether a `can_use_tool` request is a question rather than a permission.
+/// Whether a `can_use_tool` request *claims* to be a question.
 ///
-/// Both tests, because they fail differently. `requires_user_interaction` is the CLI *saying so*
-/// and is the honest signal — it is set for anything that must reach a person, whatever it ends up
-/// being called. The name is the fallback for an install too old to send the flag, and it is the
-/// one every version has.
+/// Both tests, because they fail differently. `requires_user_interaction` is the CLI saying
+/// something has to reach a person, and it is the signal for a tool this was never written
+/// against. The name is the fallback for an install too old to send the flag, and it is the one
+/// every version has.
+///
+/// Neither is sufficient, which is why this is private and a precondition rather than a decision.
+/// The flag is set for *anything* that must reach a person — `ExitPlanMode` sets it, and what it
+/// carries is a plan — while only a request with `questions` in it can be *answered* as a
+/// question. What makes something a question here is that there is a question in it, so
+/// [`ask_user_question`] is the one that decides, and [`can_use_tool`] asks it rather than
+/// repeating it.
 fn is_question(req: &Value) -> bool {
     req.get("requires_user_interaction").and_then(Value::as_bool).unwrap_or(false)
         || req.get("tool_name").and_then(Value::as_str) == Some("AskUserQuestion")
@@ -469,7 +510,9 @@ fn host_of(url: &str) -> Option<String> {
 
 #[cfg(test)]
 mod questions {
-    //! The `AskUserQuestion` half, captured from a real `claude 2.1.237`.
+    //! The `AskUserQuestion` half, captured from a real `claude 2.1.237` — and the line
+    //! between it and the permission half, which is where a request that is neither went
+    //! missing.
 
     use super::*;
     use neosh_proto::QuestionAnswer;
@@ -567,6 +610,9 @@ mod questions {
             let mut v = asked();
             v["request"]["input"] = input.clone();
             assert_eq!(ask_user_question(&v), None, "{input}");
+            // And the ordinary path really does have it. Asserted rather than assumed: the two
+            // used to read the same flag and both step aside, which left nothing to refuse it.
+            assert!(can_use_tool(&v, Path::new("/w")).is_some(), "{input}");
         }
     }
 
@@ -672,6 +718,87 @@ mod questions {
         let answers = &r["response"]["response"]["updatedInput"]["answers"];
         assert_eq!(answers["Do you prefer tabs or spaces?"], "Tabs");
         assert!(answers.get("Which of these should be enabled?").is_none());
+    }
+
+    /// A real `ExitPlanMode` request, exactly as `claude 2.1.237` sends it. Note what it has and
+    /// what it has not: the flag that says a person must see this, and an input that is a plan.
+    fn exiting_plan_mode() -> Value {
+        json!({
+            "type": "control_request",
+            "request_id": "48d09a8a-1bd5-45af-9f7e-9d5f55a5bf36",
+            "request": {
+                "subtype": "can_use_tool",
+                "tool_name": "ExitPlanMode",
+                "display_name": "ExitPlanMode",
+                "input": {
+                    "plan": "# Independent views\n\n## Context\n",
+                    "planFilePath": "/home/x/.claude/plans/quizzical-fluttering-thunder.md",
+                },
+                "tool_use_id": "toolu_01VbsogyQFdV9mqxi4Qc7JMd",
+                "requires_user_interaction": true,
+            },
+        })
+    }
+
+    #[test]
+    fn asking_to_leave_plan_mode_is_a_permission_and_is_answered() {
+        // The hang. `requires_user_interaction` was read as "this is a question", so the
+        // permission path refused it; the question path wanted a `questions` array it does not
+        // have and refused it too. Nothing replied, and the CLI blocks until something does — a
+        // turn with a spinner on it for as long as the workspace was up.
+        let v = exiting_plan_mode();
+        assert_eq!(ask_user_question(&v), None, "there is no question in it");
+        let ask = can_use_tool(&v, Path::new("/w")).expect("a permission request");
+        assert_eq!(ask.request_id, "48d09a8a-1bd5-45af-9f7e-9d5f55a5bf36");
+        assert_eq!(ask.tool_use_id.as_deref(), Some("toolu_01VbsogyQFdV9mqxi4Qc7JMd"));
+
+        // And the yes the CLI accepts for it. Verified against the real thing, which answers
+        // "User has approved exiting plan mode."
+        let r = response(&ask, &PermissionAnswer::Allow);
+        assert_eq!(r["response"]["request_id"], ask.request_id);
+        assert_eq!(r["response"]["response"]["behavior"], "allow");
+        assert_eq!(r["response"]["response"]["toolUseID"], "toolu_01VbsogyQFdV9mqxi4Qc7JMd");
+    }
+
+    #[test]
+    fn every_request_that_must_reach_a_person_is_claimed_by_exactly_one_of_the_two() {
+        // The invariant the two used to break between them, over the flag they both read.
+        for v in [exiting_plan_mode(), asked()] {
+            let question = ask_user_question(&v).is_some();
+            let permission = can_use_tool(&v, Path::new("/w")).is_some();
+            assert!(question ^ permission, "{v}");
+        }
+    }
+
+    #[test]
+    fn a_control_request_nothing_claimed_is_refused_rather_than_dropped() {
+        // The backstop, for the subtype that does not exist yet. A refusal ends the turn badly;
+        // silence does not end it at all.
+        let v = json!({
+            "type": "control_request",
+            "request_id": "r-9",
+            "request": { "subtype": "something_invented_later" },
+        });
+        assert_eq!(ask_user_question(&v), None);
+        assert_eq!(can_use_tool(&v, Path::new("/w")), None);
+        let reply = unhandled(&v).expect("a refusal");
+        assert_eq!(reply["type"], "control_response");
+        assert_eq!(reply["response"]["subtype"], "error");
+        assert_eq!(reply["response"]["request_id"], "r-9");
+        let why = reply["response"]["error"].as_str().unwrap_or_default();
+        assert!(why.contains("something_invented_later"), "{reply}");
+    }
+
+    #[test]
+    fn what_the_cli_says_back_is_never_answered_as_a_request() {
+        // `unhandled` is reached by every line, so it has to be able to tell the two apart.
+        for v in [
+            json!({ "type": "control_response", "response": { "subtype": "success" } }),
+            json!({ "type": "assistant", "message": { "content": [] } }),
+            json!({ "type": "control_request" }),
+        ] {
+            assert_eq!(unhandled(&v), None, "{v}");
+        }
     }
 }
 

--- a/crates/neosh-provider/tests/claude_stream_json.rs
+++ b/crates/neosh-provider/tests/claude_stream_json.rs
@@ -280,3 +280,79 @@ async fn a_turn_that_walked_away_from_a_shell_is_told_when_the_shell_finishes() 
     );
     assert!(said.contains("SECOND"), "and this turn's own answer never arrived\n{said:?}");
 }
+
+/// A `claude` that asks something and *waits*, which is what the control protocol always was.
+///
+/// The CLI blocks on every `control_request` it sends until a `control_response` carrying that id
+/// comes back, so this stand-in does too: it says nothing more until it is answered, and the turn
+/// only ends because something answered it.
+///
+/// Two requests, and neither of them is `AskUserQuestion`. The first is `ExitPlanMode`, captured
+/// off `claude 2.1.237` — `requires_user_interaction`, and a `plan` where a question path would
+/// look for `questions`. The second is a subtype that does not exist, standing in for the one the
+/// next release invents.
+const WAITING: &str = r##"#!/bin/sh
+n=0
+say() { printf '%s\n' "$1"; }
+finish() {
+  say '{"type":"stream_event","session_id":"s","event":{"type":"message_start","message":{"model":"m","usage":{}}}}'
+  say '{"type":"stream_event","session_id":"s","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}}'
+  say "{\"type\":\"stream_event\",\"session_id\":\"s\",\"event\":{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"$1\"}}}"
+  say '{"type":"stream_event","session_id":"s","event":{"type":"content_block_stop","index":0}}'
+  say '{"type":"stream_event","session_id":"s","event":{"type":"message_stop"}}'
+  say "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":\"$1\",\"session_id\":\"s\"}"
+}
+while IFS= read -r line; do
+  case "$line" in
+    *'"subtype":"get_context_usage"'*)
+      say '{"type":"control_response","response":{"subtype":"success","request_id":"x","response":{"totalTokens":10,"maxTokens":100}}}' ;;
+    *'"type":"control_response"'*)
+      case "$line" in
+        *'"request_id":"plan-1"'*) finish ANSWERED-PLAN ;;
+        *'"request_id":"odd-1"'*) finish ANSWERED-ODD ;;
+      esac ;;
+    *'"type":"user"'*)
+      n=$((n+1))
+      if [ "$n" = 1 ]; then
+        say '{"type":"control_request","request_id":"plan-1","request":{"subtype":"can_use_tool","tool_name":"ExitPlanMode","display_name":"ExitPlanMode","input":{"plan":"# A plan\n","planFilePath":"/tmp/p.md"},"tool_use_id":"toolu_plan","requires_user_interaction":true}}'
+      else
+        say '{"type":"control_request","request_id":"odd-1","request":{"subtype":"something_invented_later"}}'
+      fi ;;
+  esac
+done
+"##;
+
+/// The timeout is the assertion. A request nothing answers is not a turn that ends badly, it is a
+/// turn that does not end — which on screen is a spinner over an empty conversation for as long as
+/// the workspace is up, and in a test is a run that hangs rather than fails.
+async fn answered(p: &ClaudeCliProvider, fake: &Fake, text: &str) -> String {
+    let stream = p.stream(&inst(), req(&fake.dir, text), CancellationToken::new());
+    let turn = stream.collect::<Vec<_>>();
+    let got = tokio::time::timeout(std::time::Duration::from_secs(20), turn)
+        .await
+        .expect("the turn never ended: the CLI asked something nothing replied to");
+    text_of(&got)
+}
+
+#[tokio::test]
+async fn a_request_to_leave_plan_mode_is_answered_rather_than_dropped() {
+    // The hang, end to end. `requires_user_interaction` was read as "this is a question", so the
+    // permission path stood aside; the question path wanted a `questions` array `ExitPlanMode`
+    // does not have, so it stood aside too. Nothing wrote a line back, and the CLI is entitled to
+    // wait forever — 94 minutes, in the conversation this was found in.
+    let fake = Fake::running("waiting", WAITING);
+    // One provider for both turns, because one `claude` holds one conversation: a second provider
+    // would be a second process, back at its first question.
+    let p = ClaudeCliProvider::new(fake.program());
+    assert!(
+        answered(&p, &fake, "one").await.contains("ANSWERED-PLAN"),
+        "nothing replied to the CLI's plan-mode request"
+    );
+
+    // And the backstop under it, for the subtype this was not written against. A refusal ends the
+    // turn badly; silence does not end it at all.
+    assert!(
+        answered(&p, &fake, "two").await.contains("ANSWERED-ODD"),
+        "a control request nothing understood was dropped instead of refused"
+    );
+}

--- a/docs/adr/0057-a-request-nobody-answers-is-a-turn-that-never-ends.md
+++ b/docs/adr/0057-a-request-nobody-answers-is-a-turn-that-never-ends.md
@@ -1,0 +1,108 @@
+# 0057 — A request nobody answers is a turn that never ends
+
+**Status:** accepted
+
+## Context
+
+Reported as *"it did not update or anything… it's been running for more than 1.5 hours and
+nothing"*. The footer said `Running ExitPlanMode… 93m 15s`, with `esc to interrupt` beside it, over
+a conversation that had drawn its last row an hour and a half earlier.
+
+The process was alive and idle. Its own transcript ended on the `tool_use`, with no `tool_result`
+after it and no write to the file since:
+
+```text
+== assistant 2026-08-23T09:29:45.571Z
+  tool_use: ExitPlanMode toolu_01Vbso… {"plan": "# Independent views: a terminal is a place you are…
+```
+
+`ExitPlanMode` asks before it acts, and it asks over the control protocol — **even under
+`--dangerously-skip-permissions`**, which is the flag full access is launched with. Driven by hand,
+with the same flags and the stream held open, the CLI sends this and then says nothing at all:
+
+```json
+{"type":"control_request","request_id":"48d09a8a…","request":{
+  "subtype":"can_use_tool","tool_name":"ExitPlanMode",
+  "input":{"plan":"…","planFilePath":"…"},
+  "tool_use_id":"toolu_01Vbso…","requires_user_interaction":true}}
+```
+
+ADR 0043 established that a question is not a permission, and split the two paths. It split them on
+two different tests, and that is the bug:
+
+- `can_use_tool` refused anything `is_question` claimed, and `is_question` was true on
+  `requires_user_interaction` **alone**.
+- `ask_user_question` claimed only a request carrying an `input.questions` array.
+
+`ExitPlanMode` sets the flag and carries a *plan*. So the permission path stood aside for the
+question path, the question path declined it for want of a question, and the line fell past both
+into handlers that only match `control_response`. Nothing wrote a reply. The CLI is entitled to wait
+forever for one, and did.
+
+The flag was never wrong about what it says. It says *something here has to reach a person* — which
+is true of a plan, a permission and a question alike — and it was read as *this is a question*. The
+comment on `is_question` even said so: "it is set for anything that must reach a person, whatever it
+ends up being called."
+
+## Decision
+
+### Whether it is a question is decided once
+
+`can_use_tool` no longer re-decides it. It asks the other function:
+
+```rust
+if ask_user_question(v).is_some() {
+    return None;
+}
+```
+
+One parse, one owner. The two classifiers cannot disagree about a request because only one of them
+has an opinion, and what makes something a question here is what it always should have been: that
+there is a question in it. `is_question` survives as a *precondition* of `ask_user_question` — the
+flag and the tool name are still how a renamed tool and an older install are recognised — and is
+private, because on its own it decides nothing.
+
+This is also what the pre-existing test
+`a_request_with_no_answerable_question_in_it_is_not_one` claimed and did not check. Its comment said
+a dialog with no rows "goes down the ordinary path and is refused like anything else"; it asserted
+only that the question path declined it. The permission path had declined it too.
+
+### And nothing the CLI asks can go unanswered
+
+Fixing the classifier fixes `ExitPlanMode`. It does not fix the shape of the failure, which is that
+a line no handler claimed is silently discarded — and on this protocol, discarding a request is not
+ignoring an event, it is stopping a turn.
+
+So the reader ends with a backstop. Any `control_request` that reached the bottom is refused out
+loud, by request id:
+
+```json
+{"type":"control_response","response":{"subtype":"error","request_id":"…",
+ "error":"neosh does not handle something_invented_later"}}
+```
+
+Deliberately last and deliberately dumb. It is for the subtype the next release of the CLI invents,
+and the right fix for any particular one of them is a handler above it, not a better sentence here.
+A refusal ends a turn badly and visibly; silence does not end it at all, and only one of those is
+recoverable from the keyboard.
+
+## Consequences
+
+**Leaving plan mode works, and it is an ordinary permission.** Verified against the real CLI: the
+`allow` neosh already builds — `behavior`, `decisionClassification`, `toolUseID` — is answered with
+`User has approved exiting plan mode.` Under full access, policy says yes and nobody is interrupted;
+under `ask`, it is a prompt like any other, and the plan is what the prompt is about.
+
+**Every tool that must reach a person is now claimed by exactly one path**, and that is asserted
+rather than assumed. `ExitPlanMode` was simply the first such tool to exist; the flag will be set by
+the next one too, and it will land in the permission path instead of nowhere.
+
+**The class of bug is closed, not just the instance.** `a_request_to_leave_plan_mode_is_answered_rather_than_dropped`
+drives a stand-in CLI that behaves the way the real one does — it blocks until it is answered — so
+the test for an unanswered request is a turn that never ends. Without the fix it fails on a 20-second
+timeout, which is the symptom, scaled down.
+
+**The backstop is a refusal, not an answer.** A subtype neosh does not implement still fails; it
+fails in the turn, where the model can say so, instead of in a pipe. If that refusal ever turns out
+to be the wrong answer for some future request, the evidence will be a turn that reported something
+rather than a workspace somebody restarted.


### PR DESCRIPTION
Reported as *"it did not update or anything… it's been running for more than 1.5 hours and nothing"*: the footer said `Running ExitPlanMode… 93m 15s` over a conversation whose last row was drawn an hour and a half earlier. The process was alive and idle, and its own transcript ended on the `tool_use` — no `tool_result` after it, no write to the file since.

## What was wrong

`ExitPlanMode` asks before it acts, and it asks over the control protocol — **even under `--dangerously-skip-permissions`**, which is what full access launches with:

```json
{"type":"control_request","request_id":"48d09a8a…","request":{
  "subtype":"can_use_tool","tool_name":"ExitPlanMode",
  "input":{"plan":"…","planFilePath":"…"},
  "tool_use_id":"toolu_01Vbso…","requires_user_interaction":true}}
```

ADR 0043 split questions from permissions, and split them on two different tests:

- `can_use_tool` refused anything `is_question` claimed, and `is_question` was true on `requires_user_interaction` **alone**.
- `ask_user_question` claimed only a request carrying an `input.questions` array.

`ExitPlanMode` sets the flag and carries a *plan*. The permission path stood aside for the question path, the question path declined it for want of a question, and the line fell past both into handlers that only match `control_response`. Nothing wrote a reply, and the CLI is entitled to wait forever for one.

The flag was never wrong about what it says — *somebody has to see this*, which is true of a plan, a permission and a question alike. It was read as *this is a question*.

## What changed

**Whether it is a question is decided once.** `can_use_tool` asks whether `ask_user_question` would claim it rather than testing the flag itself; `is_question` stays as a precondition of the one function that decides. What makes something a question here is that there is a question in it.

**And nothing the CLI asks can go unanswered.** That fixes `ExitPlanMode` but not the shape — a line no handler claimed is silently dropped, and on this protocol dropping a request is not ignoring an event, it is stopping a turn. The reader now ends with a backstop that refuses whatever reached the bottom, by request id. Deliberately last and deliberately dumb: it is for the subtype the next release invents, and the fix for any particular one of them is a handler above it.

## Verification

- `cargo test -p neosh-provider` — 190 + 3 + 4 pass.
- `a_request_to_leave_plan_mode_is_answered_rather_than_dropped` drives a stand-in CLI that blocks until it is answered, the way the real one does, so the test for an unanswered request is a turn that never ends. **Reverted to the old sources it fails on a 20-second timeout** — the symptom, scaled down.
- Checked against the real binary that the `allow` neosh already builds is the one the CLI accepts: `User has approved exiting plan mode.`

Adds ADR 0057 and the corresponding rule in `AGENTS.md`.