### PR TITLE
fix(swarm): every computer was called neosh, and half a pairing said "connecting…"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,18 @@ is `docs/releasing.md`.
   `config.toml`, and a `[[swarm.peers]]` entry written by hand is not the UI's to remove. A dialler
   does not announce a connection until the peer has sent it something: it sends the last message of
   the handshake and cannot tell whether the far end approved, so announcing there says "joined" and
-  then "lost" every time pairing is half done.
+  then "lost" every time pairing is half done. **And half done is a state with a name on it**, not
+  a dial that failed: `LinkState::Waiting`, out of `SwarmEvent::Unapproved`, carrying the
+  `NodeInfo` the handshake did get. Reported as a `DialFailed` with attempt 0 it rendered as
+  `connecting…` — the one row with something actionable in it drawn as the one row with nothing to
+  say — so adding a computer looked like a wrong address for as long as anybody watched. It does
+  not spin, either: a spinner means *this* machine is working on it, and what this is waiting for
+  is a person at the other end. **What a machine is called is a decision too.** A hostname is
+  chosen by whoever set the box up and is `Mac` on both of them; `swarm.rename` is an SSH `Host`
+  alias, kept beside the pairing in `$STATE`, substituted once where `SwarmNode` is built so every
+  panel agrees, and never overwritten by the handshake that refreshes everything else. And the
+  hostname it falls back to is asked of the *OS*: `HOSTNAME` is unexported under bash and unset
+  under zsh, so reading only the environment named every machine in the swarm `neosh`.
 - **An agent belongs to the machine it was started on.** ASCP moves *descriptions* of agents and
   *requests* to their owners, never the agent: its files, shell and credentials are there, and a
   conversation that could migrate is one whose `cwd` means something else afterwards. The owner may
@@ -627,7 +638,7 @@ only way to do anything.
 | `^E` | Everything this model can be told, on one panel: effort, thinking, fast mode, context, and whatever a driver invented. `h`/`l` along a row, `j`/`k` between them, arrows too, and it applies as you move. Nothing else reaches the keyboard while it is open; `^E` again closes it |
 | `⇧⇥` | Permission mode — full access to start with, then ask, allow-listed, deny. Belongs to this conversation, saved with it, and takes effect on the turn that is running |
 | `^T` | Projects and conversations. Switching is never refused — turns keep running where they are |
-| `^J` | The computers in this workspace. Add one by its address, allow one that is asking, or open what it is running |
+| `^J` | The computers in this workspace. Add one by its address, allow one that is asking, rename one (`^E`), or open what it is running. A machine this one has reached that has not allowed it back says so, and says which key to press over there |
 | `^F` | What you have archived — see below. Filter it, put some back, or finally empty it |
 | `^N` | New conversation. In a repository it asks where: here, a worktree you need not name, one kept inside the project, one you do name, an existing one, another machine, elsewhere. A worktree you did not name is named by your first message — `fix/composer-paste-truncation`, not `wily-nimbus` |
 | `^O` | Add a project |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,6 +1660,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
