### PR TITLE
A mark that comes off when the work stops, not when the agent mentions it

### DIFF
--- a/crates/neosh-provider/src/drivers/claude_cli.rs
+++ b/crates/neosh-provider/src/drivers/claude_cli.rs
@@ -1233,8 +1233,17 @@ impl Watch {
     ///
     /// Read in the detached case only, so an attached turn pays nothing for it — the same trade
     /// [`Self::opens_a_turn`] makes.
+    ///
+    /// The substring is a gate and not the decision: what a line *is* still comes from the parser
+    /// below, and all this says is that a line without those characters in it cannot be one. It
+    /// earns its place because this sits between the CLI's stdout and the channel every turn reads
+    /// from — a second whole-line parse per line, on the one path where added latency shifts which
+    /// side of a turn boundary a line lands on.
     fn level_in(&self, line: &str) -> Option<Vec<neosh_proto::BackgroundTask>> {
         self.sink.as_ref()?;
+        if !line.contains("background_tasks_changed") {
+            return None;
+        }
         crate::sse::background_tasks(&serde_json::from_str::<Value>(line).ok()?)
     }
 

--- a/crates/neosh-provider/src/drivers/claude_cli.rs
+++ b/crates/neosh-provider/src/drivers/claude_cli.rs
@@ -1229,6 +1229,52 @@ impl Watch {
         self.unread.attached.load(std::sync::atomic::Ordering::SeqCst) > 0
     }
 
+    /// The live set of background tasks, if that is what this line carries.
+    ///
+    /// Read in the detached case only, so an attached turn pays nothing for it — the same trade
+    /// [`Self::opens_a_turn`] makes.
+    fn level_in(&self, line: &str) -> Option<Vec<neosh_proto::BackgroundTask>> {
+        self.sink.as_ref()?;
+        crate::sse::background_tasks(&serde_json::from_str::<Value>(line).ok()?)
+    }
+
+    /// Say what is running, when nothing is reading the pipe it was said on.
+    ///
+    /// A turn's `result` is not the end of the process, and a detached shell is the whole reason:
+    /// it finishes minutes later, the CLI says so, and until now the only thing that could carry
+    /// that to the workspace was the turn the CLI usually — but not always — runs at itself
+    /// afterwards. Said here it does not depend on that. The set is a level, so saying it twice is
+    /// saying it once, and the turn loop goes on forwarding its own copy in order.
+    ///
+    /// Nothing is said while somebody is reading, and the check is after the line has gone into the
+    /// pipe so that a turn which attached in between is the one that reports it: two paths into one
+    /// field can arrive out of order, and out of order here means the *older* set wins and the mark
+    /// is wrong until the next change — which, for a conversation nobody goes back to, is forever.
+    fn background(&self, tasks: Vec<neosh_proto::BackgroundTask>) {
+        if self.reading() {
+            return;
+        }
+        if let Some(sink) = &self.sink {
+            sink.background(&self.conversation, tasks);
+        }
+    }
+
+    /// The process is gone, so nothing it was holding is running any more.
+    ///
+    /// Whatever it had reported dies with it: the shells it detached are its children, the account
+    /// of them was only ever in its head, and nothing that comes after can ask. Without this a
+    /// conversation whose CLI was killed — crashed, OOM, `kill -9` — wears a "still working on
+    /// something" mark until somebody happens to send it another message, which for the one it was
+    /// killed in the middle of is exactly the thing they are not about to do.
+    ///
+    /// Said even when the process is being replaced on purpose, where the fresh one says the same
+    /// thing a moment later. Empty twice is empty.
+    fn ended(&self) {
+        if let Some(sink) = &self.sink {
+            sink.background(&self.conversation, Vec::new());
+        }
+    }
+
     /// A turn has begun. Report it if nothing is reading, and otherwise leave the note that
     /// whoever is reading clears by getting to it. See [`Unread`].
     fn began(&self) {
@@ -1325,8 +1371,14 @@ impl Live {
             let mut l = BufReader::new(stdout).lines();
             while let Ok(Some(line)) = l.next_line().await {
                 let opens = watch.opens_a_turn(&line);
+                // Read before the send and reported after it, because the send is what moves the
+                // line and what gives a turn the chance to answer for it instead.
+                let level = watch.level_in(&line);
                 if line_tx.send(line).is_err() {
                     break;
+                }
+                if let Some(tasks) = level {
+                    watch.background(tasks);
                 }
                 // After the send, never before: the workspace answers this by opening a turn to
                 // read, and a turn that arrives before the line it was opened for finds an empty
@@ -1335,6 +1387,8 @@ impl Live {
                     watch.began();
                 }
             }
+            // Stdout closed, which for a process reading stdin forever means the process is over.
+            watch.ended();
         });
 
         Ok(Self {
@@ -1790,6 +1844,7 @@ done
             fn began(&self, _conversation: &SessionId) {
                 self.0.fetch_add(1, Ordering::SeqCst);
             }
+            fn background(&self, _conversation: &SessionId, _tasks: Vec<neosh_proto::BackgroundTask>) {}
         }
 
         let dir = std::env::temp_dir().join(format!("neosh-unprompted-{}", std::process::id()));

--- a/crates/neosh-provider/src/drivers/mod.rs
+++ b/crates/neosh-provider/src/drivers/mod.rs
@@ -113,4 +113,21 @@ pub trait AgentDriver: Send + Sync {
 pub trait Unasked: Send + Sync + std::fmt::Debug {
     /// The agent in this conversation has begun saying something nobody asked for.
     fn began(&self, conversation: &neosh_proto::SessionId);
+
+    /// Everything running unattended in this conversation, whole, said while no turn was reading.
+    ///
+    /// The same level [`neosh_proto::Activity::Background`] carries, and here for the reason that
+    /// one is a level: the set changes *between* turns — that is what a backgrounded shell is —
+    /// and a level nobody is told about is a mark on a row that nothing will ever put right.
+    /// [`Self::began`] is not a substitute, because it only fires when the agent goes on to *say*
+    /// something about it: the CLI usually does, and a conversation whose indicator depends on
+    /// whether it felt like talking is one that is wrong whenever it did not.
+    ///
+    /// Only when nothing is reading. A turn that is running forwards this itself, in order, on its
+    /// own stream — and two paths into one field is how `[a]` lands after `[a, b]`.
+    fn background(
+        &self,
+        conversation: &neosh_proto::SessionId,
+        tasks: Vec<neosh_proto::BackgroundTask>,
+    );
 }

--- a/crates/neosh-provider/src/sse.rs
+++ b/crates/neosh-provider/src/sse.rs
@@ -331,6 +331,40 @@ fn activity(a: Activity) -> ProviderEvent {
     ProviderEvent::Activity { activity: a }
 }
 
+/// The live set of background tasks off a `background_tasks_changed` line, if that is what it is.
+///
+/// Public because there are two readers of this one line and they must not answer it differently:
+/// the turn loop, which forwards it as an event, and the reader that watches the pipe *between*
+/// turns and has no turn to forward anything on. A second reading of the same JSON is a second
+/// answer waiting to drift from the first.
+///
+/// An absent `tasks` is `None` and not an empty set: a line we cannot read says nothing rather than
+/// claiming that nothing is running.
+pub fn background_tasks(v: &Value) -> Option<Vec<BackgroundTask>> {
+    if v.get("type").and_then(Value::as_str) != Some("system")
+        || v.get("subtype").and_then(Value::as_str) != Some("background_tasks_changed")
+    {
+        return None;
+    }
+    Some(
+        v.get("tasks")?
+            .as_array()?
+            .iter()
+            .filter_map(|t| {
+                Some(BackgroundTask {
+                    id: TaskId(t.get("task_id").and_then(Value::as_str)?.to_string()),
+                    title: t
+                        .get("description")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                    kind: t.get("task_type").and_then(Value::as_str).map(str::to_string),
+                })
+            })
+            .collect(),
+    )
+}
+
 /// The `{"type":"system"}` families — everything the CLI says about its own loop rather than about
 /// the message it is producing.
 ///
@@ -423,24 +457,10 @@ fn system_line(v: &Value, state: &mut ClaudeState) -> Vec<ProviderEvent> {
         //
         // An absent `tasks` is not an empty one: a line we cannot read says nothing rather than
         // claiming the set is empty.
-        Some("background_tasks_changed") => {
-            let Some(tasks) = v.get("tasks").and_then(Value::as_array) else { return Vec::new() };
-            let tasks = tasks
-                .iter()
-                .filter_map(|t| {
-                    Some(BackgroundTask {
-                        id: TaskId(t.get("task_id").and_then(Value::as_str)?.to_string()),
-                        title: t
-                            .get("description")
-                            .and_then(Value::as_str)
-                            .unwrap_or_default()
-                            .to_string(),
-                        kind: t.get("task_type").and_then(Value::as_str).map(str::to_string),
-                    })
-                })
-                .collect();
-            vec![activity(Activity::Background { tasks })]
-        }
+        Some("background_tasks_changed") => match background_tasks(v) {
+            Some(tasks) => vec![activity(Activity::Background { tasks })],
+            None => Vec::new(),
+        },
         // A request that failed with something retryable, and the wait before it is tried again.
         //
         // The single worst-looking thing a vendor CLI does: a 529 costs several silent minutes with

--- a/crates/neosh-provider/tests/claude_stream_json.rs
+++ b/crates/neosh-provider/tests/claude_stream_json.rs
@@ -356,3 +356,152 @@ async fn a_request_to_leave_plan_mode_is_answered_rather_than_dropped() {
         "a control request nothing understood was dropped instead of refused"
     );
 }
+
+/// A `claude` that reports a finished background task and then says nothing else at all.
+///
+/// The half [`CHATTY`] does not cover, and the one the indicator's correctness cannot rest on the
+/// absence of. There, the CLI follows the empty set with a turn of its own — an `init`, a sentence,
+/// a `result` — and it is that `init` the workspace wakes for. Here there is no turn: the set moves
+/// and nothing is said about it, which is what a task the agent has nothing to add about looks
+/// like, and what a process that is about to exit looks like.
+///
+/// A second turn is never asked for, on purpose: waiting for one is exactly the bug. The
+/// conversation this happened in may be one nobody opens again for a week.
+const QUIET: &str = r#"#!/bin/sh
+say() { printf '%s\n' "$1"; }
+while IFS= read -r line; do
+  case "$line" in
+    *'"subtype":"get_context_usage"'*)
+      say '{"type":"control_response","response":{"subtype":"success","request_id":"x","response":{"totalTokens":10,"maxTokens":100}}}' ;;
+    *'"type":"user"'*)
+      say '{"type":"system","subtype":"background_tasks_changed","tasks":[{"task_id":"bq1","task_type":"local_bash","description":"npm run build"}]}'
+      say '{"type":"stream_event","session_id":"s","event":{"type":"message_start","message":{"model":"m","usage":{}}}}'
+      say '{"type":"stream_event","session_id":"s","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}}'
+      say '{"type":"stream_event","session_id":"s","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"STARTED"}}}'
+      say '{"type":"stream_event","session_id":"s","event":{"type":"content_block_stop","index":0}}'
+      say '{"type":"stream_event","session_id":"s","event":{"type":"message_stop"}}'
+      say '{"type":"result","subtype":"success","is_error":false,"result":"STARTED","session_id":"s"}'
+      # The shell exits well after the turn was read to its end, and the CLI has nothing to say
+      # about it beyond the fact itself.
+      (
+        sleep 1
+        say '{"type":"system","subtype":"background_tasks_changed","tasks":[]}'
+        say '{"type":"system","subtype":"task_updated","task_id":"bq1","patch":{"status":"completed"}}'
+      ) &
+      ;;
+  esac
+done
+"#;
+
+/// A `claude` that starts something in the background and is then killed.
+///
+/// Nothing it was holding survives it: the shells were its children and the account of them was
+/// only ever in its head. It exits without a word, which is what a crash, an OOM kill and a
+/// `kill -9` all look like from here.
+const DOOMED: &str = r#"#!/bin/sh
+say() { printf '%s\n' "$1"; }
+while IFS= read -r line; do
+  case "$line" in
+    *'"subtype":"get_context_usage"'*)
+      say '{"type":"control_response","response":{"subtype":"success","request_id":"x","response":{"totalTokens":10,"maxTokens":100}}}' ;;
+    *'"type":"user"'*)
+      say '{"type":"system","subtype":"background_tasks_changed","tasks":[{"task_id":"bd1","task_type":"local_bash","description":"npm run build"}]}'
+      say '{"type":"stream_event","session_id":"s","event":{"type":"message_start","message":{"model":"m","usage":{}}}}'
+      say '{"type":"stream_event","session_id":"s","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}}'
+      say '{"type":"stream_event","session_id":"s","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"STARTED"}}}'
+      say '{"type":"stream_event","session_id":"s","event":{"type":"content_block_stop","index":0}}'
+      say '{"type":"stream_event","session_id":"s","event":{"type":"message_stop"}}'
+      say '{"type":"result","subtype":"success","is_error":false,"result":"STARTED","session_id":"s"}'
+      (sleep 1; kill -9 $$) &
+      ;;
+  esac
+done
+"#;
+
+/// Everything the driver said about a conversation while no turn was reading it.
+#[derive(Debug, Default)]
+struct Heard(std::sync::Mutex<Vec<Vec<neosh_proto::BackgroundTask>>>);
+
+impl neosh_provider::drivers::Unasked for Heard {
+    fn began(&self, _conversation: &SessionId) {}
+    fn background(&self, _conversation: &SessionId, tasks: Vec<neosh_proto::BackgroundTask>) {
+        self.0.lock().expect("heard lock poisoned").push(tasks);
+    }
+}
+
+impl Heard {
+    /// Wait for the driver to say that nothing is running, and answer whether it ever did.
+    async fn saw_empty(&self, within: std::time::Duration) -> bool {
+        let deadline = tokio::time::Instant::now() + within;
+        while tokio::time::Instant::now() < deadline {
+            if self.0.lock().expect("heard lock poisoned").iter().any(Vec::is_empty) {
+                return true;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        false
+    }
+}
+
+fn heard_by(p: &ClaudeCliProvider) -> std::sync::Arc<Heard> {
+    let heard = std::sync::Arc::new(Heard::default());
+    neosh_provider::drivers::AgentDriver::set_unasked(p, heard.clone());
+    heard
+}
+
+/// The mark comes off without waiting for the agent to have an opinion about it.
+///
+/// A backgrounded shell finishes long after the turn that started it stopped being read, and the
+/// only thing on that pipe is a reader nothing was consuming. Until this, the news reached the
+/// workspace only when the CLI went on to *run a turn about it* — which it usually does, and which
+/// is not a thing to make a row's correctness depend on. Nobody sends a second message here: doing
+/// that is what used to be required, and a conversation nobody opens again keeps a "still working
+/// on something" mark for as long as the workspace lives.
+#[tokio::test]
+async fn a_background_task_that_ends_quietly_still_puts_the_mark_out() {
+    let fake = Fake::running("quiet", QUIET);
+    let p = ClaudeCliProvider::new(fake.program());
+    let heard = heard_by(&p);
+
+    let first: Vec<ProviderEvent> =
+        p.stream(&inst(), req(&fake.dir, "one"), CancellationToken::new()).collect().await;
+    assert!(text_of(&first).contains("STARTED"));
+    assert_eq!(
+        sets_of(&first).last().map(Vec::len),
+        Some(1),
+        "the turn ends knowing one thing is still going"
+    );
+
+    assert!(
+        heard.saw_empty(std::time::Duration::from_secs(5)).await,
+        "the shell finished and nothing ever said so: {:?}",
+        heard.0.lock().expect("heard lock poisoned")
+    );
+}
+
+/// A conversation whose CLI died is a conversation running nothing.
+///
+/// The process was the only thing that knew what it had detached, so its exit is the last word on
+/// the subject. Without this the row keeps the mark until somebody sends that conversation another
+/// message — and the conversation it was killed in the middle of is the one they are least likely
+/// to.
+#[tokio::test]
+async fn a_cli_that_dies_is_no_longer_running_anything() {
+    let fake = Fake::running("doomed", DOOMED);
+    let p = ClaudeCliProvider::new(fake.program());
+    let heard = heard_by(&p);
+
+    let first: Vec<ProviderEvent> =
+        p.stream(&inst(), req(&fake.dir, "one"), CancellationToken::new()).collect().await;
+    assert_eq!(
+        sets_of(&first).last().map(Vec::len),
+        Some(1),
+        "the turn ends knowing one thing is still going"
+    );
+
+    assert!(
+        heard.saw_empty(std::time::Duration::from_secs(5)).await,
+        "the process died holding a task nothing ever took back: {:?}",
+        heard.0.lock().expect("heard lock poisoned")
+    );
+}

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -629,8 +629,8 @@ pub struct Host {
     /// Out of band, like the quota poll and for the same reason: it is news from a driver that
     /// arrives when no turn is running, so there is no stream for it to come back on. See
     /// [`neosh_provider::drivers::Unasked`] and ADR 0056.
-    unasked_rx: Option<tokio::sync::mpsc::UnboundedReceiver<neosh_proto::SessionId>>,
-    unasked_tx: tokio::sync::mpsc::UnboundedSender<neosh_proto::SessionId>,
+    unasked_rx: Option<tokio::sync::mpsc::UnboundedReceiver<Unheard>>,
+    unasked_tx: tokio::sync::mpsc::UnboundedSender<Unheard>,
     /// Set by a turn ending, cleared by the poll that follows it. See [`crate::quota::AFTER_TURN`].
     quota_due: bool,
     /// Conversations that were blocked on an answer as of the last `question.asking`.
@@ -7781,26 +7781,16 @@ impl Host {
             // away when the turn ends, and a shell that was put in the background is still running
             // after that.
             Activity::Background { tasks } => {
-                // `if let` and not `let ... else`: the temporary `sessions()` hands back does not
-                // outlive a `let`-else, and the borrow it yields is what is being written through.
-                let changed = if let Some(s) = self.agent.sessions().get_mut(&session) {
-                    let changed = s.background != tasks;
-                    s.background = tasks;
-                    changed
-                } else {
-                    return;
-                };
-                if !changed {
-                    return;
+                if self.take_background(&session, tasks) {
+                    // Nothing else is broadcast here: the activity itself already went out to every
+                    // plugin above, and that is the signal that means what it means.
+                    // `SessionChanged` means the conversation you are *in* changed, and borrowing
+                    // it to say "a row's state moved" would have every listener refreshing a footer
+                    // about a conversation nobody switched to.
+                    self.each_view_showing(&session, |me| {
+                        me.redraw_footer();
+                    });
                 }
-                // Nothing else is broadcast here: the activity itself already went out to every
-                // plugin above, and that is the signal that means what it means. `SessionChanged`
-                // means the conversation you are *in* changed, and borrowing it to say "a row's
-                // state moved" would have every listener refreshing a footer about a conversation
-                // nobody switched to.
-                self.each_view_showing(&session, |me| {
-                    me.redraw_footer();
-                });
             }
             Activity::TaskEnded { task, status, .. } => {
                 let Some(r) = self.rounds.get_mut(&session) else { return };
@@ -8325,6 +8315,66 @@ impl Host {
         true
     }
 
+    /// Write down what a conversation is still running, and say whether that is news.
+    ///
+    /// A **level**: the whole set replaces the whole set, and empty means nothing is running rather
+    /// than nothing was said. On the conversation and not the round, which is the entire point —
+    /// the round is thrown away when the turn ends, and a shell that was put in the background is
+    /// still running after that. See [`neosh_proto::Activity::Background`].
+    fn take_background(
+        &mut self,
+        session: &neosh_proto::SessionId,
+        tasks: Vec<neosh_proto::BackgroundTask>,
+    ) -> bool {
+        // `if let` and not `let ... else`: the temporary `sessions()` hands back does not outlive a
+        // `let`-else, and the borrow it yields is what is being written through.
+        if let Some(s) = self.agent.sessions().get_mut(session) {
+            let changed = s.background != tasks;
+            s.background = tasks;
+            changed
+        } else {
+            false
+        }
+    }
+
+    /// What is running in a conversation that has no turn in it.
+    ///
+    /// Between turns there is no stream for this to arrive on, and between turns is exactly when it
+    /// changes: a detached shell finishes long after the turn that started it was read to its end.
+    /// See [`neosh_provider::drivers::Unasked::background`].
+    ///
+    /// Declined while a turn is running, and that is not belt-and-braces. The driver only speaks
+    /// here when nothing is reading, but a turn can attach in the gap between it deciding that and
+    /// this being handled — and then the level queued a moment ago would land on top of the one the
+    /// turn has already forwarded. A running turn is reading that pipe and reports the set itself,
+    /// in order, so there is nothing to lose by leaving it to.
+    fn heard_background(
+        &mut self,
+        session: neosh_proto::SessionId,
+        tasks: Vec<neosh_proto::BackgroundTask>,
+    ) {
+        if self.turns.contains_key(&session) {
+            return;
+        }
+        if !self.take_background(&session, tasks.clone()) {
+            return;
+        }
+        // The same event a turn would have carried, to the same listeners. A plugin drawing a row
+        // about this has no way to tell — and no reason to care — whether a turn happened to be
+        // running when the set moved.
+        self.bridge.broadcast(PluginEvent::Activity {
+            session: session.clone(),
+            turn: neosh_proto::TurnId::default(),
+            activity: neosh_proto::Activity::Background { tasks },
+        });
+        // Every terminal looking at this conversation, not the one that happens to be first: a
+        // conversation can be on screen in several at once, and a footer redrawn in one of them is
+        // the other ones still saying it is working on something. See ADR 0042.
+        self.each_view_showing(&session, |me| {
+            me.redraw_footer();
+        });
+    }
+
     /// Open a turn to hold something the agent has already started saying.
     ///
     /// A backgrounded command finishing is a message `claude` enqueues to itself and answers, and
@@ -8481,13 +8531,16 @@ impl Host {
                         self.drain_effects();
                     }
                 }
-                Some(session) = async {
+                Some(unheard) = async {
                     match unasked_rx.as_mut() {
                         Some(rx) => rx.recv().await,
                         // Never ready, rather than ready-with-nothing: the latter would spin.
                         None => std::future::pending().await,
                     }
-                } => self.hear_out(session),
+                } => match unheard {
+                    Unheard::Began(session) => self.hear_out(session),
+                    Unheard::Background(session, tasks) => self.heard_background(session, tasks),
+                },
                 Some(polled) = async {
                     match quota_rx.as_mut() {
                         Some(rx) => rx.recv().await,
@@ -10249,14 +10302,35 @@ pub fn install_builtin_providers(
 /// A channel rather than a call into the host: this arrives from a reader task on a driver's own
 /// thread, and the host is a single writer that owns everything it would have to touch.
 #[derive(Debug)]
-struct UnaskedSink(tokio::sync::mpsc::UnboundedSender<neosh_proto::SessionId>);
+struct UnaskedSink(tokio::sync::mpsc::UnboundedSender<Unheard>);
 
 impl neosh_provider::drivers::Unasked for UnaskedSink {
     fn began(&self, conversation: &neosh_proto::SessionId) {
         // A closed channel is a workspace that has stopped. Nothing to report it to, and nothing
         // to be done about it.
-        let _ = self.0.send(conversation.clone());
+        let _ = self.0.send(Unheard::Began(conversation.clone()));
     }
+
+    fn background(
+        &self,
+        conversation: &neosh_proto::SessionId,
+        tasks: Vec<neosh_proto::BackgroundTask>,
+    ) {
+        let _ = self.0.send(Unheard::Background(conversation.clone(), tasks));
+    }
+}
+
+/// What a driver says about a conversation when no turn is running in it.
+///
+/// Both arrive from a reader task on the driver's own thread, and the host is a single writer that
+/// owns everything either of them would have to touch — so they come down a channel rather than
+/// through a call. See [`neosh_provider::drivers::Unasked`] and ADR 0056.
+#[derive(Debug)]
+enum Unheard {
+    /// The agent has started saying something nobody asked for, and needs a turn to say it in.
+    Began(neosh_proto::SessionId),
+    /// Everything still running there that no turn is waiting for, whole.
+    Background(neosh_proto::SessionId, Vec<neosh_proto::BackgroundTask>),
 }
 
 /// Route one slow call to its service.


### PR DESCRIPTION
The dim sky-blue `○` on a conversation row is `SessionInfo::background`: the agent left a shell running that no turn is waiting for. It is a **level** — the whole set replaces the whole set, and empty is what takes the mark off — and until now the empty set could only reach the workspace by accident.

A turn's `result` is not the end of the process. A detached shell finishes minutes later and the CLI says so on `background_tasks_changed`, into a pipe whose only reader was pushing lines into a channel nobody was draining. `Watch::opens_a_turn` woke the host for exactly one line — `system`/`init` — so the news got through only when the CLI went on to *run a turn about it*. It usually does. A row's correctness cannot rest on whether an agent felt like saying something, and the conversation it did not mention is the one nobody opens again for a week.

So the reader says it itself: `Unasked::background`, the same set, carried the moment it changes. After the line has gone into the pipe and only when nothing is reading — a running turn forwards its own copy in order, and two paths into one field is how `[a]` lands on top of `[a, b]`. The host declines it while a turn exists for the same reason, because a turn can attach in the gap.

The other half is the process dying. Its detached shells were its children and the account of them was only ever in its head, so its exit is the last word: stdout closing reports the empty set. Killed mid-conversation, a row used to keep "still working on something" until somebody sent that conversation another message — which is the one thing you do not do to the conversation you just killed the agent in.

## Verification

Two new tests in `claude_stream_json.rs` — a task ending quietly with no `init` behind it, and a CLI killed while holding one. Both fail on the old code and pass on the new.

Driven against the real `claude` under a pty, CLI killed 22s in while a `sleep 600` was listed:

```
before   ○ Start background task    now     ← Status.Monitoring, stuck
after    ▸ Use the Bash tool with … now     ← cleared
```

Normal completion off-screen still lands on amber `●` unread, so the path that already worked is intact.

`neosh-provider` (199) · `neosh-core` (145) · `neosh --bins` (270) · `--test workspace` (23) · `--test builtin_plugins` (157) · generated TS unchanged.

## Not in scope

The transcript's `└ Still running in the background · 1 thing` epilogue keeps its present tense forever. It is a record of where the turn ended rather than a live claim, and the task rows under it already go grey.