### PR TITLE
fix(sidebar): `^R` left the old column on screen and opened a second one

### DIFF
--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -461,6 +461,47 @@ fn the_sidebar_toggles_and_the_second_toggle_puts_it_back() {
     assert!(s.pump(|s| !s.windows_for(buf).is_empty()), "reopens\n{}", s.transcript());
 }
 
+/// Reloading the configuration must leave one sidebar, not two.
+///
+/// `^R` unloads the plugin and loads it again. The reloaded copy asks for a panel per terminal —
+/// `view.onOpen` fires for the ones already here — but nothing took the old copy's column off the
+/// screen: the panel's `dispose` deliberately does not close a window, because its only caller was
+/// a terminal that had already gone and taken its windows with it, and on this path nothing called
+/// `dispose` at all. So the workspace got a second sidebar beside the first, and the first was
+/// drawn by code that no longer existed and answered no keys.
+///
+/// Counted across *every* `[sidebar]` buffer rather than the first one, because the whole symptom
+/// is a second buffer with a second window on it — a test that looked at one buffer would have
+/// been perfectly happy.
+#[test]
+fn reloading_the_config_leaves_one_sidebar_rather_than_two() {
+    let sb = Sandbox::new("reload-dup");
+    let mut s = sb.start();
+    s.wait_for("PROJECTS");
+    let before: usize =
+        s.buffers_named("[sidebar]").iter().map(|b| s.windows_for(*b).len()).sum();
+    assert_eq!(before, 1, "one to start with\n{}", s.transcript());
+
+    s.send(&command("config.reload"));
+    // The panel has to come back — a reload that closed the old column and never opened a new one
+    // would pass a naive "not two" assertion while leaving somebody with no sidebar at all.
+    assert!(
+        s.pump(|s| {
+            let open: usize =
+                s.buffers_named("[sidebar]").iter().map(|b| s.windows_for(*b).len()).sum();
+            open == 1 && s.buffers_named("[sidebar]").len() > 1
+        }),
+        "one sidebar after the reload, on a freshly built panel\n{}",
+        s.transcript()
+    );
+
+    // And it settles there: the old window is closed rather than merely drawn over, so nothing
+    // arrives a moment later to make it two again.
+    s.drain_for(Duration::from_secs(2));
+    let after: usize = s.buffers_named("[sidebar]").iter().map(|b| s.windows_for(*b).len()).sum();
+    assert_eq!(after, 1, "still one\n{}", s.transcript());
+}
+
 #[test]
 fn the_sidebar_stays_shut_when_config_says_so() {
     let sb = Sandbox::new("closed");

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -396,22 +396,45 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
       }
     };
 
