### PR TITLE
chore: a flag nothing reads and three methods nobody calls

### DIFF
--- a/crates/neosh/src/daemon.rs
+++ b/crates/neosh/src/daemon.rs
@@ -265,7 +265,6 @@ impl Handle {
             }
         });
 
-        let mut attached = false;
         let mut view: Option<ViewId> = None;
         while let Ok(Some(line)) = lines.next_line().await {
             if line.trim().is_empty() {
@@ -319,7 +318,6 @@ impl Handle {
                         (id, views.size().unwrap_or((width, height)))
                     };
                     view = Some(id);
-                    attached = true;
                     let _ = out.send(ServerMessage::Attached {
                         protocol_version: neosh_proto::PROTOCOL_VERSION,
                     });

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -6262,20 +6262,6 @@ impl Host {
         at.max(0) as u32
     }
 
-    /// A blank row at the end of the transcript, unless there already is one.
-    fn chat_gap(&mut self) {
-        let at = self.chat_end();
-        let blank = at <= 0
-            || self
-                .editor
-                .buffer(self.chat)
-                .map(|b| b.get_lines((at - 1) as u32, at as u32).iter().all(|l| l.trim().is_empty()))
-                .unwrap_or(true);
-        if !blank {
-            self.chat_push(vec![String::new()]);
-        }
-    }
-
     /// Where new content goes: the end, or the line above the working line when there is one.
     fn chat_end(&self) -> i64 {
         let n = self.editor.buffer(self.chat).map(|b| b.line_count() as i64).unwrap_or(0);

--- a/crates/neosh/src/swarm.rs
+++ b/crates/neosh/src/swarm.rs
@@ -108,17 +108,9 @@ impl Swarm {
         self.peers.values().filter(|p| p.up).flat_map(|p| p.agents.iter().map(move |a| (&p.info, a)))
     }
 
-    pub fn find(&self, node: &NodeId, session: &SessionId) -> Option<&AgentSummary> {
-        self.peers.get(node)?.agents.iter().find(|a| &a.session == session)
-    }
-
     /// Tell the swarm which projects this machine has, so it can answer [`Self::hosts_of`].
     pub fn set_local_projects(&mut self, projects: HashMap<ProjectKey, String>) {
         self.local_projects = projects;
-    }
-
-    pub fn is_local_project(&self, key: &ProjectKey) -> bool {
-        self.local_projects.contains_key(key)
     }
 
     /// Which *other* machines have this project, by name.


### PR DESCRIPTION
Four `unused`/`dead_code` warnings on the way to a clean build of `neosh`.

- **`daemon.rs`: `attached`** — set beside `view = Some(id)` and never read. `view` is the same fact and is the one the detach path at the bottom of the loop consults; two records of one thing is one of them going stale.
- **`host.rs`: `chat_gap`** — a blank row above whatever came next. ADR 0050 attached a card to what it did and took the air out from above it, and this went orphaned with it.
- **`swarm.rs`: `find` and `is_local_project`** — `pub` in a binary crate reaches nobody outside it, so with no caller they are dead rather than API.

No behaviour changes.

## Verification

- `cargo build -p neosh` — clean, zero warnings.
- `cargo test -p neosh --test workspace -- --test-threads 2` — 19 passed, which is the suite that drives a real `neosh --serve` over a real socket and so exercises the attach/detach path the flag was in.