### PR TITLE
fix(release): one unpublishable package must not stop the rest

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -34,7 +34,13 @@ jobs:
 
       - name: Publish what npm does not have yet
         run: |
-          set -euo pipefail
+          # Not `set -e`: one package failing must not take the rest with it. The loop is
+          # alphabetical, so when `@neosh/update` was added and could not be published — a name npm
+          # has never seen has no trusted publisher, and OIDC cannot do a first publish — it also
+          # stopped `@neosh/usage`, which had nothing wrong with it and sat a version behind.
+          # Failures are collected and reported at the end instead.
+          set -uo pipefail
+          failed=""
           # `npm/neosh` is not in this list on purpose: the launcher's optional dependencies are
           # the four binaries, so it goes up in release.yml after they do. Publishing it here would
           # put a launcher on npm before there was anything for it to launch.
@@ -47,5 +53,16 @@ jobs:
               continue
             fi
             echo "publish $name@$version"
-            (cd "$dir" && npm publish --access public --provenance)
+            if ! (cd "$dir" && npm publish --access public --provenance); then
+              # A name npm has never seen is the expected case here, and it is a person's job:
+              # publish it once by hand, then add its trusted publisher. Everything else carries on.
+              echo "::warning::$name@$version was not published"
+              failed="$failed $name"
+            fi
           done
+          if [ -n "$failed" ]; then
+            echo "::error::not published:$failed"
+            echo "A package npm has never seen cannot be published by OIDC. Publish it once by"
+            echo "hand, then: npm trust github <name> --file publish-npm.yml --repo neoswarm/neosh"
+            exit 1
+          fi

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -196,8 +196,18 @@ safe to re-run a half-failed release.
 Then regenerate the Homebrew formula, as in step 8 — a release nobody points Homebrew at is a
 release `brew upgrade` cannot see.
 
-A new crate or a new bundled plugin needs its own first manual publish and its own trusted
-publisher, exactly as above. Nothing else does.
+**A new crate or a new bundled plugin needs its own first manual publish and its own trusted
+publisher**, exactly as in steps 3–5. Nothing else does — and this is the one part of a release that
+bites, because the need for it only appears when the workflow fails:
+
+```sh
+(cd plugins/builtin/<name> && npm publish --access public)
+npm trust github "@neosh/<name>" --file publish-npm.yml --repo neoswarm/neosh --allow-publish
+```
+
+`publish-npm.yml` carries on past one that fails and reports the names at the end, so the rest of a
+release still goes out — a name npm has never seen used to stop every package alphabetically after
+it, which is how `@neosh/usage` sat a version behind `@neosh/update`.
 
 ---
 


### PR DESCRIPTION
`@neosh/update` is a name npm had never seen, and OIDC cannot do a first publish — expected, and a person's job. What was **not** expected is that it also stopped `@neosh/usage`, which had nothing wrong with it: the loop is alphabetical and `set -e` ended it there.

So v0.2.0 went out with `@neosh/usage` still at 0.1.0 until I published it by hand, and the workflow's own comment claiming it is safe to re-run was false.

Failures are collected and reported at the end now, with the two commands that fix them. The step still goes red — a package that did not publish is a release that is not finished — but everything publishable publishes. `docs/releasing.md` gains the runbook entry, since the need for it only ever appears when the workflow fails.