### PR TITLE
A project you removed is not a place to start a conversation

### DIFF
--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -2222,6 +2222,63 @@ fn a_new_conversation_in_a_repository_offers_a_worktree() {
     );
 }
 
+/// The trees it offers under "an existing one" are the ones on the panel's list, not every
+/// checkout `git worktree list` can see.
+///
+/// A scratch branch you finished with in March is still a worktree on disk long after `X` took it
+/// off the panel, so this picker was handing back every project you had ever removed — twenty rows
+/// of finished work above the three you are in — and choosing one put it straight into the sidebar
+/// again. The list is the workspace's answer to *which places do I work in* (ADR 0039), and this
+/// question asks exactly that.
+///
+/// Two worktrees, alike in every way git can see and differing only in whether anything was ever
+/// started in one of them, which is what makes this a statement about the list rather than about
+/// worktrees.
+#[test]
+fn a_worktree_that_is_not_on_the_list_is_not_offered() {
+    if !have_git() {
+        return;
+    }
+    let sb = Sandbox::new("newwherelist");
+    sb.git_init();
+    let add = |branch: &str| {
+        let at = sb.root.join(branch);
+        let out = Command::new("git")
+            .current_dir(sb.work())
+            .args(["worktree", "add", "-b", branch, &at.display().to_string()])
+            .output()
+            .expect("git runs");
+        assert!(out.status.success(), "worktree add: {}", String::from_utf8_lossy(&out.stderr));
+        at
+    };
+    let onlist = add("onlist");
+    add("offlist");
+
+    let mut s = sb.start();
+    s.wait_for("PROJECTS");
+    // A conversation started in a directory is how it joins the list. The other tree gets nothing,
+    // which is the state `X` leaves behind: on the disk, in git, on nobody's list.
+    s.send(&command_with("project.open", &onlist.display().to_string()));
+    assert!(s.pump(|s| s.sidebar_rows() >= 2), "it is a project now\n{:?}", s.sidebar_now());
+    // Asked from the checkout rather than from inside the new tree — the tree you are standing in
+    // is never one of the answers, so asking there could not tell the two rules apart.
+    s.send(&command_with("project.open", &sb.work().display().to_string()));
+    assert!(s.pump(|s| s.sidebar_rows() >= 3), "and we are back\n{:?}", s.sidebar_now());
+
+    s.ctrl("n");
+    assert!(
+        s.pump(|s| s.picker_named("[New conversation]").iter().any(|l| l.contains("onlist"))),
+        "the tree on the list is a row\n{:?}",
+        s.picker_named("[New conversation]")
+    );
+    let rows = s.picker_named("[New conversation]");
+    assert!(rows.iter().any(|l| l.contains("Here")), "the question is still asked\n{rows:?}");
+    assert!(
+        !rows.iter().any(|l| l.contains("offlist")),
+        "and the one nobody kept is not\n{rows:?}"
+    );
+}
+
 /// The picker's in-project row works with nothing configured: the tree lands in `.worktrees/`
 /// and `.gitignore` keeps it out of `git status` — no `worktree.root` edit required.
 ///

--- a/docs/adr/0039-the-archive-is-a-place-you-go.md
+++ b/docs/adr/0039-the-archive-is-a-place-you-go.md
@@ -172,3 +172,35 @@ the directory of a conversation that no longer existed.
 - **A fresh start is still a conversation.** The session a new workspace is constructed with is not
   a placeholder: nothing was cleared out, and `neosh` in a directory you have never opened should
   read as a conversation waiting rather than as a workspace you emptied.
