### PR TITLE
feat(reader): yp copies the conversation's directory, and ⌥Y is allowed to stay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,9 @@ per decision, and records the *reasoning*, not the choice.
   key in a `ui.keys.*` list is the chord: the first one is what a hint row prints, and a legend is
   a promise about a keyboard. A capability that runs out of chords loses its key and keeps its
   command — `^K` runs it by name and `init.ts` can bind it — because inventing a prefix layer for
-  one verb costs every user a concept to save one of them a keystroke. See ADR 0048.
+  one verb costs every user a concept to save one of them a keystroke. Alt is bound on the terms
+  arrows are: only where a terminal-sendable route to the same thing already exists, so `⌥Y`
+  copies the directory in chat and `yp` does it in the reader. See ADR 0048.
 - **The cursor is on a character, and the frontend is the only thing that knows where that is.**
   Reading the transcript is a normal mode, so `$` is the last character rather than the space after
   it, `h` at column zero stays on its row, nothing parks past the end of one, and a selection
@@ -585,7 +587,7 @@ only way to do anything. See ADR 0048.
 | `^G` | Git status |
 | `^D` | Show what changed |
 | `^S` | Read the transcript — see below |
-| `⌥Y` | Copy this conversation's directory — in a worktree, the worktree's path |
+| `⌥Y` | Copy this conversation's directory — in a worktree, the worktree's path. The one Alt chord that ships, because it is never the only way: `yp` in the reader, `y` in the project panel, `^K` by name |
 | `^A` `^X` | Select everything, cut the selection |
 | `^C` | Copy the selection, or clear the draft, or (twice) quit |
 | `PgUp` `PgDn` `^End` | Scroll, and back to the newest message |
@@ -601,7 +603,10 @@ Composer editing is a text field: `←`/`→` by character and `^←`/`^→` by 
 `^Home`/`^End` for the ends, shift with any of them to select, `^W` and `^U` to delete a word or
 back to the start of the line. The capability ladder — `model.upgrade`, `model.downgrade` — has no
 default key: it had `⌥↑`/`⌥↓`, which is not a key every terminal sends, and `^K` runs both by
-name.
+name. Copying this conversation's directory — `session.copy.path`, which in a worktree is the
+worktree's path — keeps `⌥Y` on the terms arrows are bound on: a key that means something where it
+arrives and is never the only way — `^K` or `/copy` here, `y` on any row of the project panel, and
+`yp` in the reader.
 
 ## Reading the transcript — `^S`
 
@@ -657,6 +662,7 @@ on it, which after wrapping is not the window's height. See ADR 0051.
 | `yi` + an object | Copy one without selecting it first — `yiw`, `yi"` |
 | `yc` | Copy the **code block** the cursor is in, without its indent or language line |
 | `ym` | Copy the whole **turn** — the question and everything it produced |
