### PR TITLE
fix(agent): a call that never came back is closed out, not left spinning

### DIFF
--- a/crates/neosh-agent/src/agent.rs
+++ b/crates/neosh-agent/src/agent.rs
@@ -18,8 +18,8 @@ use std::sync::Arc;
 use futures::StreamExt;
 use neosh_proto::{
     Activity, ContentBlock, HookName, HookOutcome, HookPayload, Message, MessageLevel,
-    ModelSelection, Role, SessionId, StopReason, ToolCall, ToolCallId, ToolResult, TurnId,
-    TurnRequest, Usage,
+    ModelSelection, ProviderEvent, Role, SessionId, StopReason, ToolCall, ToolCallId, ToolResult,
+    TurnId, TurnRequest, Usage,
 };
 use neosh_provider::ProviderRegistry;
 use tokio::sync::mpsc;
@@ -749,8 +749,9 @@ impl Agent {
             // difference between a transcript that says what is going on and one that catches up
             // at the end. Kept so a result can be matched back to the call it answers.
             let reporting = provider.delegates_agent_loop();
-            let mut announced: std::collections::HashMap<ToolCallId, ToolCall> =
-                std::collections::HashMap::new();
+            // In the order they were announced, because that is the order they are closed out in
+            // if the stream ends before they come back. See below `drop(stream)`.
+            let mut announced: Vec<ToolCall> = Vec::new();
 
             loop {
                 let next = tokio::select! {
@@ -784,7 +785,7 @@ impl Agent {
                         TurnUpdate::ToolReady { id, name, input } if reporting => {
                             let call =
                                 ToolCall { id: id.clone(), turn: turn.clone(), name, input };
-                            announced.insert(id, call.clone());
+                            announced.push(call.clone());
                             self.emit(AgentEvent::ToolStarted {
                                 session: session.clone(),
                                 turn: turn.clone(),
@@ -794,7 +795,8 @@ impl Agent {
                         TurnUpdate::ToolResult { id, content, is_error } => {
                             // Only a delegating driver sends these; our own tools report through
                             // `run_tool`, which knows a great deal more about the call.
-                            if let Some(call) = announced.remove(&id) {
+                            if let Some(k) = announced.iter().position(|c| c.id == id) {
+                                let call = announced.remove(k);
                                 self.emit(AgentEvent::ToolFinished {
                                     session: session.clone(),
                                     turn: turn.clone(),
@@ -817,6 +819,44 @@ impl Agent {
             drop(stream);
 
             let cancelled = cancel.is_cancelled();
+
+            // A call the driver announced and never answered.
+            //
+            // The stream it would have arrived on is closed, so nothing is coming: an interrupt
+            // taken while a tool was out, a turn whose round ended before the result was read, a
+            // CLI that went away mid-call. And a card with no result does not simply sit there —
+            // it *spins*, and goes on counting, for as long as the conversation is open. Worse, it
+            // does so again tomorrow: the call is in the messages with no result beside it, and a
+            // result-less call is what a rebuild draws as still running. What that looks like is
+            // the one thing a spinner is supposed to rule out — a turn that finished twenty
+            // minutes ago, in a conversation answering perfectly well, wearing a mark that says
+            // something is still happening in it.
+            //
+            // So the turn closes them itself, in the order they were announced. Through the
+            // assembler rather than as a bare event, because the conversation is what a switch
+            // away and back is drawn from: an event alone would settle the card on screen and
+            // leave the transcript on disk saying the opposite. It is an error, and says which
+            // kind — a call that was interrupted and a call the agent walked away from are
+            // different things to read about, and neither of them is "still running".
+            for call in std::mem::take(&mut announced) {
+                let content = if cancelled {
+                    "interrupted before it came back".to_string()
+                } else {
+                    "the agent ended the turn without saying how this call went".to_string()
+                };
+                assembler.push(ProviderEvent::ToolResult {
+                    id: call.id.clone(),
+                    content: content.clone(),
+                    is_error: true,
+                });
+                self.emit(AgentEvent::ToolFinished {
+                    session: session.clone(),
+                    turn: turn.clone(),
+                    call,
+                    result: ToolResult { content, is_error: true },
+                });
+            }
+
             let calls = assembler.tool_calls();
             let (produced, this_stop, usage) = assembler.finish();
             total.merge(&usage);

--- a/crates/neosh-agent/tests/agent_loop.rs
+++ b/crates/neosh-agent/tests/agent_loop.rs
@@ -112,6 +112,53 @@ fn agent_with_script(
     Agent::new(session, perms, providers)
 }
 
+/// A driver that runs its own loop, which is the only kind that reports tool calls as they happen.
+///
+/// `claude`, `codex`, anything speaking ACP: the calls are made in another process, so the stream
+/// is the only place they exist and [`AgentEvent::ToolStarted`] is said for each one as it is
+/// announced. Whether the matching [`AgentEvent::ToolFinished`] is always said is what the test
+/// below is about, so this has to be a delegating driver — a model driver never populates that
+/// bookkeeping at all.
+struct Delegating(MockProvider);
+
+#[async_trait::async_trait]
+impl neosh_provider::Provider for Delegating {
+    fn driver(&self) -> DriverKind {
+        self.0.driver()
+    }
+
+    fn delegates_agent_loop(&self) -> bool {
+        true
+    }
+
+    fn stream(
+        &self,
+        instance: &InstanceConfig,
+        request: neosh_proto::TurnRequest,
+        cancel: tokio_util::sync::CancellationToken,
+    ) -> neosh_provider::ProviderStream {
+        self.0.stream(instance, request, cancel)
+    }
+}
+
+/// An agent whose driver runs its own loop and replays exactly the given turns.
+fn agent_with_delegating_script(
+    script: Vec<Vec<neosh_proto::ProviderEvent>>,
+) -> (Agent, tokio::sync::mpsc::UnboundedReceiver<AgentEvent>) {
+    let mut providers = ProviderRegistry::new();
+    providers.register_driver(Arc::new(Delegating(MockProvider::new(script))));
+    providers.add_instance(mock_instance());
+
+    let mut session = Session::new(std::env::temp_dir());
+    session.selection = Some(ModelSelection {
+        instance: InstanceId::from("mock"),
+        model: ModelId::from("mock"),
+        options: vec![],
+    });
+    let perms = Arc::new(PermissionLayer::new(std::env::temp_dir()));
+    Agent::new(session, perms, providers)
+}
+
 fn drain(rx: &mut tokio::sync::mpsc::UnboundedReceiver<AgentEvent>) -> Vec<AgentEvent> {
     let mut v = Vec::new();
     while let Ok(e) = rx.try_recv() {
@@ -400,6 +447,84 @@ async fn a_turn_runs_in_the_conversation_it_names_not_in_whichever_is_on_screen(
         drain(&mut rx).iter().all(|e| e.session() == &elsewhere),
         "every event says which conversation it came from, and it is not the one on screen"
     );
+}
+
+#[tokio::test]
+async fn a_call_the_driver_never_answered_is_closed_out_rather_than_left_running() {
+    // A card with no result does not sit still — it spins, and goes on counting, for as long as
+    // the conversation is open. And it does it again after a restart: the call is in the messages
+    // with no result beside it, and a result-less call is what a rebuild draws as still running.
+    // So a turn that walked away from a call has to say so before it ends.
+    //
+    // A stream that announces two calls, answers the first, and closes.
+    let script = vec![vec![
+        neosh_proto::ProviderEvent::MessageStart {
+            model: Some("mock".into()),
+            usage: neosh_proto::Usage::default(),
+        },
+        neosh_proto::ProviderEvent::BlockStart {
+            index: 0,
+            block: neosh_proto::BlockStartKind::ToolUse {
+                id: neosh_proto::ToolCallId("answered".into()),
+                name: "Bash".into(),
+            },
+        },
+        neosh_proto::ProviderEvent::ToolInputDelta { index: 0, partial_json: "{}".into() },
+        neosh_proto::ProviderEvent::BlockStop { index: 0 },
+        neosh_proto::ProviderEvent::ToolResult {
+            id: neosh_proto::ToolCallId("answered".into()),
+            content: "ok".into(),
+            is_error: false,
+        },
+        neosh_proto::ProviderEvent::BlockStart {
+            index: 1,
+            block: neosh_proto::BlockStartKind::ToolUse {
+                id: neosh_proto::ToolCallId("abandoned".into()),
+                name: "Bash".into(),
+            },
+        },
+        neosh_proto::ProviderEvent::ToolInputDelta { index: 1, partial_json: "{}".into() },
+        neosh_proto::ProviderEvent::BlockStop { index: 1 },
+        neosh_proto::ProviderEvent::MessageStop,
+    ]];
+    let (agent, mut rx) = agent_with_delegating_script(script);
+    let here = agent.sessions().current_id().clone();
+    let bridge = TestBridge::default();
+    agent.run_turn(&bridge, "go on then").await;
+
+    let events = drain(&mut rx);
+    let started: Vec<_> = events
+        .iter()
+        .filter_map(|e| match e {
+            AgentEvent::ToolStarted { call, .. } => Some(call.id.0.clone()),
+            _ => None,
+        })
+        .collect();
+    let finished: Vec<_> = events
+        .iter()
+        .filter_map(|e| match e {
+            AgentEvent::ToolFinished { call, result, .. } => {
+                Some((call.id.0.clone(), result.is_error))
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(started, vec!["answered".to_string(), "abandoned".to_string()]);
+    assert_eq!(
+        finished,
+        vec![("answered".to_string(), false), ("abandoned".to_string(), true)],
+        "every call that was announced came back, and the one nobody answered says it failed"
+    );
+
+    // And the conversation agrees, or switching away and back would draw the spinner again from
+    // messages that never got the result the event carried.
+    let store = agent.sessions();
+    let s = store.get(&here).expect("the conversation is still there");
+    let answered = s.messages.iter().flat_map(|m| &m.content).any(|b| {
+        matches!(b, neosh_proto::ContentBlock::ToolResult { tool_use_id, is_error, .. }
+            if tool_use_id.0 == "abandoned" && *is_error)
+    });
+    assert!(answered, "the unanswered call has a result in the transcript too");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What was wrong

A tool card whose call never came back never stops. The turn keeps a map of the calls a delegating driver has announced (`crates/neosh-agent/src/agent.rs:751`) so a `ToolResult` can be matched to the `ToolStarted` it answers — and when the stream closed, that map was simply dropped. Every call still in it never got an `AgentEvent::ToolFinished`, so `Host::finish_card` was never reached, `leg.result` stayed `None`, and `tick_cards` went on advancing the clock on that row.

Nothing else settles a card: `TurnEnded` does not touch them, and the next turn has a map of its own.

It also survives everything. The call goes into the conversation's messages as a `ToolUse` with no `ToolResult` beside it, and a result-less call is exactly what the transcript rebuild (`host.rs:11159`) draws as `ToolState::Running` — so switching away and back, or restarting the workspace, brings the spinner straight back.

Two ordinary ways in:

- `<Esc>` while a tool is out. The CLI is asked to stop, the result never comes.
- **Queueing.** A steered message ends the driver's round and opens a new one on the same process, and the map is per round, so anything outstanding at that boundary is orphaned.

What it looks like is the one thing a spinner is supposed to rule out: a turn that finished twenty minutes ago, in a conversation answering perfectly well, wearing a mark that says something is still happening in it.

## The fix

When the stream closes, the turn closes out whatever it announced and never heard back about — pushed through the `TurnAssembler` rather than emitted as a bare event, because the conversation is what a switch away and back is drawn from: an event alone would settle the card on screen and leave the transcript on disk saying the opposite.

It is an error, and says which kind — a call that was interrupted and a call the agent walked away from are different things to read about, and neither of them is "still running":

```
✗ Ran  echo settled, sleep 999
  └ the agent ended the turn without saying how this call went

✗ Ran  cargo build --release  4.1s
  └ interrupted before it came back
```

`announced` becomes a `Vec` so the close-out order is the order the calls were made.

## Verification

Reproduced and confirmed against a stand-in `claude` on `PATH` — real driver, real host, real TUI, via `scripts/shot.py`. Before: `⠹ Ran  echo settled, sleep 999` still spinning 25s after the turn printed its answer. After: settled, with the reason on the card, and the `is_error` result present in the stored session JSON so a rebuild draws it settled too.

New regression test `a_call_the_driver_never_answered_is_closed_out_rather_than_left_running` — every `ToolStarted` gets a `ToolFinished`, and the unanswered one lands in the conversation's messages.

Suites, per crate:

| suite | result |
|---|---|
| `neosh-agent` | 95 passed |
| `neosh-provider` | 199 passed |
| `neosh --test builtin_plugins` | 170 passed |
| `neosh --test workspace` | 23 passed |
| `neosh --test sessions` | 33 passed |

## Not in this change

While reading, one other way a turn can run forever: `claude_cli.rs:741`, `owed = if live.busy { 2 } else { 1 }`. If the CLI ever owes one fewer `result` than that count says, the loop parks on `live.lines.recv()` indefinitely while the 5s context poll keeps the process looking alive. Not reproduced, and left alone here.