+
+[[package]]
 name = "hstr"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2368,6 +2379,7 @@ dependencies = [
  "crossterm",
  "directories",
  "futures",
+ "hostname",
  "image",
  "insta",
  "neosh-agent",

--- a/crates/neosh-core/src/editor.rs
+++ b/crates/neosh-core/src/editor.rs
@@ -397,6 +397,7 @@ impl Editor {
                 | ApiCall::SwarmProbe { .. }
                 | ApiCall::SwarmPair { .. }
                 | ApiCall::SwarmUnpair { .. }
+                | ApiCall::SwarmRename { .. }
                 | ApiCall::SwarmReconnect { .. }
                 | ApiCall::SwarmDisconnect { .. }
                 | ApiCall::SwarmStrangers

--- a/crates/neosh-proto/src/api.rs
+++ b/crates/neosh-proto/src/api.rs
@@ -170,11 +170,11 @@ pub struct Contribution {
 
 /// How the connection to a peer stands, beyond the fact of it being up or not.
 ///
-/// `up` is the summary and this is the story, because "not connected" is three different rows on a
+/// `up` is the summary and this is the story, because "not connected" is four different rows on a
 /// board: a machine being dialled that has never answered, one that was here and is being dialled
-/// again, and one nothing is dialling at all — it reached us last time, or it was told to stop.
-/// `attempt` counts dials since the last success, so a panel can say `try 4` instead of drawing a
-/// spinner that has been spinning since Tuesday.
+/// again, one nothing is dialling at all — it reached us last time, or it was told to stop — and
+/// one that answered and is waiting on a person. `attempt` counts dials since the last success, so
+/// a panel can say `try 4` instead of drawing a spinner that has been spinning since Tuesday.
 #[derive(TS, Serialize, Deserialize, Clone, PartialEq, Debug)]
 #[ts(export)]
 #[serde(tag = "state", rename_all = "snake_case")]
@@ -182,6 +182,19 @@ pub enum LinkState {
     /// Being dialled, never yet answered.
     Connecting { attempt: u32 },
     Up,
+    /// Reached, proved who we are, and that machine has not allowed this one yet.
+    ///
+    /// The far half of pairing, and its own state rather than a flavour of `Connecting`, because
+    /// the two are answered by different people. `Connecting` is the network's problem and gets a
+    /// spinner; this is a key somebody has to press on the *other* machine, and a spinner over it
+    /// is a promise nothing on this one is keeping. It is also the state pairing spends most of
+    /// its life in — you add a computer here, then walk over there — so a board that draws it as
+    /// "connecting…" is a board that never explains the only step left.
+    ///
+    /// Reached by the *dialler* only: the handshake sends this machine's proof last and the far
+    /// end simply stops talking to a machine it has not been told about, so "it went quiet after
+    /// the handshake" and "it has not allowed me" are the same observation.
+    Waiting,
     /// Was up, lost, and being dialled again — with backoff, so the count moves slower over time.
     Retrying { attempt: u32 },
     /// Nobody is dialling it: it dialled us last time, or a disconnect said to stop.
@@ -1131,6 +1144,21 @@ pub enum ApiCall {
     /// Withdraw authorisation, and stop dialling.
     SwarmUnpair {
         node: NodeId,
+    },
+    /// What *you* call a machine, overriding the name it announces.
+    ///
+    /// An SSH `Host` alias, and it exists for the same reason: a hostname is chosen by whoever set
+    /// the machine up, is often the same on every machine somebody owns, and is not what its owner
+    /// calls it. The announced name is a fallback rather than the truth — this is the truth.
+    ///
+    /// `None` gives the announced name back, so a rename is undoable without remembering what the
+    /// machine was called. Refused for a peer declared in `config.toml`, whose name is that file's
+    /// to change: an alias stored here would be shadowed by the config on the next reload, and a
+    /// rename that silently reverts is worse than one that says where to make it.
+    SwarmRename {
+        node: NodeId,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
     },
     /// Dial a down peer again now, rather than waiting out the retry delay.
     SwarmReconnect {

--- a/crates/neosh-swarm/src/allow.rs
+++ b/crates/neosh-swarm/src/allow.rs
@@ -24,6 +24,15 @@ pub struct Peer {
     /// What to call it until it says its own name.
     #[serde(default)]
     pub name: String,
+    /// What *this* machine's user calls it, whatever it calls itself.
+    ///
+    /// Separate from `name` rather than overwriting it, because the two answer different
+    /// questions: `name` is the best guess available before the machine has spoken, and this is a
+    /// decision somebody made. Keeping them apart is what lets a rename be undone — clearing this
+    /// gives the announced name back — and what stops a handshake, which refreshes `name`, from
+    /// quietly reverting a choice.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
     /// `host:port`, when we know where to find it.
     ///
     /// Absent for a machine that dialled *us* and was approved: it knows where we are, and the
@@ -126,6 +135,39 @@ impl Allowed {
         Ok(removed)
     }
 
+    /// Give a machine the name this user calls it, or `None` to go back to the one it announces.
+    ///
+    /// Answers whether there was a peer to rename. Refused for a config-declared one for the same
+    /// reason [`Allowed::remove`] is: only paired peers are written to the state file, so an alias
+    /// set here would survive until the next reload and then silently revert — and the config's
+    /// `name` field is one line away.
+    pub fn rename(&self, id: &NodeId, alias: Option<String>) -> Result<bool, SwarmError> {
+        let renamed = {
+            let Ok(mut m) = self.inner.write() else { return Ok(false) };
+            match m.get_mut(id) {
+                Some(p) if p.source == Source::Config => {
+                    return Err(SwarmError::Protocol(
+                        "that machine is in your config file; change the `name` on its \
+                         `[[swarm.peers]]` entry"
+                            .into(),
+                    ));
+                }
+                Some(p) => {
+                    // An empty string is somebody clearing the field rather than choosing to call
+                    // a machine nothing, and a row with no name is one you cannot pick out of a
+                    // list. Both spellings of "undo this" arrive here.
+                    p.alias = alias.filter(|a| !a.trim().is_empty()).map(|a| a.trim().to_string());
+                    true
+                }
+                None => false,
+            }
+        };
+        if renamed {
+            self.save();
+        }
+        Ok(renamed)
+    }
+
     /// Only the paired ones are written. Config peers belong to the config, and writing them here
     /// would mean a machine removed from `config.toml` staying authorised for ever.
     fn save(&self) {
@@ -154,7 +196,7 @@ mod tests {
     use super::*;
 
     fn paired(name: &str) -> Peer {
-        Peer { name: name.into(), addr: None, source: Source::Paired }
+        Peer { name: name.into(), alias: None, addr: None, source: Source::Paired }
     }
 
     #[test]
@@ -185,7 +227,7 @@ mod tests {
     fn a_config_peer_cannot_be_removed_from_the_ui() {
         let a = Allowed::load(None);
         let id = NodeId("cc".into());
-        a.add(id.clone(), Peer { name: "declared".into(), addr: None, source: Source::Config });
+        a.add(id.clone(), Peer { name: "declared".into(), alias: None, addr: None, source: Source::Config });
         let err = a.remove(&id).expect_err("refused");
         assert!(format!("{err}").contains("config"), "and says where to go instead: {err}");
         assert!(a.accepts(&id), "and it is still authorised");
@@ -201,7 +243,7 @@ mod tests {
         a.add(NodeId("aa".into()), paired("kept"));
         a.add(
             NodeId("bb".into()),
-            Peer { name: "declared".into(), addr: None, source: Source::Config },
+            Peer { name: "declared".into(), alias: None, addr: None, source: Source::Config },
         );
 
         let fresh = Allowed::load(Some(&dir));
@@ -211,5 +253,57 @@ mod tests {
             "a config peer is the config's to re-declare, not ours to cache"
         );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// What you call a machine is a decision, so it is written down and it is undoable.
+    #[test]
+    fn a_rename_is_remembered_across_a_restart_and_clearing_it_gives_the_hostname_back() {
+        let dir = std::env::temp_dir().join(format!("neosh-alias-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("dir");
+
+        let a = Allowed::load(Some(&dir));
+        let id = NodeId("aa".into());
+        a.add(id.clone(), paired("Mac"));
+        assert!(a.rename(&id, Some("  the loud one ".into())).expect("allowed"));
+
+        let fresh = Allowed::load(Some(&dir));
+        assert_eq!(
+            fresh.get(&id).expect("peer").alias.as_deref(),
+            Some("the loud one"),
+            "trimmed on the way in, so the file holds what a list would draw"
+        );
+        assert_eq!(
+            fresh.get(&id).expect("peer").name,
+            "Mac",
+            "the announced name is kept beside it — this is an alias, not an overwrite"
+        );
+
+        // Both spellings of undo. An empty field is what somebody who cleared the prompt sends.
+        assert!(fresh.rename(&id, Some("   ".into())).expect("allowed"));
+        assert_eq!(Allowed::load(Some(&dir)).get(&id).expect("peer").alias, None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Renaming a config peer is refused for the same reason removing one is: only paired peers
+    /// are written to the state file, so the alias would last exactly until the next reload.
+    #[test]
+    fn a_config_peer_cannot_be_renamed_from_the_ui() {
+        let a = Allowed::load(None);
+        let id = NodeId("cc".into());
+        a.add(
+            id.clone(),
+            Peer { name: "declared".into(), alias: None, addr: None, source: Source::Config },
+        );
+        let err = a.rename(&id, Some("mine".into())).expect_err("refused");
+        assert!(format!("{err}").contains("name"), "and names the field to change: {err}");
+        assert_eq!(a.get(&id).expect("peer").alias, None);
+    }
+
+    /// A machine nobody has heard of is not renamed into existence.
+    #[test]
+    fn renaming_an_unknown_machine_reports_that_there_was_nothing_to_rename() {
+        let a = Allowed::load(None);
+        assert!(!a.rename(&NodeId("zz".into()), Some("ghost".into())).expect("no error"));
     }
 }

--- a/crates/neosh-swarm/src/node.rs
+++ b/crates/neosh-swarm/src/node.rs
@@ -117,6 +117,19 @@ pub enum SwarmEvent {
     /// A dial did not produce a connection. `attempt` counts since the last success, so a board
     /// can say `try 4`; `node` is absent for an address whose machine we have never identified.
     DialFailed { node: Option<NodeId>, addr: String, attempt: u32, error: String },
+    /// Reached a machine we have authorised, and it has not authorised us back.
+    ///
+    /// Pairing is a decision each machine makes, so this is the ordinary state between the two
+    /// halves rather than an error — and it is the one a board most needs to name, because the
+    /// only thing that ends it is somebody pressing a key on the *other* machine. Reported as its
+    /// own event rather than as a [`SwarmEvent::DialFailed`] with a distinctive sentence in it: a
+    /// board that has to match on an error string to draw the right row is one sentence rewrite
+    /// away from drawing the wrong one.
+    ///
+    /// Carries the full [`NodeInfo`] because the handshake got that far. A row that has only ever
+    /// been half-paired can therefore still say what the machine is actually called, what it is
+    /// running and what it offers — all of which arrived before it stopped talking to us.
+    Unapproved { node: NodeInfo, capabilities: NodeCapabilities, addr: String },
     Inventory { node: NodeId, full: bool, agents: Vec<AgentSummary>, gone: Vec<SessionId> },
     Stream { node: NodeId, session: SessionId, event: StreamEvent },
     /// A peer asked us to do something. The host must answer with [`SwarmRequest::Answer`].
@@ -326,8 +339,14 @@ async fn run(
                     SwarmRequest::Projects { projects } => caps.projects = projects,
                     SwarmRequest::Pair { id, name, addr } => {
                         paused.remove(&id);
+                        // Re-pairing keeps whatever this user decided to call it. Unpair is how
+                        // you forget a machine; adding one back after a network moved is not, and
+                        // having it revert to its hostname would make the rename feel unreliable
+                        // in exactly the case somebody renamed it for.
+                        let alias = allowed.get(&id).and_then(|p| p.alias);
                         allowed.add(id.clone(), crate::allow::Peer {
                             name,
+                            alias,
                             addr: addr.clone(),
                             source: crate::allow::Source::Paired,
                         });
@@ -687,8 +706,10 @@ async fn keep_dialled(
     enum Outcome {
         /// Connected, accepted, and served until it ended.
         Served,
-        /// Reached the machine, and it has not allowed this one (yet).
-        Refused,
+        /// Reached the machine, and it has not allowed this one (yet). Carries what the handshake
+        /// learned, because that is everything a board needs to draw the row properly and it is
+        /// about to be the only thing we ever hear from this machine.
+        Refused(Box<(NodeInfo, NodeCapabilities)>),
         /// Reached a machine we have not paired with. What "add a computer" is waiting for.
         Stranger,
         Failed(String),
@@ -717,11 +738,16 @@ async fn keep_dialled(
                             "another machine answered ({})",
                             found.node.id.short()
                         ))
-                    } else if serve(stream, found, wire.clone(), true, Some(peer.addr.clone())).await
-                    {
-                        Outcome::Served
                     } else {
-                        Outcome::Refused
+                        // Kept before `serve` takes it: whether this connection was ever announced
+                        // is only known afterwards, and by then the one thing that would let a
+                        // board explain the answer is gone.
+                        let seen = (found.node.clone(), found.capabilities.clone());
+                        if serve(stream, found, wire.clone(), true, Some(peer.addr.clone())).await {
+                            Outcome::Served
+                        } else {
+                            Outcome::Refused(Box::new(seen))
+                        }
                     }
                 }
                 Err(crate::SwarmError::Stranger(s)) => {
@@ -747,16 +773,17 @@ async fn keep_dialled(
                 Duration::from_secs(1)
             }
             // The machine is *there*, so backing off would only slow down the pairing it is
-            // probably in the middle of; the flat heartbeat is the pace. Refused is still worth a
-            // row on the board — "it has not allowed this machine" names the key to press, over
-            // there, where a person is presumably sitting.
-            Outcome::Refused => {
+            // probably in the middle of; the flat heartbeat is the pace. That also means the row
+            // flips to connected within one heartbeat of somebody saying yes over there, which is
+            // what makes the second half of pairing feel like it worked rather than like it needs
+            // a restart.
+            Outcome::Refused(seen) => {
                 attempt = 0;
-                let _ = events.send(SwarmEvent::DialFailed {
-                    node: peer.expect.clone(),
+                let (node, capabilities) = *seen;
+                let _ = events.send(SwarmEvent::Unapproved {
+                    node,
+                    capabilities,
                     addr: peer.addr.clone(),
-                    attempt: 0,
-                    error: "reached it — it has not allowed this machine yet".into(),
                 });
                 every
             }

--- a/crates/neosh-swarm/tests/handshake.rs
+++ b/crates/neosh-swarm/tests/handshake.rs
@@ -26,7 +26,7 @@ fn caps() -> NodeCapabilities {
 /// Run one handshake between two identities and give back both sides' verdicts.
 fn allow(who: &Identity, name: &str) -> AllowedPeer {
     let _ = who;
-    AllowedPeer { name: name.into(), addr: None, source: Source::Paired }
+    AllowedPeer { name: name.into(), alias: None, addr: None, source: Source::Paired }
 }
 
 async fn introduce(

--- a/crates/neosh-swarm/tests/swarm.rs
+++ b/crates/neosh-swarm/tests/swarm.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedReceiver;
 const PATIENCE: Duration = Duration::from_secs(10);
 
 fn known(name: &str) -> AllowedPeer {
-    AllowedPeer { name: name.into(), addr: None, source: Source::Paired }
+    AllowedPeer { name: name.into(), alias: None, addr: None, source: Source::Paired }
 }
 
 fn summary(id: &str, project: &str) -> AgentSummary {
@@ -607,6 +607,83 @@ async fn two_strangers_can_be_introduced_while_they_are_running() {
     })
     .await;
     assert_eq!(seen, 1);
+}
+
+/// Half a pairing says which half is missing, rather than dialling in silence for ever.
+///
+/// This is the state a person is actually in for the minute between adding a computer here and
+/// walking over to allow this one there — and it used to be indistinguishable from a wrong
+/// address. The dialler completes the handshake, sends its proof last, and the far end simply
+/// stops talking to a machine it has not been told about; reported as a dial *failure*, that
+/// became `connecting…` with no reason attached, for as long as anybody was willing to watch.
+#[tokio::test]
+async fn a_machine_that_has_not_allowed_us_back_says_so_rather_than_dialling_in_silence() {
+    let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("probe");
+    let addr: SocketAddr = probe.local_addr().expect("addr");
+    drop(probe);
+
+    let a_id = Identity::ephemeral();
+    let b_id = Identity::ephemeral();
+    let (a_key, b_key) = (a_id.id().clone(), b_id.id().clone());
+
+    // A has added B — the first half of pairing, done. B has never heard of A.
+    let (aa, ba) = (Allowed::load(None), Allowed::load(None));
+    aa.add(b_key.clone(), known("the address you typed"));
+
+    let (b, mut b_rx) = neosh_swarm::node::spawn(
+        Arc::new(b_id),
+        ba,
+        SwarmConfig {
+            name: "linux-box".into(),
+            listen: Some(addr),
+            heartbeat: Duration::from_millis(150),
+            ..Default::default()
+        },
+        "0.1.0".into(),
+    );
+    let (_a, mut a_rx) = neosh_swarm::node::spawn(
+        Arc::new(a_id),
+        aa,
+        SwarmConfig {
+            name: "mac-studio".into(),
+            peers: vec![PeerAddress { addr: addr.to_string(), expect: Some(b_key.clone()) }],
+            heartbeat: Duration::from_millis(150),
+            ..Default::default()
+        },
+        "0.1.0".into(),
+    );
+
+    // Not `DialFailed`: nothing failed. The machine is there, it is the right machine, and it has
+    // said its name — all of which the row can now show while it waits on a person.
+    let waiting = wait_for(&mut a_rx, |e| match e {
+        SwarmEvent::Unapproved { node, .. } => Some(node.clone()),
+        _ => None,
+    })
+    .await;
+    assert_eq!(waiting.id, b_key, "and it is the machine we meant to reach");
+    assert_eq!(
+        waiting.name, "linux-box",
+        "the handshake got far enough to learn what it is really called, so the row stops \
+         repeating the address somebody typed"
+    );
+
+    // Over there, the other half of the same moment: somebody is asking.
+    let asking = wait_for(&mut b_rx, |e| match e {
+        SwarmEvent::Stranger { node, dialled: false } => Some(node.id.clone()),
+        _ => None,
+    })
+    .await;
+    assert_eq!(asking, a_key);
+
+    // The person walks over and presses the key. Nothing happens on A — the dialler is already
+    // retrying at the heartbeat, which is what makes the row turn over on its own.
+    b.send(SwarmRequest::Pair { id: a_key, name: "mac-studio".into(), addr: None });
+    let up = wait_for(&mut a_rx, |e| match e {
+        SwarmEvent::PeerUp { node, .. } => Some(node.name.clone()),
+        _ => None,
+    })
+    .await;
+    assert_eq!(up, "linux-box");
 }
 
 /// Unpairing stops the reconnecting, which is the half that is easy to forget.

--- a/crates/neosh-tui/src/terminal.rs
+++ b/crates/neosh-tui/src/terminal.rs
@@ -93,7 +93,6 @@ pub fn to_input_event(ev: Event) -> Option<InputEvent> {
         // see `InputEvent::Focus`.
         Event::FocusGained => Some(InputEvent::Focus { on: true }),
         Event::FocusLost => Some(InputEvent::Focus { on: false }),
-        _ => None,
     }
 }
 

--- a/crates/neosh/Cargo.toml
+++ b/crates/neosh/Cargo.toml
@@ -46,6 +46,7 @@ base64 = { workspace = true }
 image = { workspace = true }
 uuid = { workspace = true }
 tokio-stream = { workspace = true }
+hostname = "0.4"
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -1716,7 +1716,14 @@ impl Host {
                     .swarm
                     .peers()
                     .map(|p| neosh_proto::SwarmNode {
-                        info: p.info.clone(),
+                        // The name a plugin sees is the name the *user* gave it, with the
+                        // announced one behind it. Substituted here, once, rather than left for
+                        // every panel to remember: a rename that only the computers panel honoured
+                        // would be a machine with two names on one screen.
+                        info: neosh_proto::NodeInfo {
+                            name: p.display_name(),
+                            ..p.info.clone()
+                        },
                         capabilities: p.capabilities.clone(),
                         up: p.up(),
                         link: p.link.clone(),
@@ -1841,6 +1848,25 @@ impl Host {
                 }
                 h.send(neosh_swarm::SwarmRequest::Unpair { id: node });
                 self.bridge.broadcast(PluginEvent::SwarmChanged);
+                Ok(ApiOk::Unit)
+            }
+            ApiCall::SwarmRename { node, name } => {
+                if self.swarm_node.is_none() {
+                    return Err(ApiError::NotFound { what: "the swarm is not running".into() });
+                }
+                // The store is the record and the board is the picture. Written first, so a rename
+                // that the config refuses never reaches the screen at all.
+                let renamed = self
+                    .swarm_allowed
+                    .rename(&node, name.clone())
+                    .map_err(|e| ApiError::Denied { reason: e.to_string() })?;
+                if !renamed {
+                    return Err(ApiError::NotFound { what: format!("no such machine: {}", node.short()) });
+                }
+                self.swarm.set_alias(&node, name);
+                let now = self.swarm.peer(&node).map(|p| p.display_name()).unwrap_or_default();
+                self.bridge.broadcast(PluginEvent::SwarmChanged);
+                self.editor_message(MessageLevel::Info, format!("that computer is now {now}"));
                 Ok(ApiOk::Unit)
             }
             ApiCall::SwarmReconnect { node } => {
@@ -3243,6 +3269,9 @@ impl Host {
             // A row on the board from the first frame, so a machine being dialled reads as
             // "connecting" rather than as a silence to explain.
             self.swarm.seed(id.clone(), p.name.clone(), p.addr.is_some());
+            // And under the name this user gave it, from that same first frame: a rename that only
+            // takes effect once the machine has answered is one that looks lost across a restart.
+            self.swarm.set_alias(&id, p.alias.clone());
             if let Some(addr) = p.addr {
                 peers.push(neosh_swarm::PeerAddress { addr, expect: Some(id) });
             }
@@ -3254,6 +3283,10 @@ impl Host {
                     let id = neosh_proto::NodeId(id.clone());
                     allowed.add(id.clone(), neosh_swarm::AllowedPeer {
                         name: name.clone(),
+                        // A config peer's name is the config's to set, which is also why
+                        // `swarm.rename` refuses one: this file is reloaded and an alias stored
+                        // beside it would be a rename that lasts until `^R`.
+                        alias: None,
                         addr: Some(p.addr.clone()),
                         source: neosh_swarm::Source::Config,
                     });
@@ -3603,6 +3636,30 @@ impl Host {
                     self.swarm.dial_failed(&id, attempt, error);
                     self.bridge.broadcast(PluginEvent::SwarmChanged);
                 }
+            }
+            E::Unapproved { node, capabilities, .. } => {
+                // Said once per machine, not once per dial. The dialler retries at the heartbeat
+                // for as long as pairing stays half-done — which can be the whole time somebody
+                // walks to the other computer — and a notification every ten seconds about a state
+                // that has not changed is the definition of noise. The panel row is the standing
+                // record; this is the nudge that sends you to it.
+                let first = !matches!(
+                    self.swarm.peer(&node.id).map(|p| p.link.clone()),
+                    Some(neosh_proto::LinkState::Waiting)
+                );
+                self.swarm.unapproved(node.clone(), capabilities);
+                if first {
+                    let name = self
+                        .swarm
+                        .peer(&node.id)
+                        .map(|p| p.display_name())
+                        .unwrap_or_else(|| node.name.clone());
+                    self.editor_message(
+                        MessageLevel::Info,
+                        format!("{name} has not allowed this computer yet — press ^J over there"),
+                    );
+                }
+                self.bridge.broadcast(PluginEvent::SwarmChanged);
             }
             E::Inventory { node, full, agents, gone } => {
                 self.swarm.inventory(&node, full, agents, gone);
@@ -11287,13 +11344,25 @@ fn refusal_text(r: &neosh_proto::Refusal) -> String {
 
 /// What to call this machine when nobody has said.
 ///
-/// The hostname, which is what a person would answer if asked which computer they were at. Read
-/// from the environment rather than a syscall: `HOSTNAME` and `COMPUTERNAME` cover unix shells and
-/// Windows, and "neosh" is a name rather than a failure for the case where neither is set.
+/// The hostname, which is what a person would answer if asked which computer they were at — and it
+/// is asked *of the operating system* rather than of the environment, which is the whole point of
+/// this function existing in this shape.
+///
+/// `HOSTNAME` is not an exported variable on any platform worth relying on. bash sets it and does
+/// not export it, zsh does not set it at all (it has `HOST`), and the workspace is a daemon that
+/// gets a thinner environment than any of them. So the environment answered "no" on every Mac and
+/// most Linux boxes, every node fell through to the literal fallback, and every machine in the
+/// swarm was called `neosh` — in a panel whose entire job is telling machines apart.
+///
+/// The environment is still consulted *first*, because a container that sets `HOSTNAME` to
+/// something meaningful is deliberately overriding a kernel hostname that is a random hex string.
 fn machine_name() -> String {
     std::env::var("HOSTNAME")
         .or_else(|_| std::env::var("COMPUTERNAME"))
         .ok()
+        .or_else(|| hostname::get().ok().map(|h| h.to_string_lossy().into_owned()))
+        // `mini.local`, `build.tail1234.ts.net` — the first label is the name, and the rest is the
+        // network's business. A row in a list has one line for this.
         .map(|h| h.split('.').next().unwrap_or(&h).to_string())
         .filter(|h| !h.is_empty())
         .unwrap_or_else(|| "neosh".to_string())

--- a/crates/neosh/src/main.rs
+++ b/crates/neosh/src/main.rs
@@ -604,10 +604,16 @@ fn run_swarm_id(paths: &Paths) -> anyhow::Result<()> {
 }
 
 /// What this computer is called, for the sample config above.
+///
+/// Asked of the OS rather than of the environment, for the reason spelled out on the host's copy:
+/// `HOSTNAME` is unexported on macOS and unset under zsh, so the environment alone answers "no"
+/// on most machines — and this one prints an `addr` somebody is about to paste into a config file
+/// on another computer.
 fn machine_name() -> String {
     std::env::var("HOSTNAME")
         .or_else(|_| std::env::var("COMPUTERNAME"))
         .ok()
+        .or_else(|| hostname::get().ok().map(|h| h.to_string_lossy().into_owned()))
         .map(|h| h.split('.').next().unwrap_or(&h).to_string())
         .filter(|h| !h.is_empty())
         .unwrap_or_else(|| "this-machine".to_string())

--- a/crates/neosh/src/swarm.rs
+++ b/crates/neosh/src/swarm.rs
@@ -31,6 +31,10 @@ pub struct Remote {
     ever_up: bool,
     /// Why it is not up, when it is not.
     pub reason: Option<String>,
+    /// What this user calls it, if they have said. Held beside `info` rather than written into it
+    /// because every handshake replaces `info` wholesale, and a name a person chose must not be
+    /// something a reconnect can undo.
+    pub alias: Option<String>,
 }
 
 impl Remote {
@@ -38,7 +42,25 @@ impl Remote {
         matches!(self.link, LinkState::Up)
     }
 
+    /// What to call this machine: the name its owner here gave it, else the one it announces.
+    ///
+    /// Falls back through to the id when a machine has neither, which happens for exactly one row
+    /// — a config peer with no `name`, before its first handshake — and is still better than a
+    /// blank label in a list you pick from.
+    pub fn display_name(&self) -> String {
+        self.alias
+            .clone()
+            .filter(|a| !a.is_empty())
+            .or_else(|| Some(self.info.name.clone()).filter(|n| !n.is_empty()))
+            .unwrap_or_else(|| self.info.id.short().to_string())
+    }
+
     /// The state a dial that did not produce a connection leaves the row in.
+    ///
+    /// Deliberately *not* sticky against [`LinkState::Waiting`]: this is only reached when a dial
+    /// actually failed, and a machine that was waiting on a person and has now stopped answering
+    /// its port has genuinely changed state. Being told to press a key on a computer that is
+    /// switched off is worse than being told nothing.
     fn not_up(&self, attempt: u32) -> LinkState {
         if self.ever_up {
             LinkState::Retrying { attempt }
@@ -77,7 +99,37 @@ impl Swarm {
             link: if dialled { LinkState::Connecting { attempt: 0 } } else { LinkState::Down },
             ever_up: false,
             reason: None,
+            alias: None,
         });
+    }
+
+    /// What this user calls a machine, applied to a row that may already exist.
+    ///
+    /// Separate from [`Swarm::seed`] because it is called for both — a peer being seeded at boot
+    /// and one renamed while the panel is open — and because `seed` deliberately does nothing to a
+    /// row that is already there, which is right for a link state and wrong for a name.
+    pub fn set_alias(&mut self, id: &NodeId, alias: Option<String>) {
+        if let Some(p) = self.peers.get_mut(id) {
+            p.alias = alias.filter(|a| !a.trim().is_empty()).map(|a| a.trim().to_string());
+        }
+    }
+
+    /// A machine we authorised, reached, and that has not authorised us back.
+    ///
+    /// Fills the row in from the handshake even though the connection went no further: name, OS,
+    /// version and what it offers all arrived, and a half-paired row that can say `mini · macOS ·
+    /// neosh 0.2.0` is one you can tell you dialled the right computer.
+    pub fn unapproved(&mut self, info: NodeInfo, capabilities: NodeCapabilities) {
+        let id = info.id.clone();
+        self.seed(id.clone(), info.name.clone(), true);
+        if let Some(p) = self.peers.get_mut(&id) {
+            p.info = info;
+            p.capabilities = capabilities;
+            p.link = LinkState::Waiting;
+            // The state is the whole story here, and a sentence beside it would be the same
+            // sentence twice. `reason` is for the things a state cannot say.
+            p.reason = None;
+        }
     }
 
     pub fn peer_up(&mut self, info: NodeInfo, capabilities: NodeCapabilities) {
@@ -88,7 +140,10 @@ impl Swarm {
             link: LinkState::Up,
             ever_up: true,
             reason: None,
+            alias: None,
         });
+        // `alias` is untouched on purpose: a handshake refreshes everything the machine says about
+        // itself, and what it is called here is not one of those things.
         entry.info = info;
         entry.capabilities = capabilities;
         entry.link = LinkState::Up;
@@ -388,6 +443,72 @@ mod tests {
         let aa = s.peer(&NodeId("aa".into())).expect("peer");
         assert!(aa.up(), "the connection the listener holds is the truth");
         assert_eq!(aa.reason, None);
+    }
+
+    /// The far half of pairing is its own row, and it says what it is waiting for.
+    ///
+    /// This is what "connecting…" for ever was: the dialler reached the machine, proved who it
+    /// was, and the far end — which has not been told about this one — simply stopped talking.
+    /// Reported as `DialFailed` with attempt 0, it landed on `Connecting { attempt: 0 }`, and the
+    /// panel's `attempt > 0` branch was the only one that printed the reason. So the single state
+    /// with something actionable in it was the single state that said nothing.
+    #[test]
+    fn a_machine_that_has_not_allowed_this_one_says_so_rather_than_connecting_for_ever() {
+        let mut s = Swarm::default();
+        s.seed(NodeId("aa".into()), "the address you typed".into(), true);
+
+        s.unapproved(node("aa", "mini"), caps());
+        let aa = s.peer(&NodeId("aa".into())).expect("peer");
+        assert_eq!(aa.link, LinkState::Waiting, "reached, and waiting on a person over there");
+        assert!(!aa.up(), "a handshake that got no further is not a connection");
+        assert_eq!(
+            aa.info.name, "mini",
+            "the handshake got far enough to learn the real name, so the row stops saying the \
+             address somebody typed"
+        );
+        assert_eq!(aa.reason, None, "the state is the whole story; a sentence would repeat it");
+
+        // Somebody presses the key over there. The dialler is still retrying at the heartbeat, so
+        // this arrives without anything happening on this machine.
+        s.peer_up(node("aa", "mini"), caps());
+        assert!(s.peer(&NodeId("aa".into())).expect("peer").up());
+    }
+
+    /// Waiting is not sticky: a machine that stops answering its port has genuinely changed state,
+    /// and telling somebody to go and press a key on a computer that is off is worse than silence.
+    #[test]
+    fn a_waiting_peer_that_goes_away_stops_saying_go_and_press_a_key() {
+        let mut s = Swarm::default();
+        s.seed(NodeId("aa".into()), "mini".into(), true);
+        s.unapproved(node("aa", "mini"), caps());
+        s.dial_failed(&NodeId("aa".into()), 2, "connection refused".into());
+        let aa = s.peer(&NodeId("aa".into())).expect("peer");
+        assert_eq!(aa.link, LinkState::Connecting { attempt: 2 });
+        assert_eq!(aa.reason.as_deref(), Some("connection refused"));
+    }
+
+    /// A name somebody chose outlives everything the machine says about itself.
+    #[test]
+    fn an_alias_wins_over_the_announced_name_and_survives_a_reconnect() {
+        let mut s = Swarm::default();
+        s.seed(NodeId("aa".into()), "Mac".into(), true);
+        assert_eq!(s.peer(&NodeId("aa".into())).expect("peer").display_name(), "Mac");
+
+        s.set_alias(&NodeId("aa".into()), Some("  the loud one  ".into()));
+        assert_eq!(
+            s.peer(&NodeId("aa".into())).expect("peer").display_name(),
+            "the loud one",
+            "trimmed, because a name with an accidental space is a name that sorts oddly"
+        );
+
+        // A handshake replaces everything the machine announces. It must not replace this.
+        s.peer_up(node("aa", "Mac"), caps());
+        assert_eq!(s.peer(&NodeId("aa".into())).expect("peer").display_name(), "the loud one");
+
+        // And clearing it gives the announced name back, so a rename is undoable without anybody
+        // having to remember what the machine used to be called.
+        s.set_alias(&NodeId("aa".into()), None);
+        assert_eq!(s.peer(&NodeId("aa".into())).expect("peer").display_name(), "Mac");
     }
 
     /// Seeding is idempotent and never clobbers a row that has learned anything.

--- a/crates/neosh/tests/approvals.rs
+++ b/crates/neosh/tests/approvals.rs
@@ -128,12 +128,6 @@ impl Session {
         stdin.flush().expect("flush");
     }
 
-    fn key(&mut self, c: &str) {
-        self.send(&format!(
-            r#"{{"type":"key","key":{{"code":{{"kind":"char","c":"{c}"}},"mods":{{}}}}}}"#
-        ));
-    }
-
     fn special(&mut self, kind: &str) {
         self.send(&format!(r#"{{"type":"key","key":{{"code":{{"kind":"{kind}"}},"mods":{{}}}}}}"#));
     }

--- a/crates/neosh/tests/questions.rs
+++ b/crates/neosh/tests/questions.rs
@@ -351,7 +351,7 @@ fn open(name: &str) -> Session {
 
 #[test]
 fn a_question_is_drawn_with_its_options_and_what_each_one_means() {
-    let mut s = open("draws");
+    let s = open("draws");
     assert!(s.saw("Database"), "the header names what it is about\n{}", s.transcript());
     assert!(s.saw("Postgres"), "{}", s.transcript());
     assert!(

--- a/docs/config.md
+++ b/docs/config.md
@@ -393,18 +393,39 @@ which happened: `listening on 0.0.0.0:7717`, `not listening`, or `dial-only`.
 #### What a connection is doing
 
 Every paired machine is a row in `^J` from the first frame, and the row says where the link
-stands: `connecting…` for one being dialled that has never answered — with a `try 4` once it has
-failed a few times, because a spinner that has been spinning since Tuesday is not a state —
-`reconnecting` for one that was here and dropped, `disconnected` for one nothing is dialling, and
-the conversation count for one that is up. Reconnects back off from a second up to half a minute
-and reset the moment a dial lands, so a machine that reboots is back in seconds.
+stands. The glyph is the state and the sentence is what to do about it:
 
-Two verbs on any row, and the list updates live while it is open:
+| Row | Means |
+|---|---|
+| `●` and a conversation count | Up |
+| a spinner, `connecting…` | Being dialled, never yet answered. `try 4` once it has failed a few times, because a spinner that has been spinning since Tuesday is not a state |
+| a spinner, `reconnecting` | Was here, dropped, being dialled again |
+| `◍ allow this computer on linux-box — ^J there` | Reached it, and **it has not allowed this machine yet**. The second half of pairing, waiting on a person at the other end |
+| `○ disconnected` | Nothing is dialling it — it dials in, or you pressed `^D` |
+
+The spinner only ever means *this* machine is working on it. A row waiting on somebody at the other
+end does not move, because nothing here is trying: it pulses, like every other thing in the
+workspace that is waiting for you.
+
+Reconnects back off from a second up to half a minute and reset the moment a dial lands, so a
+machine that reboots is back in seconds. A half-paired row retries at the flat heartbeat instead,
+which is what makes it turn over into a connection within seconds of somebody saying yes over there
+— no key, no restart.
+
+The verbs on a row, and the list updates live while it is open:
 
 | Key | Does |
 |---|---|
+| `^E` | Call it something else. An SSH `Host` alias: it wins over the name the machine announces, everywhere, and clearing the field gives the hostname back. Refused for a machine your `config.toml` declared, whose `name` is one line away |
 | `^R` | Dial it again now, rather than waiting out the retry delay |
 | `^D` | Disconnect: close the link and stop dialling, keeping the pairing. `^R` takes it back |
+| `^X` | Unpair: forget it altogether |
+| `^Y` | Copy this computer's own id |
+
+Renaming earns its key because a hostname is chosen by whoever set the machine up: two Macs out of
+the box are both `Mac`, and a list of machines that are all called the same thing is a list you
+cannot use. What you call one is written to the state directory beside the pairing, so it survives
+a restart and every panel agrees about it.
 
 Disconnect holds in both directions — a peer that dials in is turned away until you say otherwise
 — and lasts until a reconnect or a restart. Unpairing (`^X`) is the stronger verb, for a machine
@@ -430,6 +451,10 @@ showing if it came from the other end.
 Then the other machine says `mac-studio wants to join this workspace — ^J to allow it`, and somebody
 there says yes. Two confirmations, one per machine, because authorising a computer to steer your
 agents is a decision each side gets to make.
+
+Between the two, you are put back in `^J` with the new machine sitting on `allow this computer on
+linux-box — ^J there`. That is the panel to leave open while you walk over: the row turns into its
+conversation count on its own, within a heartbeat of the yes, with nothing to press here.
 
 Nothing is restarted and nothing is written to your `config.toml` — paired machines live in the
 state directory. `^X` in that list removes one.

--- a/plugins/api/package-lock.json
+++ b/plugins/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neosh/api",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neosh/api",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.0"

--- a/plugins/api/src/generated/ApiCall.ts
+++ b/plugins/api/src/generated/ApiCall.ts
@@ -366,6 +366,7 @@ export type ApiCall =
   | { "call": "swarm_probe"; addr: string }
   | { "call": "swarm_pair"; node: NodeId; name: string; addr?: string | null }
   | { "call": "swarm_unpair"; node: NodeId }
+  | { "call": "swarm_rename"; node: NodeId; name?: string | null }
   | { "call": "swarm_reconnect"; node: NodeId }
   | { "call": "swarm_disconnect"; node: NodeId }
   | { "call": "swarm_strangers" }

--- a/plugins/api/src/generated/LinkState.ts
+++ b/plugins/api/src/generated/LinkState.ts
@@ -3,14 +3,15 @@
 /**
  * How the connection to a peer stands, beyond the fact of it being up or not.
  *
- * `up` is the summary and this is the story, because "not connected" is three different rows on a
+ * `up` is the summary and this is the story, because "not connected" is four different rows on a
  * board: a machine being dialled that has never answered, one that was here and is being dialled
- * again, and one nothing is dialling at all — it reached us last time, or it was told to stop.
- * `attempt` counts dials since the last success, so a panel can say `try 4` instead of drawing a
- * spinner that has been spinning since Tuesday.
+ * again, one nothing is dialling at all — it reached us last time, or it was told to stop — and
+ * one that answered and is waiting on a person. `attempt` counts dials since the last success, so
+ * a panel can say `try 4` instead of drawing a spinner that has been spinning since Tuesday.
  */
 export type LinkState =
   | { "state": "connecting"; attempt: number }
   | { "state": "up" }
+  | { "state": "waiting" }
   | { "state": "retrying"; attempt: number }
   | { "state": "down" };

--- a/plugins/api/src/index.ts
+++ b/plugins/api/src/index.ts
@@ -1642,6 +1642,17 @@ export interface SwarmApi {
   /** Withdraw authorisation and stop connecting. Refuses for a machine your config declared. */
   unpair(node: NodeId): Promise<void>;
   /**
+   * Call a machine something else — an SSH `Host` alias, and for the same reasons.
+   *
+   * A hostname is chosen by whoever set the machine up, is often `Mac` or `ubuntu` on every box
+   * somebody owns, and is not what its owner calls it. This wins over the announced name
+   * everywhere a `SwarmNode` is read, so every panel agrees; `null` gives the announced name back.
+   *
+   * Refuses for a machine your `config.toml` declared, naming the `name` field to change instead —
+   * an alias stored beside a config peer would be reverted by the next reload.
+   */
+  rename(node: NodeId, name: string | null): Promise<void>;
+  /**
    * Dial a down peer again now, rather than waiting out its retry delay.
    *
    * Also what lifts a {@link disconnect}: for a peer that dials *this* machine, being willing to
@@ -2052,6 +2063,9 @@ function build(
       },
       async unpair(node) {
         await c({ call: "swarm_unpair", node });
+      },
+      async rename(node, name) {
+        await c({ call: "swarm_rename", node, name });
       },
       async reconnect(node) {
         await c({ call: "swarm_reconnect", node });

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -78,6 +78,7 @@ import {
   type PickerItem,
   prompt,
   pulseBright,
+  pulseHl,
   spinnerFrame,
 } from "@neosh/api/ui";
 
@@ -1968,6 +1969,7 @@ async function showNodes(neosh: Neosh): Promise<void> {
   const listening = await neosh.vars
     .get<{ addr: string | null; error?: string }>({ scope: "global" }, "swarm.listen")
     .catch(() => null);
+  const ascii = (await neosh.opt.get<boolean>("ui.ascii_only").catch(() => false)) ?? false;
 
   type Row =
     | { kind: "node"; node: SwarmNode }
@@ -1975,11 +1977,17 @@ async function showNodes(neosh: Neosh): Promise<void> {
     | { kind: "add" }
     | { kind: "self" };
 
-  const build = async (): Promise<PickerItem<Row>[]> => {
-    const [nodes, strangers] = await Promise.all([
-      neosh.swarm.nodes().catch(() => []),
-      neosh.swarm.strangers().catch(() => []),
-    ]);
+  // The last answer from the host, so a spinner frame costs a redraw rather than two round trips.
+  // At 80ms a tick, rebuilding these over the API would be the most talkative thing in the
+  // workspace, to animate one glyph.
+  let nodes: SwarmNode[] = [];
+  let strangers: SwarmStranger[] = [];
+
+  /** Whether anything on screen is mid-dial, and therefore whether the tick has any work. */
+  const spinning = () =>
+    nodes.some((n) => n.link.state === "connecting" || n.link.state === "retrying");
+
+  const build = (): PickerItem<Row>[] => {
     const rows: PickerItem<Row>[] = [];
 
     for (const s of strangers) {
@@ -1989,17 +1997,30 @@ async function showNodes(neosh: Neosh): Promise<void> {
           ? `found at ${s.addr ?? "an address you gave"}  ·  ${fingerprint(s.info.id)}  ·  ↵ to add`
           : `wants to join  ·  ${fingerprint(s.info.id)}  ·  ↵ to allow`,
         keywords: `${s.info.id} pending join pair new`,
+        // A machine asking to join is the one row here that wants answering, so it wears the
+        // colour the workspace already uses for *act now* and pulses on the same 1 Hz duty cycle
+        // as every other waiting indicator. Nothing else in this list moves unless it is working.
+        icon: "?",
+        hl: pulseHl("Status.Pending"),
         value: { kind: "stranger", stranger: s },
       });
     }
 
     for (const n of nodes) {
       const running = n.agents.filter((a) => a.state === "running").length;
-      // One sentence per link state, because they are different answers to "why is it not
-      // here": being dialled for the first time, being dialled again, and not being dialled.
-      const state =
-        n.link.state === "up"
-          ? `${n.agents.length} ${n.agents.length === 1 ? "conversation" : "conversations"}`
+      // One sentence per link state, because they are different answers to "why is it not here" —
+      // and the fourth of them is the reason this reads the way it does. `waiting` is the far half
+      // of pairing: reached, proven, and not yet allowed over there. It used to arrive as
+      // `connecting` with attempt 0, which printed a bare `connecting…` and threw the only useful
+      // sentence away, so adding a computer looked like a network fault for as long as anybody
+      // was willing to watch it.
+      const state = n.link.state === "up"
+        ? `${n.agents.length} ${n.agents.length === 1 ? "conversation" : "conversations"}`
+        : n.link.state === "waiting"
+          // Reads on from the label, which is the machine's name — naming it again here gave
+          // `linux-box  allow this computer on linux-box`. What the sentence has to carry is the
+          // key and the fact that it is pressed somewhere else.
+          ? "has not allowed this computer yet — ^J there"
           : n.link.state === "connecting"
             ? n.link.attempt > 0
               ? `connecting — try ${n.link.attempt}, ${n.reason ?? "no answer"}`
@@ -2009,6 +2030,16 @@ async function showNodes(neosh: Neosh): Promise<void> {
                 ? `reconnecting — try ${n.link.attempt}`
                 : "reconnecting…"
               : `disconnected — ${n.reason ?? "it dials in"}  ·  ^R reconnects`;
+      // The glyph says what the row is doing; the sentence says what to do about it. A spinner
+      // only ever means "this machine is working on it" — never over `waiting`, where nothing on
+      // this computer is trying and the motion would be a promise nobody is keeping.
+      const [icon, hl] = n.link.state === "up"
+        ? [ascii ? "*" : "●", "Diagnostic.Ok"]
+        : n.link.state === "waiting"
+          ? [ascii ? "!" : "◍", pulseHl("Status.Pending")]
+          : n.link.state === "down"
+            ? [ascii ? "-" : "○", "Sidebar.Dim"]
+            : [spinnerFrame(), "Status.Streaming"];
       rows.push({
         label: n.info.name,
         detail: [
@@ -2019,14 +2050,20 @@ async function showNodes(neosh: Neosh): Promise<void> {
           fingerprint(n.info.id),
         ].filter(Boolean).join("  ·  "),
         keywords: `${n.info.os} ${n.info.id} ${n.link.state}`,
+        icon,
+        hl,
         value: { kind: "node", node: n },
       });
     }
 
     rows.push({
-      label: "+ Add a computer…",
+      // The `+` is the icon now that this list has a gutter, not the first character of the label:
+      // with both it read `+ + Add a computer…`.
+      label: "Add a computer…",
       detail: "its address on your network, or through Tailscale",
       keywords: "pair join new machine host",
+      icon: "+",
+      hl: "Sidebar.Dim",
       value: { kind: "add" },
     });
     rows.push({
@@ -2049,24 +2086,55 @@ async function showNodes(neosh: Neosh): Promise<void> {
     return rows;
   };
 
-  const items = await build();
-  const refill = async () => {
-    items.splice(0, items.length, ...(await build()));
+  /** Ask the host again. Everything else here draws from what this last brought back. */
+  const fetch = async () => {
+    [nodes, strangers] = await Promise.all([
+      neosh.swarm.nodes().catch(() => []),
+      neosh.swarm.strangers().catch(() => []),
+    ]);
   };
+
+  const redraw = () => {
+    items.splice(0, items.length, ...build());
+  };
+  const refill = async () => {
+    await fetch();
+    redraw();
+  };
+
+  await fetch();
+  const items: PickerItem<Row>[] = build();
 
   const chosen = await picker(neosh, items, {
     title: "Computers",
     width: 84,
     height: 14,
-    hints: "↵ choose   ^R reconnect   ^D disconnect   ^X remove   ^Y my id   esc close",
+    hints: "↵ open   ^E rename   ^R reconnect   ^D disconnect   ^X remove   ^Y my id",
     // The list keeps up while it is open: a machine connecting, dropping, or moving from
     // "connecting" to a row of conversations changes under the cursor rather than on reopen.
-    subscribe: (reload) =>
-      neosh.swarm.onChange(() => {
+    subscribe: (reload) => {
+      const changed = neosh.swarm.onChange(() => {
         void refill().then(reload);
-      }),
+      });
+      // And the spinner turns on the shared clock, off what the last change brought back rather
+      // than off a fresh pair of API calls: a dial takes seconds, the clock ticks twelve times a
+      // second, and asking the host what it knows on every frame to move one glyph would make
+      // this panel the noisiest thing in the workspace. Nothing ticks while nothing is dialling,
+      // so a list of connected machines costs exactly as much as it did before.
+      const ticked = onTick(() => {
+        if (!spinning()) return;
+        redraw();
+        reload();
+      });
+      return {
+        dispose() {
+          changed.dispose();
+          ticked.dispose();
+        },
+      };
+    },
     // Chords, because every bare letter a picker takes is a letter its filter can never contain.
-    ownKeys: ["<C-y>", "<C-x>", "<C-r>", "<C-d>"],
+    ownKeys: ["<C-y>", "<C-x>", "<C-r>", "<C-d>", "<C-e>"],
     async onKey(key, ctx) {
       if (key.key.code.kind !== "char" || !key.key.mods.ctrl) return;
       switch (key.key.code.c.toLowerCase()) {
@@ -2089,6 +2157,27 @@ async function showNodes(neosh: Neosh): Promise<void> {
           neosh.notify(`disconnected ${row.node.info.name} — ^R takes it back`);
           await refill();
           return "reload";
+        }
+        case "e": {
+          const row = ctx.item;
+          if (row?.kind !== "node") return "handled";
+          // Prefilled with what the row says, so this is an edit rather than a blank field you
+          // have to remember the old name to fill in. Clearing it is how you go back to the
+          // hostname, which is why an empty answer is not the same as `Esc`.
+          const next = await prompt(neosh, `Call ${row.node.info.name}`, {
+            initial: row.node.info.name,
+            width: 60,
+          });
+          if (next === null) return "handled";
+          try {
+            await neosh.swarm.rename(row.node.info.id, next.trim() === "" ? null : next.trim());
+            await refill();
+            return "reload";
+          } catch (e) {
+            // Almost always "that one is in your config file", which names the field to change.
+            neosh.notify(String(e), "warn");
+            return "handled";
+          }
         }
         case "x": {
           const row = ctx.item;
@@ -2137,6 +2226,23 @@ async function showNodes(neosh: Neosh): Promise<void> {
       return;
     }
     case "node": {
+      // A row you cannot open should say why in the terms the row is in. "Nothing running" is true
+      // of a machine that has not allowed this one yet, and is not what is wrong with it.
+      if (chosen.node.link.state === "waiting") {
+        neosh.notify(
+          `${chosen.node.info.name} has not allowed this computer yet — press ^J there and add `
+            + `${me.name}`,
+          "info",
+        );
+        return;
+      }
+      if (!chosen.node.up) {
+        neosh.notify(
+          `${chosen.node.info.name} is not connected — ${chosen.node.reason ?? "still dialling"}`,
+          "info",
+        );
+        return;
+      }
       const newest = [...chosen.node.agents].sort((a, b) => b.updated_at - a.updated_at)[0];
       if (!newest) {
         neosh.notify(`${chosen.node.info.name} has nothing running`, "info");
@@ -2384,9 +2490,16 @@ async function addComputer(neosh: Neosh): Promise<void> {
   const target = addr.includes(":") ? addr.trim() : `${addr.trim()}:7717`;
 
   let found;
+  // A dial across a network somebody just typed the address of is the one thing here that can take
+  // long enough to look broken — a wrong hostname sits on a TCP timeout — so it turns while it
+  // waits. Progress is keyed and replaced in place, which is what makes this one line rather than
+  // a column of `asking…`.
+  const turning = onTick(() => {
+    neosh.progress("swarm.probe", `${spinnerFrame()} asking ${target}…`);
+  });
   try {
     // A state that stops being true the moment the far end answers or does not.
-    neosh.progress("swarm.probe", `asking ${target}…`);
+    neosh.progress("swarm.probe", `${spinnerFrame()} asking ${target}…`);
     found = await neosh.swarm.probe(target);
   } catch (e) {
     // `String(e)` here would read `NeoshError: not found: …: swarm i/o: Connection refused (os
@@ -2401,6 +2514,7 @@ async function addComputer(neosh: Neosh): Promise<void> {
     neosh.log.warn(`swarm probe of ${target} failed: ${String(e)}`);
     return;
   } finally {
+    turning.dispose();
     neosh.done("swarm.probe");
   }
 
@@ -2419,6 +2533,12 @@ async function addComputer(neosh: Neosh): Promise<void> {
   // Both halves have to happen, and only one of them is ours. Saying so now saves the ten minutes
   // otherwise spent wondering why the machine is listed and permanently unreachable.
   neosh.notify(`${found.name} added — now allow this computer over there, with ^J`);
+  // And back to the panel, which is where that second half becomes visible: the new row sits on
+  // `allow this computer on <name>` until somebody does it and then turns over to its
+  // conversations, live, without a key being pressed here. Dropping the user back at the composer
+  // instead is what made pairing feel like it had silently failed — the one thing worth watching
+  // was on a panel they had just been taken out of.
+  await showNodes(neosh);
 }
 
 /**


### PR DESCRIPTION
Adding a computer with `^J` did not work well enough to add a computer with. Three faults, one panel — plus the three build warnings, which are the first commit.

## Every machine was called `neosh`

`machine_name()` asked the **environment** for a hostname. bash sets `HOSTNAME` without exporting it, zsh does not set it at all (it has `HOST`), and the workspace is a daemon that gets a thinner environment than either — so the lookup failed on every Mac and most Linux boxes and fell through to the literal fallback, on both ends, in a panel whose entire job is telling machines apart.

It asks the OS now. The environment is still consulted first, because a container that sets `HOSTNAME` is deliberately overriding a kernel hostname that is a random hex string. `neosh swarm-id` had the same bug and printed `this-machine` into the config line you paste on another computer.

## "connecting…" for ever was not connecting

The dial *succeeded* — right machine, identity proven, handshake complete — and then the far end stopped talking, because it has not been told about this machine yet. Pairing is a decision each side makes, and only one side had made it.

That arrived as `DialFailed { attempt: 0 }` carrying an explanatory sentence; the board mapped it to `Connecting { attempt: 0 }`; and the panel printed the reason **only when `attempt > 0`**. So the one state with something actionable in it was the one state that said nothing.

It is `LinkState::Waiting` now, out of a new `SwarmEvent::Unapproved` that carries the `NodeInfo` the handshake *did* learn — so a half-paired row shows the machine's real name and OS instead of the address you typed at it. It does not spin: a spinner means *this* machine is working on it, and this is waiting on a person at the other end. It is not sticky against a genuine dial failure, because being told to press a key on a computer that is switched off is worse than being told nothing. The retry stays at the flat heartbeat, so the row turns over on its own within seconds of the yes over there.

## A machine can be renamed

`swarm.rename` — `^E` — is an SSH `Host` alias and exists for the same reason: a hostname is chosen by whoever set the box up, and two Macs out of the box are both `Mac`. Kept in `\$STATE` beside the pairing, substituted once where `SwarmNode` is built so every panel agrees, never overwritten by the handshake that refreshes everything else, and cleared to get the announced name back. Refused for a `config.toml` peer, naming the `name` field instead.

## And the loading is visible

Braille frames on rows being dialled and on the probe behind "Add a computer…", redrawn from the last known state rather than by asking the host per frame, ticking only while something is actually dialling. `●` up, `◍` pulsing for waiting-on-you, `○` down. `↵` on a row that cannot open says why in the row's own terms rather than "nothing running", and adding a computer puts you back in the panel — which is where the second half of pairing becomes visible.

## Before / after

\`\`\`
neosh   connecting…                                        ·  ·
\`\`\`
\`\`\`
❯ ◍ the loud one  has not allowed this computer yet — ^J there  ·  macos  ·  64c3 2174
  + Add a computer…  its address on your network, or through Tailscale
    This computer  ·  Matts-Mac-mini  8c9f b9f7 e2fd 1d11  ·  dial-only  ·  ^Y copies the full id
 ↵ open   ^E rename   ^R reconnect   ^D disconnect   ^X remove   ^Y my id
\`\`\`

and once the other machine says yes, with no key pressed here:

\`\`\`
❯ ● the loud one  1 conversation  ·  macos  ·  64c3 2174 638a 7fa7
\`\`\`

## Verification

Driven against two real workspaces, one paired one way, watched go waiting → connected; `^E` driven through real key events and confirmed written to `peers.json`. New integration test `a_machine_that_has_not_allowed_us_back_says_so_rather_than_dialling_in_silence`, three board tests, three allow-list tests. Build clean of code warnings; TS regenerated and in sync; API, bundled plugins and example all type-check.

`builtin_plugins` has its two pre-existing macOS failures (`/var` vs `/private/var` string compare at `builtin_plugins.rs:5664`), unrelated to this change.

## Note for reviewers

`LinkState` gained a variant, which is breaking for an exhaustive `switch` in a third-party plugin. Worth deciding whether the release off this is `0.2.1` or `0.3.0`.