+| `yp` | Copy this conversation's **directory** — in a worktree, the worktree's path. The one `y` that is not a piece of the transcript |
 | `ya` | Copy the entire transcript. Which is why `ya`*w* is the one thing here that is not Vim's — `viwy` is |
 | `i` `a` `o` `⏎` | Back to the composer. While selecting, `i` and `a` open a text object and `o` swaps ends |
 | `^S` | And back out, the way you came in |

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -4631,6 +4631,7 @@ impl Host {
             (Pending::Yank, "y") => self.yank_line(),
             (Pending::Yank, "c") => self.yank_code(),
             (Pending::Yank, "m" | "t") => self.yank_turn(),
+            (Pending::Yank, "p") => self.yank_path(),
             (Pending::Yank, "a") => {
                 self.select_all(self.chat_win);
                 if self.copy_selection(false) {
@@ -4650,7 +4651,7 @@ impl Host {
                 Some(m) => self.yank_over(m, count),
                 None => self.editor_message(
                     MessageLevel::Info,
-                    "y then a motion, or one of y c m a — `?` lists them",
+                    "y then a motion, or one of y c m p a — `?` lists them",
                 ),
             },
 
@@ -4668,9 +4669,9 @@ impl Host {
 
     /// The motions `y` will take as its second key.
     ///
-    /// Not every motion in the table: `yy` is the line and `yc`, `ym` and `ya` are the transcript's
-    /// own three, so the letters they use are theirs. Everything here is a key that means the same
-    /// after `y` as it does on its own.
+    /// Not every motion in the table: `yy` is the line and `yc`, `ym`, `yp` and `ya` are the
+    /// transcript's own four, so the letters they use are theirs. Everything here is a key that
+    /// means the same after `y` as it does on its own.
     fn yank_motion_for(&self, ch: &str) -> Option<vim::Motion> {
         use vim::Motion as M;
         Some(match ch {
@@ -5197,8 +5198,23 @@ impl Host {
         Some(from..to)
     }
 
-    /// Copy the whole exchange the cursor is in — the question and everything it produced.
+    /// Copy the conversation's directory — in a worktree, the worktree's.
+    ///
+    /// The one `y` target that is not a piece of the transcript, here because it is the other thing
+    /// you take out of a conversation: the path its shell, its editor and its next message want.
+    /// Three keys every terminal sends, which is what lets the chat key be `⌥Y` — an Alt chord,
+    /// `¥` on a Mac out of the box, and allowed as a default only because this route exists
+    /// beside it (ADR 0048). `session.copy.path` is the same verb by name, and the panel's `y`
+    /// does it for any row.
+    fn yank_path(&mut self) {
+        let path = self.root().display().to_string();
+        let _ = self
+            .editor
+            .apply(&PluginId::from(BUILTIN), ApiCall::ClipboardWrite { text: path.clone() });
+        self.editor_message(MessageLevel::Info, format!("copied {path}"));
+    }
 
+    /// Copy the whole exchange the cursor is in — the question and everything it produced.
     fn yank_turn(&mut self) {
         let here = self.chat_cursor().0;
         let rows = self.turn_rows();
@@ -8396,7 +8412,7 @@ impl Host {
             ("chat.scroll_end", "Jump to the end of the transcript"),
             (
                 "chat.read",
-                "Read the transcript: hjkl move, [ ] turns, { } blocks, / finds, yc takes the code",
+                "Read the transcript: hjkl move, [ ] turns, { } blocks, / finds, yc takes the code, yp the path",
             ),
             ("chat.toggle_card", "Open or fold the tool card under the cursor, while reading"),
             (

--- a/crates/neosh/tests/reading.rs
+++ b/crates/neosh/tests/reading.rs
@@ -441,6 +441,34 @@ fn yank_turn_takes_the_question_and_its_whole_answer() {
     assert!(got.contains("That is all."), "and the end of it: {got:?}");
 }
 
+/// `yp` takes the conversation's directory — in a worktree, the worktree's path — which is the
+/// other thing you take out of a conversation: what your shell wants to `cd` to. The one `y`
+/// target that is not a piece of the transcript, and the route a Mac takes — `⌥Y` in chat is `¥`
+/// there, and is allowed as a default only because this exists (ADR 0048).
+#[test]
+fn yank_path_takes_the_conversations_directory() {
+    let sb = Sandbox::new("yankpath");
+    let mut s = sb.start();
+    s.answered_and_reading();
+
+    s.ch("y");
+    s.ch("p");
+    assert!(s.pump(|s| !s.copied().is_empty()), "copied\n{:?}", s.messages());
+    let want = sb.root.join("work");
+    let got = PathBuf::from(s.last_copy());
+    // Canonicalised on both sides: a temp dir on macOS is a symlink into `/private`.
+    assert_eq!(
+        got.canonicalize().unwrap_or(got.clone()),
+        want.canonicalize().unwrap_or(want.clone()),
+        "the directory, not a row of the transcript: {got:?}"
+    );
+    assert!(
+        s.pump(|s| s.messages().iter().any(|m| m.starts_with("copied ") && !m.contains("line"))),
+        "and it says which path, not how many lines\n{:?}",
+        s.messages()
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Getting to the piece you want
 // ---------------------------------------------------------------------------

--- a/docs/adr/0048-a-key-every-terminal-sends.md
+++ b/docs/adr/0048-a-key-every-terminal-sends.md
@@ -95,3 +95,13 @@ are what the row says, for the same reason.
 - One more chord is gone, and chat mode now has none left. The next capability that wants a global
   key has to take one, replace one, or live on `^K` — which is the constraint working, not the
   constraint failing.
+- The sweep missed one, and the miss turned into a refinement. `session.copy.path` landed on `⌥Y`
+  an hour before this was written — reachable on a Linux terminal, `¥` on a Mac, and mentioned
+  nowhere on screen. Chat mode has no chord to give it, and the rule above says it loses its key.
+  It keeps it instead, on the terms the fourth category already set for arrows: **Alt may be bound
+  where it means something, and never as the only way.** What made `⌥↑`/`⌥↓` and `F1` bugs was
+  that nothing else reached the same verb. Here everything does — `yp` in the reader beside `yc`,
+  `ym` and `ya` (printable letters in a mode that is not a text field are in the set), `y` on any
+  row of the project panel, `^K` and `/copy` by name — so a terminal that sends Alt gets a key in
+  the composer and one that does not has lost nothing. The test for the next Alt binding is the
+  same: name the route a Mac takes, or it does not ship.

--- a/docs/config.md
+++ b/docs/config.md
@@ -232,9 +232,11 @@ they are trees of.
 The rest of a worktree's life is on its sidebar row: `y` copies its path for the shell you are
 about to `cd` in, `p` pulls its repository from the remote and says what git said, and `d` removes
 the checkout from disk — the branch stays, it asks first, and it tells you how many conversations
-go with it. `⌥Y` in the chat copies the *current* conversation's directory, which in a worktree is
-the worktree. `p` and `d` are contributions from the git plugin (`sidebar.action`), so they follow
-it when it is disabled, and a sidebar of your own inherits them for free.
+go with it. `⌥Y` in the chat and `yp` in the reader (`^S`) copy the *current* conversation's
+directory, which in a worktree is the worktree; `session.copy.path` is the same thing by name from
+`^K` or `/copy`.
+`p` and `d` are contributions from the git plugin (`sidebar.action`), so they follow it when it is
+disabled, and a sidebar of your own inherits them for free.
 
 Conversations are saved as you go — one file each under `~/.local/state/neosh/sessions/` — and
 restored at startup, in the one you were last in. `--clean` neither reads nor writes them.
@@ -332,7 +334,10 @@ that depends on a setting you have to go and find. In practice that rules out th
   Mac could not press. The key list is `^Z`.
 - **Option / Alt.** macOS treats Option as a compose key: `⌥p` is `π`, not `Alt+p`, unless the
   terminal has been told otherwise. The model ladder was `⌥↑`/`⌥↓` and now has no default key at
-  all; taking an attached image back off was `⌥V` and is now `⌫` on an empty composer.
+  all; taking an attached image back off was `⌥V` and is now `⌫` on an empty composer. The one
+  Alt chord that ships is `⌥Y`, and it ships on the terms arrows do: copying the conversation's
+  directory is also `yp` in the reader, `y` in the project panel and `session.copy.path` from
+  `^K`, so a terminal that sends `¥` has lost nothing.
 - **Ctrl with punctuation.** In a plain terminal `Ctrl+/` and `Ctrl+7` are the same byte. Neither
   is a key worth binding — see enhanced keys, below.
 

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -1091,6 +1091,12 @@ async function registerCommands(w: Wiring): Promise<void> {
       neosh.notify(`copied ${current.cwd}`);
     }, { desc: "Copy this conversation's directory to the clipboard" }),
   );
+  // An Alt chord, which ADR 0048 keeps out of the defaults — on a Mac out of the box `⌥Y` is `¥`,
+  // a key neosh never receives — with the one exception the same ADR makes for arrows: bound where
+  // it means something, and never the only way. Chat mode has no Ctrl chord left to give this, and
+  // every terminal-sendable route exists beside it — `yp` in the reader, `y` on any row of this
+  // panel, `^K` and `/copy` by name — so a terminal that sends Alt gets a key in the composer and
+  // one that does not has lost nothing.
   await neosh.keymap.set("chat", "<A-y>", "session.copy.path", {
     desc: "Copy this conversation's directory",
   });


### PR DESCRIPTION
## What

Copying the directory you are working in — the worktree's path, in a worktree — from wherever you are:

- **`⌥Y` in chat** (`session.copy.path`) — kept as a shipped default.
- **`yp` in the reader** (`^S`) — new, beside `yc`/`ym`/`ya`.
- `y` on any row of the project panel, `^K` → `session.copy.path`, `/copy` — unchanged.

## Why

All of this existed except `yp`, and nothing on screen led to it from the composer. The chat key was also an Alt chord that landed (e86304e) an hour before ADR 0048 ruled Alt out of the defaults — `¥` on a Mac out of the box — and chat mode has no Ctrl chord left to move it to.

`yp` is in the host's own `y` table rather than a `normal`-mode keymap: a keymap prefix on `y` would make `v…y` wait out `timeoutlen` before copying.

`⌥Y` stays on the terms ADR 0048 already set for arrows — bound where it means something, never the only way. The ADR records the refinement and the test for the next Alt binding: name the route a Mac takes, or it does not ship.

## Verified

- `cargo test -p neosh --test reading` — 40/40, including the new `yank_path_takes_the_conversations_directory`.
- `cargo test -p neosh --test builtin_plugins sidebar` — 8/8.
- `tsc --noEmit -p plugins/builtin` clean.
- Driven with `scripts/shot.py`: `^S` `yp` → `copied /home/…/spry-sparrow`; `⌥Y` with a draft in the composer copies and leaves the draft; panel `y` on the project row copies the repo root, on the worktree row the worktree; `^K` and `/cop` both list the command.