+
+## What was corrected afterwards: a project you removed was still an answer to "where"
+
+`X` took a project off the list and the list stayed off it — that part worked. But the list is not
+the only place a directory is offered from, and the other one was not asking it anything.
+
+`^N` in a repository asks where the conversation goes, and among its answers are the worktrees you
+already have. Those rows came from `git worktree list`, which is every checkout on the disk. A
+worktree outlives the work in it: the branch is merged, the conversations are deleted, `X` takes the
+project off the panel, and the directory is still there — so after a few months of scratch branches
+the question "where does this conversation go" was answered with two dozen rows of finished work
+above the two or three places you are actually in. Choosing one put it straight back in the sidebar,
+which made `X` look like something that had not worked rather than something that had.
+
+**So the picker asks the list.** The trees it offers are `git worktree list` narrowed to the
+directories `sidebar.projects` knows, which is the same sentence as the one above: the list is the
+workspace's answer to which places you work in, and this question is asking exactly that. `X` now
+takes a project out of both, because there was only ever supposed to be one list.
+
+A worktree neosh has never heard of — one you made in a shell — is not on it either, and that is
+the rule rather than a casualty of it: `Another directory…`, on the bottom of the same picker, lists
+every tree git knows and is how a directory joins the list in the first place. One row for
+everything not on the list is what stops the list from being decoration.
+
+### Consequences
+
+- **`X` on a worktree row still leaves the checkout on the disk.** That is `d`'s job — the git
+  plugin's contribution — and this changes nothing about it. Taking a place off your list and
+  deleting a directory of work are different sizes of decision, and the second one asks.
+- **A tree you removed comes back the way any directory does.** `o`, or `Another directory…`, and a
+  conversation started in it puts it on the list again. Nothing is written down about the removal,
+  so nothing has to be cleared.

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -1135,7 +1135,7 @@ async function registerCommands(w: Wiring): Promise<void> {
     // row, so `n ⏎` is what `n` always did.
     const cwd = owningProject(target) ?? undefined;
     await p.leave();
-    await newConversation(neosh, cwd);
+    await newConversation(neosh, arrangement, cwd);
   }, { redraw: false });
 
   // ---- doors out of the panel ----
