### PR TITLE
chore: two methods nothing calls, and the one that is only ever a test's

### DIFF
--- a/crates/neosh-agent/src/store.rs
+++ b/crates/neosh-agent/src/store.rs
@@ -186,10 +186,6 @@ impl SessionStore {
         Ok(())
     }
 
-    fn contains(&self, id: &SessionId) -> bool {
-        self.sessions.contains_key(id)
-    }
-
     /// You are looking at it, so whatever finished while you were away has been seen.
     ///
     /// Answers whether anything changed, because the caller's next move is a write to disk and

--- a/crates/neosh/src/clients.rs
+++ b/crates/neosh/src/clients.rs
@@ -185,6 +185,11 @@ impl Clients {
     }
 
     /// Which set of windows a terminal is looking at.
+    ///
+    /// Test-only for the same reason [`attach_to`](Self::attach_to) is: a connection is handed its
+    /// [`Source`] when it attaches and keeps it for its life, so nothing in the workspace has to
+    /// look the pairing back up. What the tests are for is that the pairing is what it says.
+    #[cfg(test)]
     pub fn view_of(&self, id: ClientId) -> Option<ViewId> {
         self.clients.iter().find(|(c, _)| *c == id).map(|(_, c)| c.view)
     }


### PR DESCRIPTION
`cargo run` warned twice, once per crate, and both were dead code.

- **`SessionStore::contains`** — private, and nothing called it. `get(..).is_some()`
  is the same question, and it is the one every caller in the crate already asks.
  Removed.
- **`Clients::view_of`** — it *does* have callers, all of them in the tests directly
  below it. A connection is handed its `Source` when it attaches and keeps it for its
  life, so nothing in the workspace ever looks the client → view pairing back up;
  what the test is for is that the pairing is what it says. `#[cfg(test)]`, for the
  same reason `attach_to` beside it already is.

## Verification

`cargo build` is clean — no warnings from either crate.

```
cargo test -p neosh-agent --lib -- --test-threads 2   # 67 passed
cargo test -p neosh --bin neosh -- --test-threads 2   # 270 passed
```