### PR TITLE
fix(release): attach the assets before publishing to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,20 @@ jobs:
           (cd dist && shasum -a 256 "$name.tar.gz" > "$name.tar.gz.sha256")
           echo "asset=dist/$name.tar.gz" >> "$GITHUB_OUTPUT"
 
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          files: |
+            ${{ steps.package.outputs.asset }}
+            ${{ steps.package.outputs.asset }}.sha256
+
+      # Gated, because a trusted publisher cannot be attached to a package that does not exist, so
+      # the very first release necessarily runs before there is one. Unset, this skips loudly
+      # instead of failing the job red for a reason that is expected — and the assets are already
+      # attached by the step above either way. Set it with:
+      #   gh variable set NPM_TRUSTED_PUBLISHING --body true
       - name: Publish the npm platform package
+        if: vars.NPM_TRUSTED_PUBLISHING == 'true'
         run: |
           set -euo pipefail
           version=$(cargo metadata --format-version 1 --no-deps \
@@ -91,13 +104,6 @@ jobs:
           else
             (cd dist/npm && npm publish --access public --provenance)
           fi
-
-      - uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
-          files: |
-            ${{ steps.package.outputs.asset }}
-            ${{ steps.package.outputs.asset }}.sha256
 
   # The launcher goes up only once every binary it points at is on npm. Its `optionalDependencies`
   # name all four by exact version, and npm resolves them at install time rather than at publish
@@ -122,7 +128,15 @@ jobs:
 
       - run: npm install -g npm@latest
 
+      - name: Say so when npm publishing is skipped
+        if: vars.NPM_TRUSTED_PUBLISHING != 'true'
+        run: |
+          echo "::warning::NPM_TRUSTED_PUBLISHING is not set — nothing was published to npm."
+          echo "Configure trusted publishers for 'neosh' and the four '@neosh/cli-*' packages,"
+          echo "then: gh variable set NPM_TRUSTED_PUBLISHING --body true"
+
       - name: Publish neosh
+        if: vars.NPM_TRUSTED_PUBLISHING == 'true'
         run: |
           set -euo pipefail
           version=$(node -p "require('./npm/neosh/package.json').version")

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -144,7 +144,20 @@ four binaries onto the release, four `@neosh/cli-*` packages onto npm, and then 
 launcher once all four are up. That is the same property that lets you re-run a release which died
 halfway through.
 
-### 8. Write the Homebrew formula
+### 8. Let the workflows publish to npm from now on
+
+The first release necessarily ran before its trusted publishers existed, so `release.yml` skipped
+npm and the five binary packages went up by hand. Once the trusted publishers in step 5 are in
+place, turn the workflow's half on:
+
+```sh
+gh variable set NPM_TRUSTED_PUBLISHING --body true
+```
+
+Unset, `release.yml` still builds and attaches the binaries — it just says in the log that it
+published nothing to npm, rather than failing red for a reason that was expected.
+
+### 9. Write the Homebrew formula
 
 Only once the release has finished building, because the checksums come out of it:
 


### PR DESCRIPTION
The npm publish step ran *before* `softprops/action-gh-release`, so a failure publishing to npm meant the release got no binaries at all — and the first release is guaranteed to hit exactly that, since npm will not attach a trusted publisher to a package that does not exist yet.

Assets first now. The tarballs are the release; the npm package is a convenience built from the same binary.

The npm half is gated on a repo variable `NPM_TRUSTED_PUBLISHING` so the run that is *expected* to skip says so in the log rather than going red for a reason nobody needs to investigate. `docs/releasing.md` gains the step that turns it on.