@@ -1187,9 +1187,11 @@ async function registerCommands(w: Wiring): Promise<void> {
     }, { desc: "Redraw the sidebar now" }),
   );
   w.subscriptions.push(
-    await neosh.cmd.register("session.new", (args) => newConversation(neosh, args[0]), {
-      desc: "Start a new conversation — here, or in a worktree of its own",
-    }),
+    await neosh.cmd.register(
+      "session.new",
+      (args) => newConversation(neosh, arrangement, args[0]),
+      { desc: "Start a new conversation — here, or in a worktree of its own" },
+    ),
   );
   w.subscriptions.push(
     await neosh.cmd.register("session.new.here", async (p) => {
@@ -1440,8 +1442,22 @@ function argsFor(target: Target | undefined): string[] {
  * Outside a repository the question has one answer, so it is not asked: `^N` stays a single key
  * everywhere the choice would be theatre. Inside one, `Here` is selected, so `^N ⏎` is what `^N`
  * always did.
+ *
+ * **The worktrees it offers are the ones on the panel's list**, which is what `arrangement` is for
+ * here. Every tree `git worktree list` knows is not the same set: a scratch branch you finished
+ * with in March is still a checkout on disk long after `X` took it off the list, so this picker
+ * was offering back, under "an existing one", every project you had ever removed — twenty rows of
+ * finished work above the three you are actually in, and choosing one put it straight back in the
+ * sidebar. The list is the workspace's answer to *which places do I work in* (see ADR 0039), and
+ * this question is asking exactly that. A worktree neosh has never heard of is not on it either,
+ * which is correct rather than a casualty: `Another directory…` lists every tree git knows and is
+ * how a directory joins the list in the first place.
  */
-async function newConversation(neosh: Neosh, base?: string): Promise<void> {
+async function newConversation(
+  neosh: Neosh,
+  arrangement: Arrangement,
+  base?: string,
+): Promise<void> {
   const current = await neosh.session.current().catch(() => null);
   const here = base ?? current?.cwd;
   // Empty outside a repository, which is also how this knows there is nothing to ask about: a
@@ -1455,7 +1471,9 @@ async function newConversation(neosh: Neosh, base?: string): Promise<void> {
   const canBranch = trees.length > 0 && commands.has("git.worktree.new.auto");
   const canInside = trees.length > 0 && commands.has("git.worktree.new.inside");
   const canName = trees.length > 0 && commands.has("git.worktree.new");
-  const others = trees.filter((t) => t.path !== here);
+  // On the list, and not merely on disk. `here` is dropped because you are already in it.
+  const known = new Set(arrangement.all());
+  const others = trees.filter((t) => t.path !== here && known.has(t.path));
 
   if (!canBranch && !canInside && !canName && others.length === 0) {
     await neosh.session.create(here ? { cwd: here } : undefined);


### PR DESCRIPTION
`^N` in a repository asks where the conversation goes, and among its answers are the worktrees you already have. Those rows came from `git worktree list`, which is **every checkout on the disk** — and a worktree outlives the work in it. The branch is merged, the conversations are deleted, `X` takes the project off the panel, and the directory is still there.

On this machine that is 25 worktrees against 5 projects on the list, so the question was answered with twenty rows of finished work above the places you are actually in — and choosing one put it straight back in the sidebar, which made `X` look like something that had not worked.

Before, with the filter removed, on real state:

```
❯ ● Here  /home/meszmate/.nsh/neosh/placid-raven
  + In a new worktree  …
  ⎇ main  worktree  ·  /home/meszmate/projects/neosh
  ⎇ refactor/sidebar-row-spacing  worktree  ·  …/amber-harbor
  ⎇ verify/merged-main  worktree  ·  …/amber-kestrel
  ⎇ feature/background-work-visibility  worktree  ·  …/amber-yarrow
  ⎇ coral-raven  worktree  ·  …/coral-raven
  ⎇ fix/closing-the-last-conversation  worktree  ·  …/glad-lark
  ⎇ hardy-thistle  worktree  ·  …/hardy-thistle
  ⎇ chore/clear-dead-code-warnings  worktree  ·  …/lucid-marlin
  … (scrolls)
```

After, same state:

```
❯ ● Here  /home/meszmate/.nsh/neosh/placid-raven
  + In a new worktree  …
  ⎇ main  worktree  ·  /home/meszmate/projects/neosh
  ⎇ fix/deleted-worktrees-in-new-session-picker  worktree  ·  …/nimble-ridge
  ⎇ feature/copy-project-path  worktree  ·  …/spry-sable
  ⎇ feature/independent-per-view-navigation  worktree  ·  …/tidy-finch
  ⎇ feature/archive-management  worktree  ·  …/witty-sparrow
  … Another directory…  somewhere else entirely
```

## What changed

`newConversation` takes the `Arrangement` and narrows git's answer to it:

```ts
const known = new Set(arrangement.all());
const others = trees.filter((t) => t.path !== here && known.has(t.path));
```

Which is the same sentence as ADR 0039's: the list is the workspace's answer to *which places do I work in*, and this question is asking exactly that. `X` now takes a project out of both, because there was only ever supposed to be one list.

A worktree neosh has never heard of — one you made in a shell — is not on it either, and that is the rule rather than a casualty of it: `Another directory…`, on the bottom of the same picker, lists every tree git knows and is how a directory joins the list in the first place. Nothing is written down about a removal, so nothing has to be cleared when the tree comes back.

`X` still leaves the checkout on the disk. That is `d`'s job, and taking a place off your list is a different size of decision from deleting a directory of work.

## Verification

- New test `a_worktree_that_is_not_on_the_list_is_not_offered`: two worktrees alike in every way git can see, differing only in whether anything was ever started in one of them. Proven non-vacuous by inverting the assertion — the picker really draws `onlist` and really omits `offlist`.
- `cargo test -p neosh --test builtin_plugins -- --test-threads 2` over the `worktree`, `project` and `conversation` sets: 12 + 11 + 16, all green.
- `cargo test -p neosh --test sessions`: 32 passed.
- `tsc --noEmit -p plugins/builtin`: clean.
- Both screenshots above are `scripts/shot.py` against a copy of a real workspace's state, one build each side of the filter.