### PR TITLE
fix(claude-cli): the number a turn reports is a fraction, and the gauge is drawn in percent

### DIFF
--- a/crates/neosh-provider/src/quota.rs
+++ b/crates/neosh-provider/src/quota.rs
@@ -355,22 +355,47 @@ fn money(v: Option<&Value>) -> Option<String> {
     })
 }
 
+/// How full a window has to be for `allowed_warning` to be taken at its word.
+///
+/// Seventy percent, which is the figure the vendor's own client uses for the same decision on the
+/// same field. It is not a threshold of ours in the sense the doc on [`QuotaSeverity`] warns about
+/// — it is not deciding *when to worry*, it is deciding whether the flag beside the number is
+/// about the number or is left over from before the last reset.
+const CLAUDE_WARNING_THRESHOLD: f64 = 70.0;
+
 /// One `rate_limit_event` line of `claude --output-format stream-json`.
 ///
 /// A much thinner shape than the endpoint's: one window, the one that is closest to binding, with
 /// no scope and no idea what the others are at. So it *patches* rather than replaces — see
 /// [`Quota::is_empty`] and the store that applies it. It is worth having anyway, because it is the
 /// only figure that moves during the twenty minutes an agent driver can spend on one turn.
+///
+/// **Its `utilization` is a fraction, and the endpoint's is a percentage.** The same word, two
+/// scales, one type away from each other: `SDKRateLimitInfoSchema` carries the number the CLI read
+/// off an `anthropic-ratelimit-unified-*-utilization` response header, which is `0.56` for
+/// fifty-six percent — the vendor multiplies by a hundred at every use of it and compares it to a
+/// `0.7` threshold — while `/api/oauth/usage` answers with `percent` and a legacy `utilization`
+/// that are both already out of a hundred. Read as a percentage, a weekly limit at 56% patched the
+/// polled snapshot down to `0.56`, which is `1%` in the sidebar and `99% left` under it, and stayed
+/// that way until the next poll replaced it — which is what made opening the panel look like the
+/// thing that fixed it. It also meant the grade below was computed from a number that can never
+/// reach [`QuotaSeverity::Warn`], so nothing mid-turn ever crossed a threshold on its own.
 pub fn parse_claude_rate_limit_event(info: &Value) -> Quota {
     let Some(kind) = info.get("rateLimitType").and_then(Value::as_str) else {
         return Quota::default();
     };
-    let Some(pct) = info.get("utilization").and_then(Value::as_f64) else {
+    let Some(pct) = info.get("utilization").and_then(Value::as_f64).map(|u| u * 100.0) else {
         return Quota::default();
     };
+    // `allowed_warning` is only worth believing once the number agrees with it. The vendor's own
+    // client discards it below seventy percent and says why: the endpoint sends `allowed_warning`
+    // with stale data for a while after a window resets, so an account four percent into a fresh
+    // week gets told it is nearly out. Graded straight through, that is a red row and a
+    // notification about a limit that is further away than it has been all week — and `Critical`
+    // is the grade the strip spends its loudest colour on.
     let severity = match info.get("status").and_then(Value::as_str) {
         Some("rejected") => QuotaSeverity::Exhausted,
-        Some("allowed_warning") => QuotaSeverity::Critical,
+        Some("allowed_warning") if pct >= CLAUDE_WARNING_THRESHOLD => QuotaSeverity::Critical,
         _ => QuotaSeverity::of(pct as f32),
     };
     let window = QuotaWindow {
@@ -752,7 +777,7 @@ mod tests {
     fn a_rate_limit_event_carries_the_window_that_binds() {
         let info = serde_json::json!({
             "status": "allowed_warning", "rateLimitType": "seven_day",
-            "utilization": 91.0, "resetsAt": 1_787_400_000_i64,
+            "utilization": 0.91, "resetsAt": 1_787_400_000_i64,
         });
         let q = parse_claude_rate_limit_event(&info);
         assert_eq!(q.windows.len(), 1);
@@ -761,6 +786,89 @@ mod tests {
         assert!(q.windows[0].active);
         assert_eq!(q.windows[0].severity, QuotaSeverity::Critical);
         assert_eq!(q.windows[0].resets_at, Some(1_787_400_000));
+    }
+
+    /// The scale, on its own, because it is the whole bug and it is invisible in every other
+    /// assertion here: a mid-turn line says `0.56` where the endpoint says `56`.
+    #[test]
+    fn a_rate_limit_events_utilization_is_a_fraction() {
+        let info = serde_json::json!({ "rateLimitType": "seven_day", "utilization": 0.56 });
+        let q = parse_claude_rate_limit_event(&info);
+        assert_eq!(q.windows[0].used_percent, 56.0);
+        // And the grade comes off the same number, so it moves with it. Read as a percentage this
+        // was `Normal` at every value a fraction can take.
+        assert_eq!(q.windows[0].severity, QuotaSeverity::Normal);
+
+        let hot = serde_json::json!({ "rateLimitType": "five_hour", "utilization": 0.94 });
+        let q = parse_claude_rate_limit_event(&hot);
+        assert_eq!(q.windows[0].used_percent, 94.0);
+        assert_eq!(q.windows[0].severity, QuotaSeverity::Critical);
+    }
+
+    /// `allowed_warning` arriving on a window that is nowhere near full, which is what the endpoint
+    /// sends for a while after a reset. Graded on the flag alone this was a red row and a
+    /// notification about the emptiest allowance of the week.
+    #[test]
+    fn a_stale_warning_flag_does_not_outrank_the_number_beside_it() {
+        let stale = serde_json::json!({
+            "status": "allowed_warning", "rateLimitType": "seven_day", "utilization": 0.04,
+        });
+        assert_eq!(parse_claude_rate_limit_event(&stale).windows[0].severity, QuotaSeverity::Normal);
+
+        // At the threshold and above it, the flag is about the number and is believed — including
+        // where the number on its own would only have been `Warn`.
+        let real = serde_json::json!({
+            "status": "allowed_warning", "rateLimitType": "seven_day", "utilization": 0.7,
+        });
+        assert_eq!(
+            parse_claude_rate_limit_event(&real).windows[0].severity,
+            QuotaSeverity::Critical,
+        );
+
+        // `rejected` is never second-guessed: it is not a prediction, it is a refusal that already
+        // happened.
+        let out = serde_json::json!({
+            "status": "rejected", "rateLimitType": "seven_day", "utilization": 0.0,
+        });
+        assert_eq!(
+            parse_claude_rate_limit_event(&out).windows[0].severity,
+            QuotaSeverity::Exhausted,
+        );
+    }
+
+    /// The other side of the same coin, and the reason the two spellings are not interchangeable:
+    /// the endpoint's numbers are already out of a hundred, in both of its shapes.
+    #[test]
+    fn the_endpoints_percentages_are_left_alone() {
+        let limits = serde_json::json!({
+            "limits": [{ "kind": "weekly_all", "percent": 56.0 }],
+        });
+        assert_eq!(parse_claude_usage(&limits).windows[0].used_percent, 56.0);
+
+        let legacy = serde_json::json!({ "seven_day": { "utilization": 56.0 } });
+        assert_eq!(parse_claude_usage(&legacy).windows[0].used_percent, 56.0);
+    }
+
+    /// The two arriving one after the other, which is the sequence that was on screen: a poll, then
+    /// a turn moving the window it happens to be about. Patched by id, so the fixed scale is what
+    /// decides whether the row goes up by a point or falls off the bottom of the gauge.
+    #[test]
+    fn a_turn_patch_lands_on_the_same_scale_as_the_poll_it_patches() {
+        let polled = parse_claude_usage(&serde_json::json!({
+            "limits": [
+                { "kind": "session", "percent": 9.0 },
+                { "kind": "weekly_all", "percent": 56.0 },
+            ],
+        }));
+        let event = parse_claude_rate_limit_event(
+            &serde_json::json!({ "rateLimitType": "seven_day", "utilization": 0.57 }),
+        );
+        assert_eq!(polled.windows.len(), 2);
+        assert_eq!(event.windows[0].id, polled.windows[1].id);
+        assert!(
+            event.windows[0].used_percent > polled.windows[1].used_percent,
+            "a turn spends an allowance, so the patch has to read higher than the poll before it",
+        );
     }
 
     /// `status: allowed` with no type at all, which is what the line looks like before anything has

--- a/crates/neosh-provider/src/sse.rs
+++ b/crates/neosh-provider/src/sse.rs
@@ -1020,6 +1020,31 @@ mod tests {
         );
     }
 
+    /// The whole line, on the scale it really arrives on.
+    ///
+    /// Captured from a live run: `utilization` here is the fraction the CLI read off an
+    /// `anthropic-ratelimit-unified-*-utilization` header, not the percentage `/api/oauth/usage`
+    /// answers with. Pinned at this level as well as in the parser because the two numbers are the
+    /// same field name one type apart, and nothing between here and the sidebar can tell them
+    /// apart once the mistake has been made.
+    #[test]
+    fn a_rate_limit_line_arrives_as_a_percentage() {
+        let events = cli(&[
+            r#"{"type":"rate_limit_event","rate_limit_info":{"status":"allowed_warning","unifiedRateLimitFallbackAvailable":false,"rateLimitType":"seven_day","utilization":0.56,"resetsAt":1787965200}}"#,
+        ]);
+        let [Activity::Quota { windows, .. }] = only_activity(&events)[..] else {
+            panic!("one quota activity, got {events:?}")
+        };
+        assert_eq!(windows.len(), 1, "one window, and it says nothing about the others");
+        assert_eq!(windows[0].id, "weekly");
+        assert_eq!(windows[0].used_percent, 56.0);
+        assert_eq!(
+            windows[0].severity,
+            neosh_proto::quota::QuotaSeverity::Normal,
+            "and 56% is not the emergency the stale flag beside it claims",
+        );
+    }
+
     /// A real capture of a turn that ran the `Agent` tool. The sub-agent's three calls arrive as
     /// whole `assistant` messages the CLI never streams, so reading its `user` lines put results
     /// in the transcript with no card to sit under; its report comes back on the parent's own

--- a/crates/neosh-provider/tests/claude_stream_json.rs
+++ b/crates/neosh-provider/tests/claude_stream_json.rs
@@ -505,3 +505,61 @@ async fn a_cli_that_dies_is_no_longer_running_anything() {
         heard.0.lock().expect("heard lock poisoned")
     );
 }
+
+/// A `claude` that reports a limit in the middle of an answer, the way the real one does.
+///
+/// The line is copied from a live run — `utilization` is the fraction the CLI carries, not the
+/// percentage `/api/oauth/usage` answers with — because the two are one field name apart and
+/// nothing downstream of the parse can tell which scale it was handed. End to end rather than only
+/// in the parser: this is the path a real turn takes, and the bug it pins was one where every unit
+/// test still passed while the sidebar read `1%`.
+const METERED: &str = r#"#!/bin/sh
+say() { printf '%s\n' "$1"; }
+while IFS= read -r line; do
+  case "$line" in
+    *'"type":"user"'*)
+      say '{"type":"stream_event","session_id":"s","event":{"type":"message_start","message":{"model":"m","usage":{}}}}'
+      say '{"type":"rate_limit_event","rate_limit_info":{"status":"allowed_warning","unifiedRateLimitFallbackAvailable":false,"rateLimitType":"seven_day","utilization":0.56,"resetsAt":1787965200}}'
+      say '{"type":"stream_event","session_id":"s","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}}'
+      say '{"type":"stream_event","session_id":"s","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"METERED"}}}'
+      say '{"type":"stream_event","session_id":"s","event":{"type":"content_block_stop","index":0}}'
+      say '{"type":"stream_event","session_id":"s","event":{"type":"message_stop"}}'
+      say '{"type":"result","subtype":"success","is_error":false,"result":"METERED","session_id":"s"}' ;;
+  esac
+done
+"#;
+
+#[tokio::test]
+async fn a_limit_reported_mid_turn_arrives_on_the_scale_the_gauges_are_drawn_in() {
+    use neosh_proto::provider::Activity;
+
+    let fake = Fake::running("metered", METERED);
+    let p = ClaudeCliProvider::new(fake.program());
+    let events: Vec<ProviderEvent> =
+        p.stream(&inst(), req(&fake.dir, "one"), CancellationToken::new()).collect().await;
+
+    assert!(text_of(&events).contains("METERED"), "the answer still arrives: {events:?}");
+
+    let quotas: Vec<&Activity> = events
+        .iter()
+        .filter_map(|e| match e {
+            ProviderEvent::Activity { activity } => Some(activity),
+            _ => None,
+        })
+        .filter(|a| matches!(a, Activity::Quota { .. }))
+        .collect();
+    let [Activity::Quota { windows, .. }] = quotas[..] else {
+        panic!("one report of what the plan has left, got {quotas:?}")
+    };
+    assert_eq!(windows.len(), 1, "one window, patched over the rest rather than replacing them");
+    assert_eq!(windows[0].id, "weekly");
+    assert_eq!(
+        windows[0].used_percent, 56.0,
+        "fifty-six percent, not the `0.56` that reads as `1%` beside a polled `9%` session",
+    );
+    assert_eq!(
+        windows[0].severity,
+        neosh_proto::quota::QuotaSeverity::Normal,
+        "and a warning flag left over from before the reset does not outrank the number",
+    );
+}


### PR DESCRIPTION
The sidebar's plan strip reads `1%` for a limit that is really at 56%, and pressing `^L` puts it right — including in the sidebar. `^L` calls `quota.refresh()` when it opens, so the panel was never fixing anything; the poll behind it was.

## What was wrong

`claude`'s mid-turn `rate_limit_event` carries `utilization` as a **fraction** — `0.56` for fifty-six percent. It is the number the CLI read off an `anthropic-ratelimit-unified-*-utilization` response header: the vendor's own client multiplies it by a hundred at every use and compares it against a `0.7` threshold. `/api/oauth/usage` answers with `percent`, and a legacy `utilization` that is *also* already out of a hundred. The same word, two scales, one type apart, and `parse_claude_rate_limit_event` read the fraction as a percentage.

A `Turn` source patches rather than replaces (ADR 0044), so this landed as one window written over a correct polled snapshot: `weekly` went to `0.56` while `session` and `weekly_scoped` — which that line says nothing about — stayed right. `1%` in the strip, `99% left` in the sentence under it, until the next poll replaced the lot.

Caught in the act in a live `quota.json` while the fix was being written:

```json
{ "id": "weekly", "used_percent": 0.56, "severity": "critical", "active": true }
```

under `"source": "turn"`, beside a `session` at `11.0` and a `weekly_scoped` at `61.0`.

## Two things that came off the same number

- **The grade.** `QuotaSeverity::of` is handed `used_percent`, so a fraction could never reach `Warn`. Nothing reported mid-turn ever crossed a threshold on its own — only an explicit `status` did.
- **The warning.** `usage.warn_at` compares `used_percent >= 90`, and a window below it is *deleted* from the already-warned set so the next climb is news again. A patch to `0.56` cleared that bookkeeping every turn, so the next poll at 91% warned all over again.

## And a second bug the same file exposed

`allowed_warning` was graded `Critical` on the flag alone — which is why `weekly` at 56% is `"severity": "critical"` above. The endpoint sends that flag with stale data for a while after a window resets, which the vendor's client discards below seventy percent and comments on:

> Only show warnings when utilization is above threshold (70%). This prevents false warnings after week reset when API may send allowed_warning with stale data at low usage levels.

Ungated, that is a red row and a notification about the emptiest allowance of the week. Now gated on the number agreeing with the flag, at the same seventy percent, for the same reason. `rejected` is never second-guessed: it is not a prediction, it is a refusal that already happened.

## Verification

Pinned at three levels, because each is somewhere the scale could be lost again:

- `parse_claude_rate_limit_event` directly, and the endpoint's two shapes asserted *unchanged* beside it — the scales are only wrong relative to each other, so testing one without the other pins nothing.
- The `rate_limit_event` line through `sse.rs`, on a payload captured from a live run.
- End to end through the real driver against a stand-in `claude` (`tests/claude_stream_json.rs`). This one fails without the fix with `left: 0.56` — the same number that was in the live state file.

`cargo test -p neosh-provider` passes. `a_turn_the_cli_started_for_itself_does_not_end_the_one_we_asked_for` and `an_agent_that_speaks_unprompted_is_reported_and_then_listened_to` flake under parallel load and pass singly; that is the known ADR 0056 timing race and this diff does not touch `claude_cli.rs`.

Screen-checked with `scripts/shot.py` against a seeded snapshot: `▸ Weekly ███░░ 56% 5d` over `44% left · back in 5d`.

## Note for anyone whose gauges looked wrong

The workspace is a process (ADR 0058) — a rebuilt binary does not fix a workspace that is already running. `neosh stop`, then reattach.

Existing `quota.jsonl` samples written at the wrong scale stay wrong: they are observations, not derivations, and there is nothing to recompute them from. They age out at `RETENTION` (30 days) and show as false dropouts in the `^L` sparklines until then.