### PR TITLE
fix(context): the meter stays on the strip, and moves when the context does

### DIFF
--- a/crates/neosh-agent/src/session.rs
+++ b/crates/neosh-agent/src/session.rs
@@ -70,6 +70,17 @@ pub struct Session {
     pub context_tokens: u64,
     /// What the driver says the window is. See [`neosh_proto::SessionInfo::context_window`].
     pub context_window: Option<u64>,
+    /// Whether a driver has ever answered "how full is it" for this conversation.
+    ///
+    /// Not the same question as "is the window known", and spelling it as
+    /// `context_window.is_some()` was one field standing in for two facts. `Activity::Compacted`
+    /// carries `post_tokens` and no window — a driver answering the first question and saying
+    /// nothing about the second — so applying it on a conversation whose window nobody had
+    /// reported left this reading as *nobody has told us*, which turned the estimate in
+    /// [`Self::add_usage`] back on. The next `TurnEnded` then set the meter to the prompt size of
+    /// the request that did the compacting, which is the whole pre-compaction conversation:
+    /// `/compact` moved the meter and then, a moment later, moved it back.
+    pub context_counted: bool,
     pub active_turn: Option<TurnId>,
     /// Things said to *this* conversation while its turn was running, waiting for a gap to be
     /// taken in.
@@ -161,6 +172,7 @@ impl Session {
             usage: Usage::default(),
             context_tokens: 0,
             context_window: None,
+            context_counted: false,
             active_turn: None,
             steering: Vec::new(),
             turn_started_at: None,
@@ -268,9 +280,16 @@ impl Session {
     /// for itself what to keep and when to compact, and is the only thing that can answer "how
     /// full is it". Where it does answer, guessing alongside it would be inventing a second number
     /// for a question that already has one.
+    ///
+    /// `window` of zero is *not said*, never *gone*. A driver that reports a count without a
+    /// denominator — which is what a compaction boundary is — must not take the percentage off a
+    /// meter at the exact moment the number finally moved.
     pub fn set_context(&mut self, used: u64, window: u64) {
         self.context_tokens = used;
-        self.context_window = (window > 0).then_some(window);
+        self.context_counted = true;
+        if window > 0 {
+            self.context_window = Some(window);
+        }
     }
 
     pub fn add_usage(&mut self, u: &Usage) {
@@ -281,7 +300,7 @@ impl Session {
         // direction that matters — it counts one request rather than the conversation the agent is
         // holding, which for a CLI that compacts on its own is not the same thing at all.
         let prompt = u.input_tokens + u.cache_read_tokens + u.cache_write_tokens;
-        if prompt > 0 && self.context_window.is_none() {
+        if prompt > 0 && !self.context_counted {
             self.context_tokens = prompt;
         }
         self.usage.input_tokens += u.input_tokens;

--- a/crates/neosh-proto/src/api.rs
+++ b/crates/neosh-proto/src/api.rs
@@ -1512,6 +1512,24 @@ pub struct AttachmentInfo {
 #[ts(export)]
 pub struct StatusSegment {
     pub text: String,
+    /// The same thing, said in less room — used when the strip will not fit and before this
+    /// segment is dropped for it.
+    ///
+    /// A narrow terminal is the case a status line has to survive, and the two answers it had were
+    /// both wrong. Truncating is out: half a token count is a wrong token count, and a bar cut
+    /// short is a bar reading a level nothing is at. Dropping is what happened instead, and it
+    /// took the context meter out of exactly the terminal that most needed it — a turn running
+    /// adds a segment, which is why the number people watch went missing precisely while there was
+    /// something to watch.
+    ///
+    /// So the segment says its own short form, for the reason [`Hint`] splits its key from its
+    /// label: what may be given up is a decision only the thing that wrote the text can make, and
+    /// it cannot be made once the text is one string. `███░░░░░ 34%` is the same fact as
+    /// `███░░░░░ 34% of 200k` with the denominator left out, and it is still true.
+    ///
+    /// Absent means there is no shorter true version, and the segment is dropped whole.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub short: Option<String>,
     /// The key that changes this, written the way the user would press it — `^P`, `^Z`.
     ///
     /// Beside what it acts on rather than in a list of its own, because a key is only memorable
@@ -1525,6 +1543,12 @@ pub struct StatusSegment {
     pub align: StatusAlign,
     /// Lower sorts first within its side. Ties break by key, so the order is stable across redraws
     /// rather than depending on which plugin happened to load first.
+    ///
+    /// It is also what a narrow strip gives up first, in reverse — so this is a statement about
+    /// how much the segment is worth, not only about where it goes. Two segments on the same
+    /// number are separated by the spelling of their keys, which is fine for an order and is no
+    /// way to decide which of them survives: give anything you would mind losing a number of its
+    /// own.
     #[serde(default)]
     pub priority: i32,
 }

--- a/crates/neosh-proto/src/provider.rs
+++ b/crates/neosh-proto/src/provider.rs
@@ -841,6 +841,18 @@ pub enum Activity {
     /// like everything else here `TurnAssembler` never reads it.
     Resume { token: String },
     /// How full the context window is, as of now.
+    ///
+    /// **As of now**, and that is the whole of the contract: a driver that asks its agent this
+    /// question and reads the answer later owes it to the receiver not to send one that has since
+    /// been overtaken. Nothing downstream can tell a stale count from a fresh one — they are the
+    /// same message — so the driver, which knows what it asked and when, is the only place the
+    /// distinction exists. `claude-cli` asks on a five-second clock and a compaction takes twenty:
+    /// every answer outstanding when the boundary lands measures a conversation that no longer
+    /// exists, and forwarding them put the meter back where [`Self::Compacted`] had just moved it
+    /// from.
+    ///
+    /// `total` of zero means *not said* rather than *gone*: a receiver keeps whatever denominator
+    /// it already had.
     Context {
         #[ts(type = "number")]
         used: u64,

--- a/crates/neosh-provider/src/drivers/claude_cli.rs
+++ b/crates/neosh-provider/src/drivers/claude_cli.rs
@@ -751,6 +751,21 @@ async fn run_turn(
     let mut abandoned = false;
     // Whether the context question in flight is the one that ends the turn.
     let mut ending = false;
+    // How many "how full is it" questions have been asked and not yet answered, and how many of
+    // those answers are about a context that no longer exists.
+    //
+    // The question is asked on a five-second clock and a compaction takes twenty, so when the
+    // boundary lands there are several of them outstanding — each one a measurement of the
+    // conversation *before* it was compacted, arriving after the line that said it had been. The
+    // last of them won, and `/compact` ended with the meter back at the number it started from,
+    // under a card saying `180k → 12k`. Answers are matched by shape rather than by request id, so
+    // this counts rather than names: every answer outstanding at the boundary is stale, in order.
+    //
+    // Per turn, deliberately. If the CLI never answers one of them the count does not come back
+    // down, and the cost of that is a meter that stops moving until the turn ends — which is a
+    // meter showing the boundary's own `post_tokens`, and therefore still right.
+    let mut asked = 0usize;
+    let mut stale = 0usize;
     // Lines read during that wait, which belong to whatever comes next. Held here rather than put
     // straight back where the next turn will find them, because this loop reads from there too —
     // put back, the same line is read, put back and read again, forever.
@@ -805,7 +820,9 @@ async fn run_turn(
                 }
             }
             _ = clock.tick(), if !interrupted && !ending => {
-                let _ = live.control(&json!({"subtype": "get_context_usage"})).await;
+                if live.control(&json!({"subtype": "get_context_usage"})).await.is_ok() {
+                    asked += 1;
+                }
             }
             // Asked to stop, not killed. A killed CLI takes the conversation with it, and the next
             // turn would resume into a history that has never heard of the work it interrupted.
@@ -947,11 +964,36 @@ async fn run_turn(
                 // of these are asked over a long turn, they all answer the same question, and the
                 // only one that matters is the newest.
                 if let Some(ev) = context_usage(&v) {
+                    asked = asked.saturating_sub(1);
+                    // Unless it is an answer about a context a compaction has since thrown away.
+                    // Dropped rather than corrected, because there is nothing here to correct it
+                    // with: the next tick asks again and the boundary's own `post_tokens` is what
+                    // the meter reads until it does. See `stale`.
+                    if stale > 0 {
+                        stale -= 1;
+                        // Still the line the ending was waiting for, even though nothing is sent
+                        // on: the turn is over either way, and a turn that hangs on for want of a
+                        // number is worse than a turn that ends without one.
+                        if ending {
+                            break;
+                        }
+                        continue;
+                    }
                     let _ = tx.send(ev).await;
                     if ending {
                         break;
                     }
                     continue;
+                }
+                // The boundary. Everything asked before it measured a conversation the CLI has
+                // just thrown away, so the answers still to come are about nothing. Read here
+                // rather than off the `Compacted` this line becomes, because what has to be
+                // counted is *when the line arrived*, and by the time an activity is an activity
+                // it has left this loop.
+                if v.get("type").and_then(Value::as_str) == Some("system")
+                    && v.get("subtype").and_then(Value::as_str) == Some("compact_boundary")
+                {
+                    stale = asked;
                 }
                 for ev in control_failure(&v).into_iter().chain(sse::claude_cli_line(&v, &mut live.state)) {
                     if abandoned {
@@ -1016,6 +1058,7 @@ async fn run_turn(
                         && live.control(&json!({"subtype": "get_context_usage"})).await.is_ok()
                     {
                         ending = true;
+                        asked += 1;
                         // Bounded, because an install that will not answer must not hold the turn
                         // open. Two seconds is far more than a local answer takes.
                         giveup.as_mut().reset(
@@ -1826,6 +1869,92 @@ done
             "the background command finished / answer 2",
             "the ending that arrives first belongs to the turn this one was queued behind, and the \
              message that was actually sent is still answered after it"
+        );
+
+        p.shutdown(&neosh_proto::SessionId::from("test"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A measurement of a context that no longer exists does not get to be the meter.
+    ///
+    /// How full the context is is asked on a five-second clock; a compaction takes twenty. So when
+    /// the boundary lands there are several of those questions outstanding, and their answers —
+    /// each one a count of the conversation the CLI has just thrown away — are read after the line
+    /// saying it threw it away. The last of them won, so `/compact` finished with the meter back
+    /// at the number it started from, directly under a card reading `20.3k → 1.6k`. ADR 0050 made
+    /// the boundary move the meter; this stops the answers behind it moving it back.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_context_answer_from_before_a_compaction_does_not_undo_it() {
+        use futures::StreamExt;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join(format!("neosh-compactrace-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("dirs");
+        let script = dir.join("fake-claude");
+        // The prompt starts a compaction and nothing else. The next question about the context is
+        // held — which is what a CLI busy compacting for twenty seconds does with it — and answered
+        // only after the boundary has gone out, with the count from before it. The question the
+        // *ending* asks is answered with the truth, because it was asked after the boundary and is
+        // the one answer here that is not stale.
+        std::fs::write(
+            &script,
+            r#"#!/bin/sh
+armed=
+while IFS= read -r line; do
+  case "$line" in
+    *get_context_usage*)
+      id=`printf '%s' "$line" | sed 's/.*"request_id":"\([^"]*\)".*/\1/'`
+      if [ -n "$armed" ]; then
+        armed=
+        printf '{"type":"system","subtype":"compact_boundary","compact_metadata":{"trigger":"manual","pre_tokens":20317,"post_tokens":1597}}\n'
+        printf '{"type":"control_response","response":{"subtype":"success","request_id":"%s","response":{"totalTokens":20317,"maxTokens":200000}}}\n' "$id"
+        printf '{"type":"result","subtype":"success","is_error":false,"session_id":"s","result":"Compacted the conversation."}\n'
+      else
+        printf '{"type":"control_response","response":{"subtype":"success","request_id":"%s","response":{"totalTokens":1597,"maxTokens":200000}}}\n' "$id"
+      fi
+      continue
+      ;;
+    *control_request*)
+      id=`printf '%s' "$line" | sed 's/.*"request_id":"\([^"]*\)".*/\1/'`
+      printf '{"type":"control_response","response":{"subtype":"success","request_id":"%s","response":{}}}\n' "$id"
+      continue
+      ;;
+  esac
+  armed=1
+  printf '{"type":"system","subtype":"init","session_id":"s","slash_commands":[]}\n'
+  printf '{"type":"system","subtype":"status","status":"compacting"}\n'
+done
+"#,
+        )
+        .expect("script");
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+        let p = ClaudeCliProvider::new(script.display().to_string());
+        let events: Vec<_> =
+            p.stream(&inst(), req("claude-opus-5"), CancellationToken::new()).collect().await;
+        let acts: Vec<&Activity> = events
+            .iter()
+            .filter_map(|e| match e {
+                ProviderEvent::Activity { activity } => Some(activity),
+                _ => None,
+            })
+            .collect();
+
+        let boundary = acts
+            .iter()
+            .position(|a| matches!(a, Activity::Compacted { .. }))
+            .unwrap_or_else(|| panic!("the boundary is reported at all\n{acts:?}"));
+        assert_eq!(
+            acts[boundary],
+            &Activity::Compacted { before: Some(20317), after: Some(1597) },
+            "with the counts either side of it\n{acts:?}"
+        );
+        assert!(
+            !acts[boundary + 1..]
+                .iter()
+                .any(|a| matches!(a, Activity::Context { used: 20317, .. })),
+            "and nothing after it says the window still holds what the compaction removed\n{acts:?}"
         );
 
         p.shutdown(&neosh_proto::SessionId::from("test"));

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -3815,7 +3815,8 @@ impl Host {
         left.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
         right.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
 
-        // Drop what does not fit, least important first.
+        // Make it fit: shorten what can be shortened, then drop what still does not fit, least
+        // important first both times.
         //
         // Both sides at once, because the two halves are competing for one line and the loser is
         // whichever segment is worth least, not whichever side it happens to be on. Without this,
@@ -3824,7 +3825,17 @@ impl Host {
         // as a corrupted line rather than as a full one.
         //
         // Nothing is truncated. Half a token count is a wrong token count, and a bar cut short is
-        // a bar reading a level nothing is at.
+        // a bar reading a level nothing is at. But dropping was the *only* other answer, and it
+        // is too blunt on its own: a segment then costs its full width or nothing, so the widest
+        // one in the strip is the one most likely to vanish — and the widest one here is the
+        // context meter, which is also the number people are watching. Worse, a turn starting adds
+        // a segment, so the strip got a column narrower at exactly the moment there was something
+        // to watch, and on a terminal a few columns short of the whole line the meter disappeared
+        // for the length of the turn and came back when it ended.
+        //
+        // A short form is not a truncation and is not this code's to invent: the segment carries
+        // it, because only the thing that wrote `███░░░░░ 34% of 200k` knows that the denominator
+        // is the part it can do without. See [`neosh_proto::StatusSegment::short`].
         {
             let width = self.status_width();
             // The mode word, the space each side of the line, and the single column that keeps the
@@ -3842,7 +3853,6 @@ impl Host {
                 left.iter().chain(right.iter()).map(|(p, k, _)| (*p, k.clone())).collect();
             // Least important last in the strip, so least important first out of it.
             order.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| b.1.cmp(&a.1)));
-            let mut dropped: std::collections::HashSet<String> = Default::default();
             for (_, key) in &order {
                 let seg = left
                     .iter()
@@ -3852,6 +3862,58 @@ impl Host {
                     .expect("came from those lists");
                 used += cost(seg);
             }
+            // One at a time and stopping the moment it fits, so the strip gives up as little as
+            // will do rather than shrinking everything the first time anything is tight.
+            if width > 0 {
+                let mut given_up: Vec<(String, String)> = Vec::new();
+                for (_, key) in order.iter() {
+                    if used <= width {
+                        break;
+                    }
+                    let Some(seg) = left
+                        .iter_mut()
+                        .chain(right.iter_mut())
+                        .find(|(_, k, _)| k == key)
+                        .map(|(_, _, s)| s)
+                    else {
+                        continue;
+                    };
+                    // Taken rather than read, so a segment cannot be shortened twice — and an
+                    // empty short form is no short form, not a segment that says nothing.
+                    let Some(short) = seg.short.take().filter(|s| !s.is_empty()) else { continue };
+                    let before = cost(seg);
+                    let full = std::mem::replace(&mut seg.text, short);
+                    // `+` before `-`: a short form is shorter, but this must not depend on it.
+                    used = used + cost(seg) - before;
+                    given_up.push((key.clone(), full));
+                }
+                // And give back whatever still fits, most important first.
+                //
+                // Shortening is granular — the meter gives up eight columns to recover one — so
+                // stopping at the first arrangement that fits stops one step past the best one
+                // whenever it took more than a single segment to get there. Without this the
+                // strip has blank columns in the middle of it *and* something abbreviated, which
+                // is the one outcome nothing here wanted.
+                for (key, full) in given_up.iter().rev() {
+                    let Some(seg) = left
+                        .iter_mut()
+                        .chain(right.iter_mut())
+                        .find(|(_, k, _)| k == key)
+                        .map(|(_, _, s)| s)
+                    else {
+                        continue;
+                    };
+                    // The two forms differ only in their text — the key beside them is the same —
+                    // so the difference in what the line costs is the difference in their widths.
+                    // `used` already counts the short one, so this cannot go below zero.
+                    let want = used + display_width(full) - display_width(&seg.text);
+                    if want <= width {
+                        seg.text.clone_from(full);
+                        used = want;
+                    }
+                }
+            }
+            let mut dropped: std::collections::HashSet<String> = Default::default();
             for (_, key) in order.iter() {
                 if width == 0 || used <= width {
                     break;
@@ -8094,14 +8156,13 @@ impl Host {
                 // estimate in `add_usage` off, and the next answer only arrives with the next
                 // request. The driver said `post_tokens`; this is what it is for.
                 if let Some(used) = after {
-                    let window = self
-                        .agent
-                        .sessions()
-                        .get(&session)
-                        .and_then(|s| s.context_window)
-                        .unwrap_or(0);
+                    // No window with it, and none is wanted: a boundary is a count, and
+                    // `set_context` keeps whatever denominator is already known. Reading the old
+                    // one back out to hand it straight in again was this doing `set_context`'s job
+                    // — and doing it through the session lock, which is the one thing here that
+                    // must not be taken twice in a statement.
                     if let Some(s) = self.agent.sessions().get_mut(&session) {
-                        s.set_context(used, window);
+                        s.set_context(used, 0);
                     }
                     self.persist_sessions();
                 }
@@ -8488,6 +8549,20 @@ impl Host {
                         data: Some(serde_json::json!({ "win": win, "width": width, "height": height })),
                         from: BUILTIN.to_string(),
                     });
+                    // The strip is *fitted* to its own width — segments are shortened and then
+                    // dropped until the line fits — and this is the only place that width arrives.
+                    // Without this the fitting stands from whenever a plugin last wrote a segment,
+                    // which at rest is not again: nothing lays the strip out unless something in
+                    // it changed, and at rest nothing in it does. So a terminal made wider kept a
+                    // strip missing everything that had not fitted the old one, and a terminal
+                    // made narrower kept a strip too long for it, with the right-hand half drawn
+                    // over the end of the left — until a turn started or a conversation changed and
+                    // it silently put itself right, which is the version of this that is hardest to
+                    // report.
+                    let strip = self.editor.window(win).map(|w| w.buf) == Some(self.v().status);
+                    if strip {
+                        self.refresh_status();
+                    }
                 }
                 // What the frontend *drew*, which is not always what was asked for: a window whose
                 // scroll had to bend to keep its cursor on screen is showing a different first row.
@@ -8502,6 +8577,10 @@ impl Host {
                 // one's welcome until something unrelated happens to redraw it.
                 if win == self.v().chat_win && self.chat_width() != was {
                     self.draw_welcome();
+                    // And the block at the bottom of a running turn, for the same reason: the plan
+                    // and what is out are laid out against `chat_width`, so after a resize they are
+                    // wrapped to a width the window no longer has.
+                    self.redraw_footer();
                 }
             }
             InputEvent::Attached { .. } => {

--- a/crates/neosh/src/sessions.rs
+++ b/crates/neosh/src/sessions.rs
@@ -47,6 +47,14 @@ struct Stored {
     /// meter whose denominator changed on reload would move without anything having happened.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     context_window: Option<u64>,
+    /// And whether that count came from a driver rather than from a prompt size.
+    ///
+    /// Persisted for the reason the other two are: a reopened conversation that started estimating
+    /// again would move its meter on the next turn with nothing having happened. Absent in a file
+    /// written before this existed, where `context_window` being set is what the answer used to
+    /// be — see [`Stored::into_session`].
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    context_counted: bool,
     /// A turn finished here and nobody has been back to look at it.
     ///
     /// Persisted because that is exactly the case it exists for: the workspace ran the turn while
@@ -132,6 +140,7 @@ impl From<&Session> for Stored {
             usage: s.usage,
             context_tokens: s.context_tokens,
             context_window: s.context_window,
+            context_counted: s.context_counted,
             unread: s.unread,
             running_since: s.running_since,
             interrupted: s.interrupted,
@@ -156,6 +165,10 @@ impl Stored {
         s.usage = self.usage;
         s.context_tokens = self.context_tokens;
         s.context_window = self.context_window;
+        // A file written before this field existed says so by not having it, and there the window
+        // being known *was* the answer. Reading it as `false` would turn the estimate back on for
+        // every conversation that has ever been reopened.
+        s.context_counted = self.context_counted || self.context_window.is_some();
         s.unread = self.unread;
         // A turn that was in flight when this was written is a turn nobody ended: the only process
         // that could have ended it is the one that wrote this and is now gone. Loading is the only

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -4364,6 +4364,78 @@ export async function activate({ neosh }: PluginContext) {
 }
 "#;
 
+/// A driver that compacts without ever having said how big its window is.
+///
+/// Which is most of them, and `claude` whenever the control question goes unanswered: a boundary
+/// carries `post_tokens` and no denominator. The turn then ends carrying the usage of the request
+/// that did the compacting — the whole pre-compaction conversation — and that is what used to land
+/// on the meter.
+const AMNESIAC: &str = r#"
+import type { PluginContext } from "@neosh/api";
+
+export async function activate({ neosh }: PluginContext) {
+  await neosh.provider.register("amnesiac", [{
+    id: "amnesiac", driver: "amnesiac", display_name: "Amnesiac",
+    models: [{ id: "amnesiac", display_name: "Amnesiac", context_window: 300000 }],
+  }], async (_req, emit) => {
+    emit({ type: "message_start", model: "amnesiac", usage: {} });
+    emit({ type: "activity", activity: { kind: "compacted", before: 180000, after: 12000 } });
+    emit({ type: "block_start", index: 0, block: { kind: "text" } });
+    emit({ type: "text_delta", index: 0, text: "Carrying on." });
+    emit({ type: "block_stop", index: 0 });
+    emit({
+      type: "message_delta",
+      stop_reason: { kind: "end_turn" },
+      usage: { input_tokens: 180000, output_tokens: 20 },
+    });
+    emit({ type: "message_stop" });
+  }, { agentLoop: true });
+  neosh.event.on("neosh.ready", () => neosh.notify("amnesiac ready"));
+}
+"#;
+
+fn install_amnesiac(sb: &Sandbox) {
+    let dir = sb.root.join("config/plugins/amnesiac");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    std::fs::write(
+        dir.join("plugin.toml"),
+        "name = \"amnesiac\"\nversion = \"0.1.0\"\nentry = \"main.ts\"\npermissions = [\"providers\"]\n",
+    )
+    .expect("manifest");
+    std::fs::write(dir.join("main.ts"), AMNESIAC).expect("plugin");
+}
+
+/// A count from a driver turns the guess off, even when it comes without a window.
+///
+/// "A driver has answered how full it is" and "the window is known" were one field, and a
+/// compaction boundary is the case that tells them apart: it is the first without being the
+/// second. Read as *nobody has told us*, it turned `add_usage`'s estimate back on — so the turn
+/// ended, the prompt that did the compacting was counted, and the meter went back to the number
+/// the compaction had just removed. See ADR 0050, which is the same failure through another door.
+#[test]
+fn a_compaction_without_a_window_still_stops_the_meter_being_guessed() {
+    let sb = Sandbox::new("ctxamnesia");
+    install_amnesiac(&sb);
+    sb.write_config("[options]\n\"agent.model\" = \"amnesiac/amnesiac\"\n");
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("amnesiac ready");
+    s.type_text("go");
+    s.enter();
+    assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("Carrying on."))),
+        "the turn finished\n{:?}",
+        s.chat_now()
+    );
+    // Past the turn's end, which is where the estimate used to be applied. The failure is not that
+    // the wrong number is drawn once; it is that it settles there.
+    s.drain_for(Duration::from_millis(2000));
+    let line = s.status_now().join("");
+    assert!(
+        line.contains("4% of 300k") && !line.contains("60%"),
+        "and the meter keeps what the compaction left, not the prompt that did it\n{line:?}"
+    );
+}
+
 /// A driver that fills its context and then compacts it, reporting both the way `claude` does.
 ///
 /// `Activity::Context` is the driver answering "how full is it"; `Activity::Compacted` carries the
@@ -4454,6 +4526,97 @@ fn the_context_meter_is_there_before_the_first_turn() {
     assert!(
         s.status_now().iter().any(|l| l.contains('\u{2588}')),
         "with filled cells\n{:?}",
+        s.status_now()
+    );
+}
+
+/// The same driver, holding the turn open, so the strip can be read while one is actually running.
+///
+/// The bug this exists for only happens mid-turn: a running turn puts a segment of its own on the
+/// right-hand end, and a strip that fitted at rest is several columns too long the moment there is
+/// something to watch.
+const SLOW_WIDE: &str = r#"
+import type { PluginContext } from "@neosh/api";
+const nap = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export async function activate({ neosh }: PluginContext) {
+  await neosh.provider.register("wide", [{
+    id: "wide", driver: "wide", display_name: "Wide",
+    models: [{ id: "wide-1", display_name: "Wide One", context_window: 300000 }],
+  }], async (_req, emit) => {
+    emit({ type: "message_start", model: "wide-1", usage: { input_tokens: 100000 } });
+    emit({ type: "text_delta", index: 0, text: "ok" });
+    await nap(12000);
+    emit({
+      type: "message_delta",
+      stop_reason: { kind: "end_turn" },
+      usage: { input_tokens: 100000, output_tokens: 20 },
+    });
+    emit({ type: "message_stop" });
+  });
+  neosh.event.on("neosh.ready", () => neosh.notify("slow wide ready"));
+}
+"#;
+
+fn install_slow_wide(sb: &Sandbox) {
+    let dir = sb.root.join("config/plugins/wide");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    std::fs::write(
+        dir.join("plugin.toml"),
+        "name = \"wide\"\nversion = \"0.1.0\"\nentry = \"main.ts\"\npermissions = [\"providers\"]\n",
+    )
+    .expect("manifest");
+    std::fs::write(dir.join("main.ts"), SLOW_WIDE).expect("plugin");
+}
+
+/// The meter says less rather than nothing, and it is the last thing on the strip to go.
+///
+/// Two bugs, one line. A segment used to cost its full width or nothing, so the widest thing in
+/// the strip was the first thing to disappear from a narrow one — and the widest thing is the
+/// context meter, which is also the only number here that says whether the conversation is about
+/// to stop working. It sat on priority 20, tied with the git branch and separated from it only by
+/// the fact that `context` sorts after `branch`, which made it the second segment out of the line.
+/// And a running turn adds a segment, so a terminal wide enough at rest lost the meter for exactly
+/// the length of every answer — the one time anybody is watching it.
+///
+/// Now it carries a short form of itself: the denominator comes off before the segment does, and
+/// `██░░░░░░ 33%` is as true as `██░░░░░░ 33% of 300k`.
+#[test]
+fn a_narrow_strip_shortens_the_context_meter_rather_than_dropping_it() {
+    let sb = Sandbox::new("ctxnarrow");
+    install_slow_wide(&sb);
+    sb.write_config("[options]\n\"agent.model\" = \"wide/wide-1\"\n");
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("slow wide ready");
+
+    // A stdio frontend has no geometry, so the strip is unfitted until a width is said out loud —
+    // which is the whole subject here.
+    s.viewport("[status]", 50, 1);
+
+    s.type_text("go");
+    s.enter();
+    assert!(
+        s.pump(|s| s.status_now().iter().any(|l| l.contains("33%"))),
+        "the meter is on a 50-column strip with a turn in flight\n{:?}",
+        s.status_now()
+    );
+    assert!(
+        !s.status_now().iter().any(|l| l.contains("of 300k")),
+        "shortened rather than dropped — the denominator is what it gave up\n{:?}",
+        s.status_now()
+    );
+    assert!(
+        s.status_now().iter().any(|l| l.contains('\u{2588}') || l.contains('\u{2591}')),
+        "and it is still a bar, not only a number\n{:?}",
+        s.status_now()
+    );
+
+    // And the strip is fitted *here*, on the width arriving, rather than whenever a plugin next
+    // happens to rewrite a segment. Widening used to leave the old, narrower line in place.
+    s.viewport("[status]", 200, 1);
+    assert!(
+        s.pump(|s| s.status_now().iter().any(|l| l.contains("33% of 300k"))),
+        "and a terminal made wider says the whole thing again\n{:?}",
         s.status_now()
     );
 }
@@ -4796,6 +4959,12 @@ fn compacting_updates_the_context_meter() {
 
 /// A strip too narrow for everything drops whole segments, least important first, rather than
 /// writing the right half over the end of the left one.
+///
+/// Shortening comes first and dropping is what is left — see
+/// [`a_narrow_strip_shortens_the_context_meter_rather_than_dropping_it`] — so at forty columns the
+/// meter has already given up its denominator and it is the model name that goes. What must never
+/// happen either way is the thing this test is named for: a right-hand segment written over the end
+/// of a left-hand one, which reads as a corrupted line rather than as a full one.
 #[test]
 fn a_narrow_status_strip_drops_segments_rather_than_overlapping_them() {
     let sb = Sandbox::new("narrowstatus");
@@ -4811,7 +4980,7 @@ fn a_narrow_status_strip_drops_segments_rather_than_overlapping_them() {
             let line = s.status_now().join("");
             !line.contains("of 300k") && line.contains("chat")
         }),
-        "the meter went and the mode stayed\n{:?}",
+        "the denominator went and the mode stayed\n{:?}",
         s.status_now()
     );
     let line = s.status_now().join("");
@@ -4819,6 +4988,12 @@ fn a_narrow_status_strip_drops_segments_rather_than_overlapping_them() {
         line.chars().count() <= 41,
         "and the line still fits the window: {} chars of 40\n{line:?}",
         line.chars().count()
+    );
+    // Something was dropped — forty columns is not enough for what is left even shortened — and
+    // what went is the model name rather than the meter.
+    assert!(
+        line.contains('%') && !line.contains("^P"),
+        "and what went is the model name, not the number the meter exists for\n{line:?}"
     );
 }
 

--- a/plugins/api/src/generated/StatusSegment.ts
+++ b/plugins/api/src/generated/StatusSegment.ts
@@ -7,6 +7,25 @@ import type { StatusAlign } from "./StatusAlign";
 export type StatusSegment = {
   text: string;
   /**
+   * The same thing, said in less room — used when the strip will not fit and before this
+   * segment is dropped for it.
+   *
+   * A narrow terminal is the case a status line has to survive, and the two answers it had were
+   * both wrong. Truncating is out: half a token count is a wrong token count, and a bar cut
+   * short is a bar reading a level nothing is at. Dropping is what happened instead, and it
+   * took the context meter out of exactly the terminal that most needed it — a turn running
+   * adds a segment, which is why the number people watch went missing precisely while there was
+   * something to watch.
+   *
+   * So the segment says its own short form, for the reason [`Hint`] splits its key from its
+   * label: what may be given up is a decision only the thing that wrote the text can make, and
+   * it cannot be made once the text is one string. `███░░░░░ 34%` is the same fact as
+   * `███░░░░░ 34% of 200k` with the denominator left out, and it is still true.
+   *
+   * Absent means there is no shorter true version, and the segment is dropped whole.
+   */
+  short?: string | null;
+  /**
    * The key that changes this, written the way the user would press it — `^P`, `^Z`.
    *
    * Beside what it acts on rather than in a list of its own, because a key is only memorable
@@ -19,6 +38,12 @@ export type StatusSegment = {
   /**
    * Lower sorts first within its side. Ties break by key, so the order is stable across redraws
    * rather than depending on which plugin happened to load first.
+   *
+   * It is also what a narrow strip gives up first, in reverse — so this is a statement about
+   * how much the segment is worth, not only about where it goes. Two segments on the same
+   * number are separated by the spelling of their keys, which is fine for an order and is no
+   * way to decide which of them survives: give anything you would mind losing a number of its
+   * own.
    */
   priority: number;
 };

--- a/plugins/api/src/index.ts
+++ b/plugins/api/src/index.ts
@@ -1247,11 +1247,21 @@ export interface StatusApi {
    * `keys` is drawn immediately after `text`, dimmed — the key that changes this thing, beside the
    * thing it changes. Write it the way the user would press it (`^P`, `^Z`), not the way a keymap
    * spells it.
+   *
+   * `short` is the same thing said in less room, and the strip asks for it before it drops your
+   * segment. Give one to anything wide: without it a segment costs its full width or nothing, so
+   * the widest thing in the strip is the first thing to vanish on a narrow terminal — which is
+   * usually the thing worth the most. It is not a truncation and the host will not invent one; it
+   * is the fact with a part left out, and only you know which part that is.
+   *
+   * `priority` is where the segment sits *and* what the strip gives up first, in reverse.
    */
   set(
     key: string,
     segment: {
       text: string;
+      /** The same fact in fewer columns, used before this segment is dropped for want of room. */
+      short?: string;
       keys?: string;
       hl?: string;
       align?: StatusAlign;
@@ -2654,6 +2664,7 @@ function build(
           key,
           segment: {
             text: segment.text,
+            short: segment.short ?? null,
             keys: segment.keys ?? null,
             hl: segment.hl ?? null,
             align: segment.align ?? "left",

--- a/plugins/builtin/model/main.ts
+++ b/plugins/builtin/model/main.ts
@@ -99,14 +99,29 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
     // Whether the next turn can authenticate belongs beside the model name, not in the error it
     // would otherwise become. "opus · no key" is something you fix before you have typed the
     // question; a failure on send is something you fix after losing your train of thought.
-    const cred = (await neosh.agent.credentials().catch(() => []))
-      .find((c) => c.instance === selection.instance);
+    //
+    // Together with the catalogue, because both are wanted before the strip is written and
+    // neither depends on the other — asked one after the other, the model name appeared a round
+    // trip later than it had to for the sake of a shorter spelling of itself.
+    const [creds, entries] = await Promise.all([
+      neosh.agent.credentials().catch(() => []),
+      neosh.agent.listModels(selection.instance).catch(() => [] as ModelEntry[]),
+    ]);
+    const cred = creds.find((c) => c.instance === selection.instance);
     const unusable = cred?.source.kind === "missing";
+    const info = entries.find((e) => e.model.id === selection.model)?.model;
     // Right-hand end, where pi puts it: the left of the strip is what the conversation is
     // spending, which changes constantly, and the right is what it is spending it on, which does
     // not. Two things that move at different rates should not be interleaved.
+    //
+    // `short` is the id with the vendor's half of it off — `claude-opus-4-5` is `opus-4-5`, and
+    // `anthropic/claude-opus-5` is `opus-5`. This is the widest thing on the strip and it used to
+    // cost its full width or nothing, which on a narrow terminal meant the segments after it went
+    // instead. Which vendor you are on is the part of that string you already knew.
+    const brief = withoutVendor(selection.model, info?.family ?? undefined);
     await neosh.status.set("model", {
       text: `${selection.model}${unusable ? "  no key" : ""}`,
+      short: brief ? `${brief}${unusable ? "  no key" : ""}` : undefined,
       keys: "^P",
       hl: unusable ? "Diagnostic.Warn" : "Accent",
       align: "right",
@@ -115,10 +130,7 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
 
     // Its own segment, with its own key. Glued onto the model name they read as one word, and the
     // one you want to change is whichever you are not looking at.
-    const entries = await neosh.agent.listModels(selection.instance).catch(() => [] as ModelEntry[]);
-    const descriptors =
-      entries.find((e) => e.model.id === selection.model)?.model.capabilities?.option_descriptors ??
-      [];
+    const descriptors = info?.capabilities?.option_descriptors ?? [];
     const options = summarise(selection.options ?? [], descriptors);
     if (options) {
       await neosh.status.set("effort", {
@@ -203,6 +215,28 @@ function beyond(
       ? value === true && typeof d.prompt_injected_word === "string"
       : typeof value === "string" && (d.prompt_injected_values ?? []).includes(value);
   });
+}
+
+/**
+ * The model id with the vendor's half of it taken off — `claude-opus-4-5` becomes `opus-4-5`.
+ *
+ * The strip's short form for the model segment. Cut at the *family*, which the catalogue already
+ * says (`"opus"`, `"sonnet"`, `"gpt-5"`), rather than at a prefix this file guesses at: a list of
+ * vendor spellings to strip is a list that is wrong about the next provider somebody registers,
+ * and the whole point of the catalogue is that a plugin's models arrive described.
+ *
+ * Nothing when there is no shorter honest version of the name — no family, a family that is not in
+ * the id, or an id that is already only its family. The segment is then dropped whole if it comes
+ * to that, which is the right answer: half a model id names a different model.
+ */
+function withoutVendor(id: string, family?: string): string | undefined {
+  // A namespaced id is a vendor and a name, and the vendor is the part being dropped either way.
+  const bare = id.slice(id.lastIndexOf("/") + 1);
+  if (!family) return bare === id ? undefined : bare;
+  const at = bare.indexOf(family);
+  if (at <= 0) return bare === id ? undefined : bare;
+  const cut = bare.slice(at);
+  return cut === id ? undefined : cut;
 }
 
 /**

--- a/plugins/builtin/usage/main.ts
+++ b/plugins/builtin/usage/main.ts
@@ -1539,7 +1539,9 @@ async function drawContext(neosh: Neosh, session: SessionInfo) {
   // Nothing to be a percentage of. Better to say the number than to invent a denominator.
   if (!window) {
     if (used > 0) {
-      await neosh.status.set("context", { text: `${short(used)} ctx`, priority: 20 });
+      // Same rank as the meter below: it is the same fact, said without a denominator because
+      // there is not one to be had.
+      await neosh.status.set("context", { text: `${short(used)} ctx`, priority: 8 });
     } else {
       await neosh.status.clear("context");
     }
@@ -1548,10 +1550,25 @@ async function drawContext(neosh: Neosh, session: SessionInfo) {
   const ascii = (await neosh.opt.get<boolean>("ui.ascii_only").catch(() => false)) ?? false;
   const fraction = Math.min(1, used / window);
   const percent = fraction * 100;
+  const bar = meter(fraction, CELLS, { ascii });
   await neosh.status.set("context", {
-    text: `${meter(fraction, CELLS, { ascii })} ${percent.toFixed(0)}% of ${short(window)}`,
+    text: `${bar} ${percent.toFixed(0)}% of ${short(window)}`,
+    // What to give up when the strip runs out of room: the denominator. It is the one part of
+    // this that does not change all conversation — the window is a property of the model, and it
+    // is on the model picker, in `/usage` and in the sidebar — whereas the bar and the percentage
+    // are the whole reason anybody looks here. Not a truncation: `███░░░░░ 34%` is true.
+    short: `${bar} ${percent.toFixed(0)}%`,
     hl: percent > 90 ? "Meter.Full" : percent > 70 ? "Meter.Warn" : "Comment",
-    priority: 20,
+    // Ahead of the branch, the cost and the token counts, and this is the point rather than a
+    // detail of the ordering. Priority is also what a narrow strip gives up first, and this used
+    // to sit on 20 — tied with the git branch, separated only by the fact that "context" sorts
+    // after "branch" — which made it the second thing out of the line after the token counts. So
+    // on a terminal a few columns short, the meter vanished; and because a running turn adds its
+    // own segment to the right-hand end, a terminal wide enough at rest was several columns too
+    // narrow the moment an answer started, which is precisely when the number matters. It is the
+    // most valuable thing on this strip: it is the one that says whether the conversation is
+    // about to stop working.
+    priority: 8,
   });
 }
 


### PR DESCRIPTION
Two reports, three faults, all of them the one number nobody could trust.

## 1. The meter vanished while a turn was running

A status segment cost its full width or nothing, so the widest thing in the strip was the first thing to disappear from a narrow one — and the widest thing is the context meter. It sat on `priority: 20`, tied with the git branch and separated from it only by the fact that `context` sorts after `branch`, which made it the second segment out of the line after the token counts. A running turn then adds a segment of its own to the right-hand end, so a terminal wide enough at rest was several columns too narrow the moment an answer started.

The strip is also narrower than the terminal by the whole width of the sidebar, so this bit far earlier than it looks like it should. Driven under a pty, sidebar open, real branch name — **before**:

```
cols 100 │ chat  full access ⇧⇥                                    mock ^P │
cols 120 │ chat  full access ⇧⇥  fix/context-window-hidden-during-turn ●7    mock ^P │
cols 140 │ chat  full access ⇧⇥  fix/context-window-hidden-during-turn ●7  ███░░░░░ 34% of 200k   mock ^P │
```

Gone from 100 to 130. The branch name — which never changes — kept its 38 columns.

**After**:

```
cols 100 │ chat  full access ⇧⇥  ███░░░░░ 34%                      mock ^P │
cols 130 │ chat  full access ⇧⇥  ███░░░░░ 34%  fix/context-window-hidden-during-turn ●7   mock ^P │
cols 160 │ chat  full access ⇧⇥  ███░░░░░ 34% of 200k  fix/…-turn ●7  ↑68k ↓420    mock ^P │
```

Truncating is still out — half a token count is a wrong token count, and a bar cut short reads a level nothing is at. But dropping was too blunt on its own. `StatusSegment::short` is the same fact in less room, asked for before the segment is dropped, and it is not the host's to invent: only the thing that wrote `███░░░░░ 34% of 200k` knows the denominator is the part it can do without. The model name gives up the vendor the same way, cut at the catalogue's `family` rather than at a prefix list that would be wrong about the next provider somebody registers.

Shortening runs least-important-first and stops the moment it fits, then gives back whatever still fits, most-important-first — otherwise it stops one step past the best arrangement and the strip has blank columns *and* an abbreviation.

**Second half: the strip was never re-fitted on resize.** `ViewportChanged` is the only place a width arrives, and the fitting stood from whenever a plugin last happened to rewrite a segment — which at rest is not again. A terminal made wider kept a strip missing everything that had not fitted the old one; a terminal made narrower kept one too long for it, with the right-hand half drawn over the end of the left, until a turn started and it silently put itself right.

## 2. `/compact` moved the meter and then moved it back

**"A driver has counted" and "the window is known" were one field.** A compaction boundary is the case that tells them apart: it carries `post_tokens` and no denominator. Applied to a conversation whose window nobody had reported, it left `context_window` as `None`, which read as *nobody has told us* and turned the estimate in `add_usage` back on. The turn then ended carrying the usage of the request that did the compacting — the whole pre-compaction conversation — and that landed on the meter:

```
" chat  full access ⇧⇥  █████░░░ 60% of 300k  ↑180k ↓20  amnesiac ^P "
```

`60%`, under a card that had just said `180k → 12k`. This is ADR 0050's failure through another door: that made the boundary move the meter, and this moved it straight back.

`context_counted` is now its own field and its own question, persisted, defaulting on load to `context_window.is_some()` so nothing already written regresses. `set_context` with a window of zero now means *not said* rather than *gone*, which lets the compaction handler stop reading the old denominator back out to hand it straight in again — through the session lock, which is the one thing here that must not be taken twice in a statement.

**And answers about a context that no longer existed.** `claude` is asked how full it is on a five-second clock; a compaction takes twenty (`duration_ms: 19927` in the recorded fixture). So several of those questions are outstanding when the boundary lands, and their answers are read after the line saying the context was thrown away:

```
Compacting, Compacted { before: 20317, after: 1597 }, Context { used: 20317, .. }
                                                      ^^^^ undoes it
```

They are matched by shape rather than by request id, so nothing downstream can tell a stale one from a fresh one — the driver, which knows what it asked and when, is the only place the distinction exists. Every answer outstanding at a boundary is now dropped, in order, and per turn: a CLI that never answers one costs a meter that stops refreshing until the turn ends, which is a meter showing the boundary's own `post_tokens` and therefore still right. The contract is written down on `ProviderEvent::Activity::Context` for third-party drivers.

End to end:

```
▌ /compact

  Compacted the conversation  180.0k → 12.0k

Compacted. Carrying on.
─────────────────────────────────────────────────
 chat  full access ⇧⇥  12k ctx  fix/…-turn ●7  ↑180k ↓20   mock ^P
```

## Verification

Three tests, each checked to **fail** with only its own fix backed out:

- `a_narrow_strip_shortens_the_context_meter_rather_than_dropping_it` — mid-turn on a fifty-column strip, and across a resize.
- `a_compaction_without_a_window_still_stops_the_meter_being_guessed` — past the turn end, which is where the estimate used to be applied.
- `a_context_answer_from_before_a_compaction_does_not_undo_it` — against a stand-in `claude` over a real pty.

`a_narrow_status_strip_drops_segments_rather_than_overlapping_them` had been asserting the old behaviour ("the meter went and the mode stayed"); it now asserts that what goes instead is the model name, and that nothing overlaps.

Suites: `neosh-core` 157, `neosh-agent` 94, `neosh-provider` 200, `builtin_plugins` 172, `workspace` 23, `plugin_manager` 5, `sessions` 33, `editing` 23, `reading` 40, `questions` 17, `approvals` 7, `user_config` 37 — all passing. Bindings regenerate with no drift; both tsconfigs typecheck.

## Not done

No ADR. This turns "nothing is truncated, drop instead" into "shorten first, then drop", and splits a field that ADR 0050 leaned on — the reasoning is currently only in the code comments. Happy to write it up if that is wanted.
