### PR TITLE
fix(release): one name per local, or set -u eats the formula generator

### DIFF
--- a/scripts/brew-formula.sh
+++ b/scripts/brew-formula.sh
@@ -22,7 +22,11 @@ repo="neoswarm/neosh"
 base="https://github.com/$repo/releases/download/$tag"
 
 sha_for() {
-  local target="$1" url="$base/neosh-$target.tar.gz.sha256"
+  # One name per `local`: bash creates every name in a `local` declaration before it assigns any of
+  # them, so `local a="$1" b="$a"` expands `$a` as the *new, unset* local — which under `set -u` is
+  # an error rather than the outer value somebody expected.
+  local target="$1"
+  local url="$base/neosh-$target.tar.gz.sha256"
   local line
   # The file is `<sha256>  <filename>`, which is what `shasum -a 256` writes.
   line=$(curl -fsSL "$url") || {


### PR DESCRIPTION
`local target="$1" url="...$target..."` — bash creates every name in a `local` declaration before it assigns any of them, so `$target` expanded to the *new, unset* local rather than the argument. Under `set -u` that is 'unbound variable', and the generator failed on its first real use with all eight release assets present and correct.

Split onto separate lines, with the reason written down.

Verified end to end after the fix: formula generated with the four real checksums, pushed to the tap, `brew install neoswarm/tap/neosh` installs 0.2.0 and `neosh --version` agrees.