-    const open = async () => {
-      if (win === null) {
-        // Read defensively: a reload takes every declared option away and puts it back, and this
-        // can be called from a view arriving in the gap. A panel that throws there used to take
-        // the whole plugin runtime with it.
-        const width = (await neosh.opt.get<number>("sidebar.width").catch(() => null)) ?? 34;
-        win = await here.win.open(buf, "left", { size: width });
-      }
-      await draw();
-      // And again once the frontend has said how tall the panel turned out to be. The foot is held
-      // against the bottom edge, which is a measurement — and on the first frame there is nothing
-      // to measure yet, so without this the strip sits under the last project until something else
-      // happens to redraw.
-      // Not held in `subscriptions`: the panel is opened and closed as often as `^B` is pressed,
-      // and the runtime cancels a plugin's timers when it unloads anyway.
-      neosh.timer.after(120, () => void draw());
+    /**
+     * The open in flight, so two callers cannot each make a window.
+     *
+     * `win` is assigned two `await`s after it is tested — a host round trip for the width, then
+     * the window itself — so `if (win === null)` is a check whose answer is stale by the time it
+     * is acted on. Two calls in that gap both saw `null`, both opened a column, and `win` kept
+     * only the second: the first stayed on screen and could never be closed again, because
+     * `close` closes `win`. Two sidebars, from pressing `^B` or `^T` twice quickly, or from a key
+     * arriving while `view.onOpen` was still building the panel.
+     *
+     * Concurrent callers await the same open rather than starting another. They all wanted the
+     * same end state and now they all get it — which is why this returns the promise instead of
+     * dropping the second call, whose caller is about to `focus` something.
+     */
+    let opening: Promise<void> | null = null;
+
+    const open = (): Promise<void> => {
+      if (opening) return opening;
+      const run = (async () => {
+        if (win === null) {
+          // Read defensively: a reload takes every declared option away and puts it back, and this
+          // can be called from a view arriving in the gap. A panel that throws there used to take
+          // the whole plugin runtime with it.
+          const width = (await neosh.opt.get<number>("sidebar.width").catch(() => null)) ?? 34;
+          win = await here.win.open(buf, "left", { size: width });
+        }
+        await draw();
+        // And again once the frontend has said how tall the panel turned out to be. The foot is
+        // held against the bottom edge, which is a measurement — and on the first frame there is
+        // nothing to measure yet, so without this the strip sits under the last project until
+        // something else happens to redraw.
+        // Not held in `subscriptions`: the panel is opened and closed as often as `^B` is pressed,
+        // and the runtime cancels a plugin's timers when it unloads anyway.
+        neosh.timer.after(120, () => void draw());
+      })();
+      opening = run.finally(() => {
+        opening = null;
+      });
+      return opening;
     };
 
     const leave = async () => {
@@ -424,6 +447,11 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
     };
 
     const close = async () => {
+      // Let an open that is still in flight finish first. `^B` twice quickly is open-then-close,
+      // and a close that reads `win` while the open has not assigned it yet sees `null`, returns
+      // having done nothing, and leaves the column that arrives a moment later on screen — with
+      // the panel now believing it is shut. The next `^B` opens a second one.
+      if (opening) await opening.catch(() => {});
       if (win === null) return;
       const w = win;
       win = null;
@@ -586,11 +614,24 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
   // loaded. `sidebar.open` decides whether it starts showing, per view rather than once for the
   // workspace: `^B` in one window is `^B` in that window.
   const startOpen = (await neosh.opt.get<boolean>("sidebar.open")) ?? true;
+  // Panels being built, keyed by the terminal they are for. The same check-then-act as `open`, one
+  // level up and worse: `panels.set` lands after `makePanel` resolves, so two events for one view
+  // in that gap built two complete panels — two buffers, two windows — and the map kept the
+  // second. Reserved *synchronously*, before the first `await`, which is what makes the test and
+  // the claim one step.
+  const making = new Map<ViewId, Promise<Panel>>();
   subscriptions.push(
     neosh.view.onOpen((view) => {
       void (async () => {
-        if (panels.has(view)) return;
-        const made = await makePanel(view);
+        if (panels.has(view) || making.has(view)) return;
+        const building = makePanel(view);
+        making.set(view, building);
+        let made: Panel;
+        try {
+          made = await building;
+        } finally {
+          making.delete(view);
+        }
         panels.set(view, made);
         if (startOpen) await made.open();
       })().catch((e: unknown) => {
@@ -610,6 +651,26 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
       panels.delete(view);
     }),
   );
+  // And when *we* are the ones going away, which is not the same thing and is the one this panel
+  // got wrong. `dispose` deliberately does not close a window, because its only caller was a
+  // terminal that had already gone and taken its windows with it. A reload is the opposite: every
+  // terminal is still there, still showing a column that nothing is going to take off the screen,
+  // and nothing disposed the panels on this path at all. So `^R` left the old sidebar standing,
+  // the reloaded plugin's `view.onOpen` built a second one beside it, and the workspace had two —
+  // one of them drawn by code that no longer existed and answering no keys.
+  //
+  // Closed rather than merely forgotten, and fire-and-forget because a `Disposable` is
+  // synchronous: the op is in flight before the runtime tears down, and a failure here means the
+  // window was going anyway.
+  subscriptions.push({
+    dispose: () => {
+      for (const p of panels.values()) {
+        void p.close().catch(() => {});
+        p.dispose();
+      }
+      panels.clear();
+    },
+  });
 }
 
 function same(a: Target, b: Target): boolean {


### PR DESCRIPTION
Reloading the configuration gave you **two sidebars**. The second one worked; the first was drawn by a plugin instance that no longer existed, answered no keys, and could not be closed by anything.

## The cause

A reload unloads the plugin and loads it again. The new copy asks for a panel per terminal — `view.onOpen` fires for the ones already here, which is what it's for — and nothing had taken the old copy's window off the screen.

`Panel.dispose` doesn't close a window, deliberately, with a comment saying why:

```js
dispose: () => {
  capture?.dispose();
  capture = null;
  // Not closed here: the terminal has gone and the host took its windows with it. Closing a
  // window that is already gone is an error message about nothing.
  win = null;
},
```

That reasoning is correct for its only caller, `view.onClose`. But it made "the terminal is leaving" the only case handled — and on the other one, where *we* are leaving and every terminal is still here, nothing called `dispose` at all. The panels were never in `subscriptions`, so the column outlived the code that drew it.

Now they are. Closed rather than merely forgotten, and fire-and-forget because a `Disposable` is synchronous: the op is in flight before the runtime tears down, and if it loses that race the window was going anyway.

## Two races found on the way

Both produce the same symptom from a *key* rather than a reload, so they're fixed here too.

**`open`** tested `win === null` and assigned it two `await`s later — a host round trip for the width, then the window itself:

```js
if (win === null) {                            // check
  const width = await neosh.opt.get(...)       // ← gap
  win = await here.win.open(buf, "left", ...)  // ← claim, far too late
}
```

Two calls inside that gap both saw `null`, both opened a column, and `win` kept only the second — leaving the first unclosable. `^B` and `^T` both reach it, as does a key arriving while `view.onOpen` is still building the panel.

**`view.onOpen`** had the same shape one level up and worse: `panels.set` lands after `makePanel` resolves, so two events for one view built two complete panels — two buffers, two windows — and the map kept the second.

Both are now check-and-claim in one step: an in-flight promise concurrent callers await rather than race, and a `making` map reserved *synchronously* before the first `await`. `close` waits on an open in flight too — otherwise `^B` twice quickly reads `win` before the open assigned it, does nothing, and leaves a column the panel believes is shut.

## Measured

Counting left-docked windows still open at the end of a real `config.reload`:

| | opened | still open at the end |
|---|---|---|
| before | `[4, 5]` | `[4, 5]` → **2 sidebars** |
| after | `[4, 5]` | `[5]` → **1 sidebar** |

## The test

`reloading_the_config_leaves_one_sidebar_rather_than_two` counts across **every** `[sidebar]` buffer rather than the first — the symptom is a second buffer with a second window on it, and a test looking at one buffer would have been perfectly happy. It also asserts the panel comes *back*, since "not two" is equally satisfied by none.

Confirmed it fails with the fix reverted. Full suite: 171 passed, plus the two pre-existing macOS `/var` vs `/private/var` path failures.