### PR TITLE
The path was at the bottom of the list, and the other computers were not on it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,26 @@ is `docs/releasing.md`.
   NAT traversal — plain TCP, with Tailscale or the like underneath — and does not trust the network
   to say who may steer an agent: a node is its ed25519 public key, and authorisation is a list you
   wrote. `accepts_approvals` is separate from `accepts_commands` and off by default, because
-  steering is a message and approving is a write to that machine's disk.
+  steering is a message and approving is a write to that machine's disk. **`Browse` is not a third
+  permission**, though: a node that accepts commands already accepts `NewSession` with any `cwd` on
+  its disk, so naming the directories that exist withholds strictly less than it has given away, and
+  a knob for it would be a question nobody has the information to answer. `NodeCapabilities::browse`
+  is therefore a *compatibility* flag — an unknown message tag fails the frame and takes the
+  connection with it, so a directory picker aimed at an older peer would knock it off the board
+  rather than come back empty. It defaults to `false`, which is what an older handshake decodes to,
+  so "does not say" and "cannot" are one answer and a version bump was never needed.
+- **What another machine knows about this one is a roster, not a snapshot.** `publish_inventory` was
+  called when a peer connected and when a peer drove something here, and never once because somebody
+  *sitting at this machine* started, renamed, archived or deleted a conversation — so every other
+  computer's picture of this one was frozen at whenever it last dialled, and a project added an hour
+  ago was invisible over there with nothing on screen to say why. A timer rather than a call at each
+  of the places a conversation can change, because that list is long and was already wrong; it
+  recomputes and compares, so an idle workspace with peers puts nothing on the wire. And what it
+  advertises is the list its **own panel** shows — `sidebar.projects`, read the way
+  `question.asking` is, because which places you work in is a fact about the workspace rather than
+  about the panel that wrote it down. Derived from live conversations alone it was also a constant:
+  every project on the list had one, so `RemoteProject::active` said `true` for all of them and a
+  board drawing the flag drew one colour.
 - `Editor::handles` is a **deny-list**. A new API call that is not added to it silently routes to
   the core.
 - **A driver's account of its own loop is not a content block.** Sub-agents, plans, compaction and
@@ -361,6 +380,25 @@ is `docs/releasing.md`.
   worktree does not rename it to `wt-fe3c0d93`), and leaves by `X` on its heading and nothing else.
   Empty, that asks nothing — `o` puts it back; with conversations still in it, it is a delete of
   every one of them and asks like one.
+- **"Where?" is one field, and the field is the path field.** `^N` and `^O` ask the same question and
+  ask it the same way: type nothing and it is a menu, type `/`, `~` or `./` and it completes
+  directories, type `linux-box:` and it completes directories **on that computer**. `<Tab>` walks
+  into the highlighted one and `↵` takes it — `pathPicker`'s bargain, which is why a completion row's
+  label has to be the whole path and why a remote one is prefixed rather than bare. The scp spelling
+  is not decoration: `host:path` means there what it means here, it is what makes one field able to
+  point at two machines, and it is learned by reading a machine's row rather than by being told. What
+  this replaced was a path sitting at the bottom of a list of every worktree the program had ever
+  heard of — a verb whose distance from the cursor grew with how long you had used it — so
+  `Another directory…` is above that list now and `Type a path…` is the first row of `^O`. Choosing a
+  machine reopens the picker seeded with `<machine>:` rather than descending in place, because a
+  second level whose rows lie about what is in the field is a `<Tab>` that jumps somewhere nobody
+  asked for. **Every paired machine is a row, including the ones that cannot be used**, greyed with
+  the reason on them: skipping them is right about what can be *done* and wrong about what should be
+  *said*, and somebody who has just paired a computer and finds an empty list reads it as the feature
+  not existing. A machine with no projects yet falls through to its home directory rather than
+  showing none. And starting one over there **opens it** — `swarm.command` answers with the
+  conversation `NewSession` made, which until it did meant the same key did visibly less for the same
+  intention: you had to go and find, in `^J`, the thing you had just made.
 - **What you have archived is not in the sidebar at all, and it is something you can empty.** The
   panel is the list you work in; a section of things you are finished with is the only part of that
   column that is never the answer, and it grows forever. The first cut left one dim row with a count
@@ -686,7 +724,7 @@ only way to do anything.
 | `^J` | The computers in this workspace. Add one by its address, allow one that is asking, rename one (`^E`), or open what it is running. A machine this one has reached that has not allowed it back says so, and says which key to press over there |
 | `^F` | What you have archived — see below. Filter it, put some back, or finally empty it |
 | `^N` | New conversation. In a repository it asks where: here, a worktree you need not name, one kept inside the project, one you do name, an existing one, another machine, elsewhere. A worktree you did not name is named by your first message — `fix/composer-paste-truncation`, not `wily-nimbus` |
-| `^O` | Add a project |
+| `^O` | Add a project. The filter line **is** the path field: `/`, `~` and `./` complete directories from the first keystroke, `⇥` walks into the highlighted one, `↵` takes what you typed. `linux-box:` completes on that computer instead |
 | `^B` | Toggle the sidebar |
 | `^K` | Command palette |
 | `/` | Completes a command by name — neosh's, and whatever the agent says it accepts. Keep typing; the composer is still the field, and `↵` sends what you typed when nothing matches |

--- a/crates/neosh-core/src/editor.rs
+++ b/crates/neosh-core/src/editor.rs
@@ -401,6 +401,7 @@ impl Editor {
                 | ApiCall::SwarmReconnect { .. }
                 | ApiCall::SwarmDisconnect { .. }
                 | ApiCall::SwarmStrangers
+                | ApiCall::SwarmBrowse { .. }
                 // The plan's allowance: credentials, other programs' transcripts and a clock.
                 // Nothing here is UI state, and the store outlives every window that draws it.
                 | ApiCall::QuotaList

--- a/crates/neosh-proto/src/api.rs
+++ b/crates/neosh-proto/src/api.rs
@@ -1174,6 +1174,24 @@ pub enum ApiCall {
     },
     /// Machines that have asked to join, or that we found and have not added.
     SwarmStrangers,
+    /// Which directories on another machine start with `prefix` — [`ApiCall::PathComplete`], asked
+    /// over there.
+    ///
+    /// What makes "start a conversation on that computer" a place you can *go* rather than a menu
+    /// of the three checkouts it happens to have open. Without it the only way to reach a fourth is
+    /// to type its path from memory, which is a path typed wrong, and the way you find out is a
+    /// conversation that refuses to start.
+    ///
+    /// Answers with the same shape [`ApiCall::PathComplete`] does — each entry as you would have
+    /// typed it, trailing separator and all — so one field can complete against either machine and
+    /// the only thing that changes is which one is asked. Rejects when the peer is not connected,
+    /// when it does not accept commands, and when it is too old to have heard of the question; the
+    /// message says which.
+    SwarmBrowse {
+        node: NodeId,
+        #[serde(default)]
+        prefix: String,
+    },
 
     // ---- the plan ------------------------------------------------------
     // What the account has left, and what it has already spent. The capability is in the host
@@ -1579,6 +1597,16 @@ pub enum ApiOk {
     SwarmNodes { nodes: Vec<SwarmNode> },
     SwarmAgents { agents: Vec<SwarmAgent> },
     SwarmStrangers { strangers: Vec<SwarmStranger> },
+    /// A command a peer carried out, and the conversation it made if it made one.
+    ///
+    /// Only [`AgentCommand::NewSession`] fills it in, and dropping it was what made "start
+    /// something over there" a dead end: the far end knew the id, said it in its `Ack`, and the
+    /// host threw it away — so a plugin could start a conversation on another machine and then had
+    /// no way to open the thing it had just started.
+    SwarmCommanded {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session: Option<SessionId>,
+    },
     // ---- the plan ----
     Quotas { quotas: Vec<QuotaSnapshot> },
     QuotaHistory { samples: Vec<QuotaSample> },

--- a/crates/neosh-proto/src/ascp.rs
+++ b/crates/neosh-proto/src/ascp.rs
@@ -275,8 +275,24 @@ pub struct RemoteProject {
     /// [`AgentCommand::NewSession`], not something to look at locally.
     pub cwd: String,
     /// Whether this node has a conversation open in it now.
+    ///
+    /// Meant something for exactly as long as this list was derived from live conversations: every
+    /// project on it had one, so every one of them said `true` and a board drawing the flag drew
+    /// one colour. A node now advertises the places it *works in* — which is the list its own panel
+    /// shows, and includes the project you cleared out this morning — so the two states exist and
+    /// the flag is worth reading.
     #[serde(default)]
     pub active: bool,
+    /// How many conversations are open in it there.
+    #[serde(default)]
+    pub sessions: u32,
+    /// How many of those are mid-turn.
+    ///
+    /// Separate from `sessions` because they are different questions and a board answers both in
+    /// one row: `3 conversations · 1 working` is what the sidebar says about a local project, and a
+    /// remote one should not have to say less.
+    #[serde(default)]
+    pub running: u32,
 }
 
 /// What a node is willing to have done to it.
@@ -298,6 +314,16 @@ pub struct NodeCapabilities {
     /// Whether [`AscpMessage::Subscribe`] will produce anything.
     #[serde(default)]
     pub streams: bool,
+    /// Whether [`AscpMessage::Browse`] will be answered.
+    ///
+    /// Not a permission — it follows `accepts_commands`, for the reason written on `Browse` — but a
+    /// *compatibility* flag, and that is why it is here rather than derived. A node built before
+    /// `Browse` existed cannot skip a message it has never heard of: the frame parses or the
+    /// connection fails, so a new node that sent one on spec would drop an old peer's link every
+    /// time somebody opened a directory picker. It defaults to `false`, which is exactly what an
+    /// older node's handshake decodes to, so "does not say" and "cannot" are the same answer.
+    #[serde(default)]
+    pub browse: bool,
     /// The checkouts this node has, for starting something on it.
     #[serde(default)]
     pub projects: Vec<RemoteProject>,
@@ -417,6 +443,26 @@ pub enum AscpMessage {
         session: Option<SessionId>,
     },
     Refused { id: String, refusal: Refusal },
+    /// Which directories on that machine start with `prefix`.
+    ///
+    /// [`NodeCapabilities::projects`] is what a node *offers*, and it is a short list of places it
+    /// already works in. This is the other half: the directory over there that neither machine has
+    /// ever opened, which without this can only be reached by typing a path from memory and finding
+    /// out it was wrong when the conversation fails to start.
+    ///
+    /// Gated on [`NodeCapabilities::accepts_commands`], and deliberately not on a knob of its own.
+    /// A node that accepts commands already accepts [`AgentCommand::NewSession`] with an arbitrary
+    /// `cwd` — it will *start an agent* anywhere on its disk you name — so declining to say which
+    /// directories exist would withhold strictly less than it has already given away, at the cost
+    /// of a third permission for people to reason about. Directory names only: never files, never
+    /// contents, never anything a `read_dir` cannot answer.
+    ///
+    /// Answered with [`Self::Browsed`] or [`Self::Refused`], exactly once, like every other
+    /// request here.
+    Browse { id: String, prefix: String },
+    /// The answer to [`Self::Browse`] — each entry as the asker would have typed it, trailing
+    /// separator and all, so it can go straight back into a field.
+    Browsed { id: String, paths: Vec<String> },
     /// Closing cleanly, so a peer can say "went away" rather than waiting out a timeout.
     Goodbye {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -478,5 +524,56 @@ mod tests {
         assert_eq!(NodeId("0123456789abcdef".into()).short(), "01234567");
         assert_eq!(NodeId("abc".into()).short(), "abc");
         assert_eq!(NodeId(String::new()).short(), "");
+    }
+
+    /// A machine that predates [`AscpMessage::Browse`] has to decode as one that cannot answer it.
+    ///
+    /// This is the whole of what keeps a directory picker from knocking an older peer off the
+    /// board. An unknown message tag fails the frame and fails the connection with it, so
+    /// [`NodeCapabilities::browse`] is what a new node checks before ever sending one — and the
+    /// handshake of a node that has never heard of the field says nothing about it. "Did not say"
+    /// and "cannot" must therefore be the same answer, which is what `#[serde(default)]` on a
+    /// `bool` buys and what this pins down.
+    #[test]
+    fn a_handshake_from_before_browse_existed_says_it_cannot_browse() {
+        let older = r#"{
+            "accepts_commands": true,
+            "accepts_approvals": false,
+            "streams": true,
+            "projects": [
+                {"key":"git:example.com/me/thing","name":"thing","cwd":"/home/me/thing","active":true}
+            ]
+        }"#;
+        let caps: NodeCapabilities = serde_json::from_str(older).expect("an older handshake parses");
+        assert!(!caps.browse, "and it is not asked to browse");
+        assert!(caps.accepts_commands, "while everything it did say survives");
+        // The counts are the same bargain one type down: absent is zero, not a parse failure.
+        let p = &caps.projects[0];
+        assert_eq!((p.sessions, p.running), (0, 0));
+        assert!(p.active, "and the flag it did send is believed");
+    }
+
+    /// And the other direction: an older node is handed fields it has never heard of.
+    ///
+    /// Serde ignores unknown keys on a struct by default, which is the half of the bargain that
+    /// lets a new node advertise `browse` at all — but "by default" is a setting somebody could
+    /// change to `deny_unknown_fields` on a tidying pass, and that would break every mixed-version
+    /// swarm at the handshake. Pinned here so the tidying pass fails a test instead.
+    #[test]
+    fn a_handshake_carrying_fields_an_older_node_lacks_still_parses() {
+        let newer = r#"{
+            "accepts_commands": true,
+            "accepts_approvals": false,
+            "streams": true,
+            "browse": true,
+            "something_from_next_year": 7,
+            "projects": [
+                {"key":"git:example.com/me/thing","name":"thing","cwd":"/t","active":false,
+                 "sessions":3,"running":1,"another_new_one":"x"}
+            ]
+        }"#;
+        let caps: NodeCapabilities = serde_json::from_str(newer).expect("a newer handshake parses");
+        assert!(caps.browse);
+        assert_eq!((caps.projects[0].sessions, caps.projects[0].running), (3, 1));
     }
 }

--- a/crates/neosh-proto/tests/ascp_vectors.rs
+++ b/crates/neosh-proto/tests/ascp_vectors.rs
@@ -76,11 +76,14 @@ fn caps() -> NodeCapabilities {
         accepts_commands: true,
         accepts_approvals: false,
         streams: true,
+        browse: true,
         projects: vec![RemoteProject {
             key: ProjectKey("git:github.com/neoswarm/neosh".into()),
             name: "neosh".into(),
             cwd: "/home/me/src/neosh".into(),
             active: true,
+            sessions: 2,
+            running: 1,
         }],
     }
 }
@@ -180,6 +183,20 @@ fn every_message_has_a_canonical_encoding() {
         }),
     );
     check("12-goodbye.json", canonical(&AscpMessage::Goodbye { message: None }));
+    check(
+        "13-browse.json",
+        canonical(&AscpMessage::Browse { id: "b1".into(), prefix: "/home/me/src/".into() }),
+    );
+    check(
+        "14-browsed.json",
+        canonical(&AscpMessage::Browsed {
+            id: "b1".into(),
+            // Each one as the asker would have typed it, trailing separator and all — which is the
+            // part an implementation in another language gets wrong, because a `read_dir` gives you
+            // bare names and a field needs a path.
+            paths: vec!["/home/me/src/neosh/".into(), "/home/me/src/dotfiles/".into()],
+        }),
+    );
 }
 
 /// The exact bytes a peer has to sign.

--- a/crates/neosh-swarm/src/node.rs
+++ b/crates/neosh-swarm/src/node.rs
@@ -79,6 +79,10 @@ pub enum SwarmRequest {
     Command { node: NodeId, id: String, session: SessionId, command: AgentCommand },
     /// Answer a request that came in.
     Answer { node: NodeId, id: String, result: Result<Option<SessionId>, Refusal> },
+    /// Ask a peer which of its directories start with `prefix`.
+    Browse { node: NodeId, id: String, prefix: String },
+    /// Answer a [`SwarmEvent::Browse`] that came in.
+    Browsed { node: NodeId, id: String, result: Result<Vec<String>, Refusal> },
     Subscribe { node: NodeId, session: SessionId },
     Unsubscribe { node: NodeId, session: SessionId },
     /// Something happened in a local session. Sent only to peers that subscribed to it.
@@ -136,6 +140,11 @@ pub enum SwarmEvent {
     Command { node: NodeId, id: String, session: SessionId, command: AgentCommand },
     /// A command we sent has been answered. Exactly one of these per command, ever.
     Answer { node: NodeId, id: String, result: Result<Option<SessionId>, Refusal> },
+    /// A peer wants to know which of our directories start with `prefix`. The host must answer with
+    /// [`SwarmRequest::Browsed`].
+    Browse { node: NodeId, id: String, prefix: String },
+    /// A browse we sent has been answered. Exactly one of these per browse, ever.
+    Browsed { node: NodeId, id: String, result: Result<Vec<String>, Refusal> },
     /// A machine proved who it is and is not one we have paired with.
     ///
     /// The beginning of pairing rather than the end of a connection. Reported for both directions:
@@ -148,6 +157,10 @@ pub enum SwarmEvent {
 }
 
 /// What the host holds.
+///
+/// Clonable so a spawned task can answer a peer without the host loop having to wait for it: the
+/// only thing in here is a sender and an id, and every request on it is fire-and-forget.
+#[derive(Clone)]
 pub struct SwarmHandle {
     tx: mpsc::UnboundedSender<SwarmRequest>,
     id: NodeId,
@@ -237,6 +250,10 @@ async fn run(
         accepts_commands: config.accepts_commands,
         accepts_approvals: config.accepts_approvals,
         streams: true,
+        // A build fact rather than a setting: it says this binary understands the message, and what
+        // decides whether the message is *answered* is `accepts_commands`, checked when one
+        // arrives. A knob here would be a second permission for something already permitted.
+        browse: true,
         projects: Vec::new(),
     };
 
@@ -450,6 +467,51 @@ async fn run(
                             });
                         }
                     }
+                    SwarmRequest::Browse { node, id, prefix } => {
+                        match peers.get(&node) {
+                            // Never sent to a peer that has not said it understands the question:
+                            // an unknown message tag fails the frame and takes the connection with
+                            // it, so a directory picker aimed at an older machine would knock it
+                            // off the board rather than come back empty. See
+                            // `NodeCapabilities::browse`.
+                            Some(p) if p.capabilities.browse => {
+                                let _ = p.out.send(AscpMessage::Browse { id, prefix });
+                            }
+                            Some(p) => {
+                                let _ = events.send(SwarmEvent::Browsed {
+                                    node,
+                                    id,
+                                    result: Err(Refusal::NotPermitted {
+                                        what: format!(
+                                            "{} is running neosh {}, which cannot list directories \
+                                             for another machine",
+                                            p.info.name, p.info.version
+                                        ),
+                                    }),
+                                });
+                            }
+                            // Answered locally rather than dropped, for the reason `Command` is:
+                            // a request with no reply is indistinguishable from a slow network,
+                            // and the caller is a field somebody is typing into.
+                            None => {
+                                let _ = events.send(SwarmEvent::Browsed {
+                                    node,
+                                    id,
+                                    result: Err(Refusal::Busy {
+                                        message: "not connected".into(),
+                                    }),
+                                });
+                            }
+                        }
+                    }
+                    SwarmRequest::Browsed { node, id, result } => {
+                        if let Some(p) = peers.get(&node) {
+                            let _ = p.out.send(match result {
+                                Ok(paths) => AscpMessage::Browsed { id, paths },
+                                Err(refusal) => AscpMessage::Refused { id, refusal },
+                            });
+                        }
+                    }
                     SwarmRequest::Subscribe { node, session } => {
                         if let Some(p) = peers.get(&node) {
                             let _ = p.out.send(AscpMessage::Subscribe { session });
@@ -593,6 +655,25 @@ async fn run(
                         } else {
                             let _ = events.send(SwarmEvent::Command { node, id, session, command });
                         }
+                    }
+                    AscpMessage::Browse { id, prefix } => {
+                        // The same gate the command path applies, and deliberately the same one:
+                        // a node that accepts commands already accepts `NewSession` with any path
+                        // on its disk, so naming the directories that exist is strictly less than
+                        // it has given away. A node that does not is not asked to list anything.
+                        if caps.accepts_commands {
+                            let _ = events.send(SwarmEvent::Browse { node, id, prefix });
+                        } else if let Some(p) = peers.get(&node) {
+                            let _ = p.out.send(AscpMessage::Refused {
+                                id,
+                                refusal: Refusal::NotPermitted {
+                                    what: "this node does not accept commands".into(),
+                                },
+                            });
+                        }
+                    }
+                    AscpMessage::Browsed { id, paths } => {
+                        let _ = events.send(SwarmEvent::Browsed { node, id, result: Ok(paths) });
                     }
                     AscpMessage::Ack { id, session } => {
                         let _ = events.send(SwarmEvent::Answer {

--- a/crates/neosh-swarm/src/wire.rs
+++ b/crates/neosh-swarm/src/wire.rs
@@ -83,6 +83,7 @@ mod tests {
                 accepts_commands: true,
                 accepts_approvals: false,
                 streams: true,
+                browse: true,
                 projects: Vec::new(),
             },
             nonce: "00".into(),

--- a/crates/neosh-swarm/tests/handshake.rs
+++ b/crates/neosh-swarm/tests/handshake.rs
@@ -19,6 +19,7 @@ fn caps() -> NodeCapabilities {
         accepts_commands: true,
         accepts_approvals: false,
         streams: true,
+        browse: true,
         projects: Vec::new(),
     }
 }

--- a/crates/neosh-swarm/tests/swarm.rs
+++ b/crates/neosh-swarm/tests/swarm.rs
@@ -284,6 +284,74 @@ async fn a_read_only_node_refuses_without_asking_its_host() {
     assert!(heard.is_err(), "a read-only node's host is not asked to enforce it");
 }
 
+/// A directory listing reaches the owner and comes back under the id it was asked with.
+#[tokio::test]
+async fn browsing_a_peer_answers_with_that_machines_directories() {
+    let mut p = pair(true).await;
+    let b_id = wait_for(&mut p.a_rx, |e| match e {
+        SwarmEvent::PeerUp { node, .. } => Some(node.id.clone()),
+        _ => None,
+    })
+    .await;
+
+    p.a.send(SwarmRequest::Browse { node: b_id.clone(), id: "b1".into(), prefix: "/src/".into() });
+
+    let (id, prefix) = wait_for(&mut p.b_rx, |e| match e {
+        SwarmEvent::Browse { id, prefix, .. } => Some((id.clone(), prefix.clone())),
+        _ => None,
+    })
+    .await;
+    assert_eq!((id.as_str(), prefix.as_str()), ("b1", "/src/"), "asked, verbatim");
+
+    let a_id = wait_for(&mut p.b_rx, |e| match e {
+        SwarmEvent::PeerUp { node, .. } => Some(node.id.clone()),
+        _ => None,
+    })
+    .await;
+    p.b.send(SwarmRequest::Browsed {
+        node: a_id,
+        id: "b1".into(),
+        result: Ok(vec!["/src/neosh/".into()]),
+    });
+
+    let answer = wait_for(&mut p.a_rx, |e| match e {
+        SwarmEvent::Browsed { id, result, .. } if id == "b1" => Some(result.clone()),
+        _ => None,
+    })
+    .await;
+    assert_eq!(answer.expect("answered"), vec!["/src/neosh/".to_string()]);
+}
+
+/// A read-only node is not asked to list its directories either.
+///
+/// Browsing follows `accepts_commands` rather than a permission of its own — a node that will start
+/// an agent at any path you name has already given away more than the names of its directories —
+/// which means the gate has to be the same gate, applied in the same place, and not a second one
+/// somebody remembered to write.
+#[tokio::test]
+async fn a_read_only_node_will_not_be_browsed() {
+    let mut p = pair(false).await;
+    let b_id = wait_for(&mut p.a_rx, |e| match e {
+        SwarmEvent::PeerUp { node, .. } => Some(node.id.clone()),
+        _ => None,
+    })
+    .await;
+
+    p.a.send(SwarmRequest::Browse { node: b_id, id: "b1".into(), prefix: "/".into() });
+
+    let heard = tokio::time::timeout(Duration::from_millis(700), async {
+        loop {
+            match p.b_rx.recv().await {
+                Some(SwarmEvent::Browse { .. }) => return true,
+                Some(_) => continue,
+                None => return false,
+            }
+        }
+    })
+    .await;
+    assert!(heard.is_err(), "its host is not asked to enforce what it already declared");
+}
+
 /// Streams go to subscribers and to nobody else.
 #[tokio::test]
 async fn a_stream_arrives_only_after_subscribing() {

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -39,6 +39,15 @@ use crate::vim;
 /// How long mutations accumulate before a frame is emitted.
 const COALESCE: Duration = Duration::from_millis(16);
 
+/// How often to check whether the other machines have been told something out of date.
+///
+/// Slow on purpose. What it carries is "which projects and conversations exist here", which moves
+/// when a person does something rather than when a token arrives, and two seconds of lag on
+/// somebody else's screen is not a thing anybody could notice. It also bounds the cost: the check
+/// is a recompute-and-compare, and doing it on the host loop's every iteration would put it on the
+/// token path.
+const ROSTER_INTERVAL: Duration = Duration::from_secs(2);
+
 /// The plugin id the host registers its own things under.
 ///
 /// Not a special case in the core: the built-in UI, commands, keymaps and options are all owned by
@@ -642,6 +651,16 @@ pub struct Host {
     swarm_node: Option<neosh_swarm::SwarmHandle>,
     /// Commands sent to peers that have not been answered yet, and who to settle when they are.
     swarm_pending: std::collections::HashMap<String, (PluginId, RequestId)>,
+    /// The last thing said to the peers about what is here, so a poll can say nothing when nothing
+    /// has changed. `None` until the first publish.
+    published: Option<(Vec<neosh_proto::AgentSummary>, Vec<neosh_proto::RemoteProject>)>,
+    /// Which of those are directory listings rather than commands.
+    ///
+    /// One waiting map for both, because a peer that goes away has to fail everything outstanding
+    /// and a second map would be a second place to remember to do it. This set is only consulted on
+    /// the way *back*: a refusal arrives as `Refused { id }` with nothing on it to say what it is
+    /// refusing, so the id is what says whether the answer is `Paths` or a started conversation.
+    swarm_browsing: std::collections::HashSet<String>,
     swarm_next_command: u64,
     /// Local conversations somebody on another machine is watching.
     ///
@@ -1093,6 +1112,8 @@ impl Host {
             swarm: Default::default(),
             swarm_node: None,
             swarm_pending: Default::default(),
+            published: None,
+            swarm_browsing: Default::default(),
             swarm_next_command: 0,
             swarm_watched: Default::default(),
             swarm_strangers: Default::default(),
@@ -1928,9 +1949,12 @@ impl Host {
             ApiCall::SwarmProbe { .. } => {
                 Err(ApiError::Internal { message: "swarm.probe is answered asynchronously".into() })
             }
-            // Taken over before dispatch, because its answer comes from another machine.
+            // Taken over before dispatch, because their answers come from another machine.
             ApiCall::SwarmCommand { .. } => Err(ApiError::Internal {
                 message: "swarm.command is answered asynchronously".into(),
+            }),
+            ApiCall::SwarmBrowse { .. } => Err(ApiError::Internal {
+                message: "swarm.browse is answered asynchronously".into(),
             }),
             // ---- events -------------------------------------------------
             // `from` is stamped here rather than taken from the call, so "who said this" is one of
@@ -3467,6 +3491,69 @@ impl Host {
         handle.send(neosh_swarm::SwarmRequest::Command { node, id, session, command });
     }
 
+    /// Ask a peer which of its directories start with `prefix`, and remember who is waiting.
+    ///
+    /// Shares [`Self::swarm_next_command`] with the command path so the two id spaces cannot
+    /// collide — which matters because a refusal comes back as a bare `Refused { id }` with nothing
+    /// on it to say which question it is refusing, and the id is the only thing that tells them
+    /// apart.
+    fn begin_swarm_browse(
+        &mut self,
+        node: neosh_proto::NodeId,
+        prefix: String,
+        waiting: (PluginId, RequestId),
+    ) {
+        // This machine, reached the way any other is. A picker walking `swarm.nodes()` finds its
+        // own node in the list, and asking ourselves over a socket would make a local directory
+        // listing depend on the swarm being up — and fail outright with `--clean`, which has
+        // nowhere to keep the key that is this machine's identity.
+        if self.swarm_self().is_some_and(|me| me.id == node) {
+            let svc = self.services(&PluginId::from(BUILTIN));
+            let bridge = self.bridge.clone();
+            let (plugin, id) = waiting;
+            tokio::spawn(async move {
+                let result = svc.path_complete(prefix).await;
+                let response: ApiResponse = result.into();
+                let _ = bridge.script().send(ScriptInbound::Plugin {
+                    plugin,
+                    msg: PluginInbound::Response { id, response },
+                });
+            });
+            return;
+        }
+        let Some(handle) = &self.swarm_node else {
+            self.answer_swarm(waiting, Err(ApiError::NotFound {
+                what: "the swarm is not running".into(),
+            }));
+            return;
+        };
+        self.swarm_next_command += 1;
+        let id = format!("b{}", self.swarm_next_command);
+        self.swarm_pending.insert(id.clone(), waiting);
+        self.swarm_browsing.insert(id.clone());
+        handle.send(neosh_swarm::SwarmRequest::Browse { node, id, prefix });
+    }
+
+    /// A peer asked which of our directories start with `prefix`. Answer exactly once, whatever
+    /// happens.
+    ///
+    /// Off the loop, because it is a `read_dir` and the loop is what draws. Directory names only —
+    /// the same listing the local completer produces, which never opens a file and never says
+    /// whether one is there.
+    fn run_swarm_browse(&mut self, node: neosh_proto::NodeId, id: String, prefix: String) {
+        let Some(handle) = self.swarm_node.as_ref() else { return };
+        let handle = handle.clone();
+        let svc = self.services(&PluginId::from(BUILTIN));
+        tokio::spawn(async move {
+            let result = match svc.path_complete(prefix).await {
+                Ok(ApiOk::Paths { paths }) => Ok(paths),
+                Ok(_) => Ok(Vec::new()),
+                Err(e) => Err(neosh_proto::Refusal::Failed { message: format!("{e:?}") }),
+            };
+            handle.send(neosh_swarm::SwarmRequest::Browsed { node, id, result });
+        });
+    }
+
     /// Find out what machine is at an address, off the loop.
     ///
     /// Given a short deadline of its own: the address came from somebody typing, and a wrong one is
@@ -3483,10 +3570,14 @@ impl Host {
             self.answer_swarm(waiting, Err(ApiError::NotFound { what: "no state directory".into() }));
             return;
         };
+        // A probe says hello and hangs up, so everything here is `false`: it is not offering to do
+        // anything for the machine it is asking about, and a capability it advertised would be one
+        // it is about to stop being able to honour.
         let caps = neosh_proto::NodeCapabilities {
             accepts_commands: false,
             accepts_approvals: false,
             streams: false,
+            browse: false,
             projects: Vec::new(),
         };
         let bridge = self.bridge.clone();
@@ -3580,23 +3671,85 @@ impl Host {
     /// The checkouts this machine can start something in, for a peer's "new conversation over
     /// there" menu.
     ///
-    /// Derived from where conversations already are rather than from a scan of the disk: a list of
-    /// every git repository on somebody's laptop is both slow to produce and more than a peer needs
-    /// to know.
-    fn local_projects(&self, agents: &[neosh_proto::AgentSummary]) -> Vec<neosh_proto::RemoteProject> {
+    /// Never a scan of the disk: a list of every git repository on somebody's laptop is slow to
+    /// produce and far more than a peer needs to know. It is the list this machine's own panel
+    /// shows — the places you work — which is two sources rather than one.
+    ///
+    /// The live conversations are the obvious half and were once the whole of it, which made the
+    /// answer wrong in a way that only showed up from the other machine: a project is a place you
+    /// work rather than a property of the work in it, so a repository you cleared out this morning
+    /// vanished from every other computer's "start something over there", and the checkout you have
+    /// had open for a month but are not mid-turn in was never on it at all. It also made
+    /// [`neosh_proto::RemoteProject::active`] a constant — everything on the list had a
+    /// conversation, so everything said `true`.
+    ///
+    /// So the other half is `sidebar.projects`, the workspace var that *is* the panel's list. Read
+    /// here for the same reason `question.asking` is: it is a fact about this workspace rather than
+    /// about whichever panel happened to write it down, which is what a var is for. A workspace
+    /// whose panel is switched off simply falls back to the conversations, which is what this
+    /// answered before.
+    fn local_projects(
+        &mut self,
+        agents: &[neosh_proto::AgentSummary],
+    ) -> Vec<neosh_proto::RemoteProject> {
         let mut out: Vec<neosh_proto::RemoteProject> = Vec::new();
         for a in agents {
-            if out.iter().any(|p| p.cwd == a.cwd) {
+            match out.iter_mut().find(|p| p.cwd == a.cwd) {
+                Some(p) => {
+                    p.sessions += 1;
+                    p.running += u32::from(a.state == neosh_proto::AgentState::Running);
+                }
+                None => out.push(neosh_proto::RemoteProject {
+                    key: a.project.clone(),
+                    name: a.project_name.clone(),
+                    cwd: a.cwd.clone(),
+                    active: true,
+                    sessions: 1,
+                    running: u32::from(a.state == neosh_proto::AgentState::Running),
+                }),
+            }
+        }
+
+        // And the quiet ones. `sidebar.name` is what the host called each directory when it last
+        // had something in it — a worktree's `neosh (fix/thing)` rather than its `wt-fe3c0d93` —
+        // so an emptied project keeps the name the other machine already knows it by.
+        let known: Vec<String> = serde_json::from_value(
+            self.vars.get(&neosh_proto::VarScope::Global, "sidebar.projects"),
+        )
+        .unwrap_or_default();
+        for cwd in known {
+            if out.iter().any(|p| p.cwd == cwd) {
                 continue;
             }
+            let path = std::path::Path::new(&cwd);
+            // Only somewhere that is still there. A project on the list whose directory has been
+            // deleted is a row on another machine that can only ever fail to open.
+            if !path.is_dir() {
+                continue;
+            }
+            let name = self
+                .vars
+                .get(&neosh_proto::VarScope::Project { cwd: cwd.clone() }, "sidebar.name")
+                .as_str()
+                .map(str::to_string)
+                .filter(|n| !n.is_empty())
+                .unwrap_or_else(|| {
+                    path.file_name().map(|n| n.to_string_lossy().into_owned()).unwrap_or_default()
+                });
             out.push(neosh_proto::RemoteProject {
-                key: a.project.clone(),
-                name: a.project_name.clone(),
-                cwd: a.cwd.clone(),
-                active: true,
+                key: self.project_key(path),
+                name,
+                cwd,
+                active: false,
+                sessions: 0,
+                running: 0,
             });
         }
-        out.sort_by(|a, b| a.name.cmp(&b.name));
+
+        // Somewhere being worked in first, and alphabetical inside that: the list is read by
+        // somebody looking for where to start something, and "there is already an agent in here"
+        // is the most useful thing a row can say about itself.
+        out.sort_by(|a, b| b.active.cmp(&a.active).then_with(|| a.name.cmp(&b.name)));
         out
     }
 
@@ -3612,10 +3765,30 @@ impl Host {
         }
         self.swarm.set_local_projects(keys);
         let projects = self.local_projects(&agents);
+        self.published = Some((agents.clone(), projects.clone()));
         if let Some(h) = &self.swarm_node {
             h.send(neosh_swarm::SwarmRequest::Publish { full: true, agents, gone: Vec::new() });
             h.send(neosh_swarm::SwarmRequest::Projects { projects });
         }
+    }
+
+    /// The same, but only when the answer has moved since the last time it was said.
+    ///
+    /// Called on a timer, so this is the comparison that keeps an idle workspace silent: two
+    /// vectors of small structs against the two that were last sent, and nothing on the wire when
+    /// they match. `AgentSummary` carries `updated_at` and `usage`, so a turn producing tokens
+    /// moves it and peers watching a board see the count climb — which is the point of a roster
+    /// rather than a snapshot.
+    fn publish_inventory_if_changed(&mut self) {
+        if self.swarm_node.is_none() {
+            return;
+        }
+        let agents = self.local_inventory();
+        let projects = self.local_projects(&agents);
+        if self.published.as_ref().is_some_and(|(a, p)| a == &agents && p == &projects) {
+            return;
+        }
+        self.publish_inventory();
     }
 
     /// One event from the swarm.
@@ -3669,6 +3842,7 @@ impl Host {
                 // Anything still waiting on that machine will never be answered by it.
                 let orphaned: Vec<String> = self.swarm_pending.keys().cloned().collect();
                 for id in orphaned {
+                    self.swarm_browsing.remove(&id);
                     if let Some(waiting) = self.swarm_pending.remove(&id) {
                         self.answer_swarm(waiting, Err(ApiError::NotFound {
                             what: format!("{name} went away before answering"),
@@ -3741,11 +3915,15 @@ impl Host {
                 self.broadcast(PluginEvent::SwarmChanged);
             }
             E::Answer { id, result, .. } => {
-                let (ok, message) = match result {
-                    Ok(_) => (true, String::new()),
-                    Err(r) => (false, refusal_text(&r)),
+                let (ok, message, session) = match result {
+                    Ok(session) => (true, String::new(), session),
+                    Err(r) => (false, refusal_text(&r), None),
                 };
-                self.on_swarm_reply(&id, ok, message);
+                self.on_swarm_reply(&id, ok, message, session);
+            }
+            E::Browse { node, id, prefix } => self.run_swarm_browse(node, id, prefix),
+            E::Browsed { id, result, .. } => {
+                self.on_swarm_browsed(&id, result.map_err(|r| refusal_text(&r)));
             }
             E::Subscribed { session, .. } => {
                 let fresh = self.swarm_watched.insert(session.clone());
@@ -3901,14 +4079,40 @@ impl Host {
     }
 
     /// Settle a command we sent, when the far end answers.
-    pub fn on_swarm_reply(&mut self, id: &str, ok: bool, message: String) {
+    ///
+    /// `session` is what a [`neosh_proto::AgentCommand::NewSession`] made, and is the whole of what
+    /// makes starting something on another machine reversible into looking at it: the far end knows
+    /// the id and says it, and until this carried it the caller could start a conversation over
+    /// there and then had nothing to open.
+    pub fn on_swarm_reply(
+        &mut self,
+        id: &str,
+        ok: bool,
+        message: String,
+        session: Option<neosh_proto::SessionId>,
+    ) {
         let Some(waiting) = self.swarm_pending.remove(id) else { return };
-        let result = if ok {
-            Ok(ApiOk::Unit)
-        } else {
+        let browsing = self.swarm_browsing.remove(id);
+        let result = if !ok {
             Err(ApiError::Denied { reason: message })
+        } else if browsing {
+            // A `Browsed` settles through `on_swarm_browsed`; reaching here with `ok` means the
+            // peer answered a directory listing with a bare `Ack`, which no version of it does.
+            Ok(ApiOk::Paths { paths: Vec::new() })
+        } else {
+            Ok(ApiOk::SwarmCommanded { session })
         };
         self.answer_swarm(waiting, result);
+    }
+
+    /// Settle a directory listing we asked a peer for.
+    pub fn on_swarm_browsed(&mut self, id: &str, result: Result<Vec<String>, String>) {
+        let Some(waiting) = self.swarm_pending.remove(id) else { return };
+        self.swarm_browsing.remove(id);
+        self.answer_swarm(waiting, match result {
+            Ok(paths) => Ok(ApiOk::Paths { paths }),
+            Err(reason) => Err(ApiError::Denied { reason }),
+        });
     }
 
     /// Act on an option the host itself owns. Everything else is a plugin's business.
@@ -4825,9 +5029,12 @@ impl Host {
             ApiCall::ChatAttach { path: None } => {
                 Some("there is no clipboard here — name a file: chat.attach with a path")
             }
-            ApiCall::SwarmProbe { .. } | ApiCall::SwarmCommand { .. } => Some(
+            ApiCall::SwarmProbe { .. }
+            | ApiCall::SwarmCommand { .. }
+            | ApiCall::SwarmBrowse { .. } => Some(
                 "the swarm is answered by the machine at the other end, which this connection has \
-                 no way to wait for. Use `agent.command` for a conversation on this machine",
+                 no way to wait for. Use `agent.command` for a conversation on this machine, and \
+                 `path.complete` for a directory on it",
             ),
             _ => None,
         };
@@ -8783,6 +8990,10 @@ impl Host {
             );
             return;
         }
+        if let ApiCall::SwarmBrowse { node, prefix } = &call {
+            self.begin_swarm_browse(node.clone(), prefix.clone(), (plugin.clone(), id.clone()));
+            return;
+        }
         if self.spawn_slow(&plugin, Some(id.clone()), &call) {
             return;
         }
@@ -9379,6 +9590,24 @@ impl Host {
         tokio::pin!(burst);
         let mut bursting = false;
 
+        // What the other machines are told this one has. A day away when there is no swarm, which
+        // is the shape every optional timer above has.
+        //
+        // A *timer* rather than a call at each of the places a conversation can change, because
+        // that list is long and was already wrong: the inventory was published when a peer
+        // connected and when a peer drove something here, and never once because somebody sitting
+        // at this machine started, renamed, archived or deleted a conversation. Every other
+        // computer's picture of this one was therefore a snapshot from whenever it last dialled —
+        // a project added an hour ago was invisible over there, with nothing to say why. Nothing
+        // goes on the wire unless the answer actually changed, so an idle workspace with peers is
+        // one comparison every two seconds and no traffic at all.
+        let roster = tokio::time::sleep(if self.swarm_node.is_some() {
+            ROSTER_INTERVAL
+        } else {
+            Duration::from_secs(86_400)
+        });
+        tokio::pin!(roster);
+
         loop {
             tokio::select! {
                 Some(out) = script_rx.recv() => self.handle_script_out(out).await,
@@ -9509,6 +9738,10 @@ impl Host {
                 () = &mut burst, if bursting => {
                     bursting = false;
                     self.deliver_alerts().await?;
+                }
+                () = &mut roster, if self.swarm_node.is_some() => {
+                    self.publish_inventory_if_changed();
+                    roster.as_mut().reset(Instant::now() + ROSTER_INTERVAL);
                 }
                 () = &mut plan => {
                     self.refresh_quota(None);

--- a/crates/neosh/src/swarm.rs
+++ b/crates/neosh/src/swarm.rs
@@ -93,6 +93,7 @@ impl Swarm {
                 accepts_commands: false,
                 accepts_approvals: false,
                 streams: false,
+                browse: true,
                 projects: Vec::new(),
             },
             agents: Vec::new(),
@@ -295,6 +296,7 @@ mod tests {
             accepts_commands: true,
             accepts_approvals: false,
             streams: true,
+            browse: true,
             projects: Vec::new(),
         }
     }

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -2273,6 +2273,63 @@ fn a_new_conversation_in_a_repository_offers_a_worktree() {
     );
 }
 
+/// Somewhere else sits above the worktrees, and says the field completes paths.
+///
+/// The list of trees is unbounded and the verb under it was therefore at a distance that grew with
+/// how long you had used the program: "I can't go down in the sidebar for it" is the same complaint
+/// one panel along. It is also the row that tells you the filter line *is* a path field, and a
+/// sentence about how to type is no use once you have scrolled past it looking for somewhere to
+/// type.
+#[test]
+fn somewhere_else_is_above_the_worktrees_rather_than_under_them() {
+    if !have_git() {
+        return;
+    }
+    let sb = Sandbox::new("newwhereorder");
+    sb.git_init();
+    let mut s = sb.start();
+    s.wait_for("PROJECTS");
+    s.ctrl("n");
+    assert!(s.pump(|s| !s.picker_named("[New conversation]").is_empty()), "the picker opened");
+
+    let rows = s.picker_named("[New conversation]");
+    let elsewhere = rows.iter().position(|l| l.contains("Another directory"));
+    let trees = rows.iter().position(|l| l.contains("worktree  ·  "));
+    assert!(elsewhere.is_some(), "somewhere else is offered\n{rows:?}");
+    // Only meaningful when there is a tree to be above; without one the row's position is not in
+    // question and asserting on it would be asserting on nothing.
+    if let (Some(e), Some(t)) = (elsewhere, trees) {
+        assert!(e < t, "somewhere else comes first\n{rows:?}");
+    }
+    assert!(
+        rows.iter().any(|l| l.contains("type a path")),
+        "and it says the field takes one\n{rows:?}"
+    );
+}
+
+/// `^O` lands in the path field, rather than in a menu with the path field at the bottom of it.
+///
+/// This used to be the current repository's worktrees with `Type a path…` under them — a list of
+/// the one place you were already in, which you had to read to the end of every time to reach the
+/// thing you almost always wanted. The row is first now, and it is a fallback rather than the
+/// route: typing a path is what the field does from the first keystroke.
+#[test]
+fn add_project_puts_the_path_first() {
+    let sb = Sandbox::new("addfirst");
+    let mut s = sb.start();
+    s.wait_for("PROJECTS");
+
+    s.send(&command("project.open"));
+    // The float, not the sidebar's `+ Add project` row — which is on screen from the start and
+    // would let this assert before anything opened.
+    assert!(s.pump(|s| !s.float_named("[Add project").is_empty()), "the field opened");
+
+    let rows = s.float_named("[Add project");
+    // The title, then the filter line, then the rows — so the first row is the third line.
+    let first = rows.iter().skip(2).find(|l| !l.trim().is_empty()).cloned().unwrap_or_default();
+    assert!(first.contains("Type a path"), "the path is the first row\n{rows:?}");
+}
+
 /// The trees it offers under "an existing one" are the ones on the panel's list, not every
 /// checkout `git worktree list` can see.
 ///

--- a/docs/ascp/SPEC.md
+++ b/docs/ascp/SPEC.md
@@ -144,6 +144,7 @@ is an accident of who booted first.
 | `Presence` | one per node per heartbeat | always |
 | `Inventory` | one per change | always |
 | `Command` / `Ack` / `Refused` | one per meaningful keystroke | on demand |
+| `Browse` / `Browsed` / `Refused` | one per keystroke in a directory field | on demand |
 | `Subscribe` / `Stream` | **one per token** | only while subscribed |
 
 That last row is the whole performance argument. Twenty machines streaming every token to everyone
@@ -193,6 +194,28 @@ must be able to say no to — hence `NodeCapabilities::accepts_approvals`, separ
 Capabilities are advisory **to the caller** — they let a board grey out a verb rather than offering
 one that will be refused. The owner enforces regardless, because a capability list is something the
 other side could have lied about.
+
+### Browse
+
+`Browse { id, prefix }` asks which directories on that node start with `prefix`; `Browsed { id,
+paths }` answers, or `Refused` does. Exactly once, like every request here. Each path comes back as
+the asker would have typed it — trailing separator and all — so it can go straight into a field.
+**Directory names only**: never files, never contents, never anything a `read_dir` cannot answer.
+
+`NodeCapabilities::projects` is what a node *offers* and is a short list of places it already works
+in. This is the other half, and without it the only way to reach a fourth directory over there is to
+type its path from memory and find out it was wrong when the conversation fails to start.
+
+Gated on `accepts_commands`, and deliberately **not** on a permission of its own. A node that
+accepts commands already accepts `NewSession` with an arbitrary `cwd` — it will start an agent
+anywhere on its disk you name — so declining to say which directories exist would withhold strictly
+less than it has already given away, at the cost of a third permission for people to reason about.
+
+`NodeCapabilities::browse` is a *compatibility* flag rather than a permission, and it is the reason
+this could be added without a version bump. An unknown message tag fails the frame and fails the
+connection with it, so a node built before `Browse` existed cannot simply ignore one — a caller must
+therefore check the flag before sending. It defaults to `false`, which is exactly what an older
+node's handshake decodes to, so "does not say" and "cannot" are the same answer.
 
 ### Stream
 
@@ -247,9 +270,13 @@ An implementation is ASCP-0 conformant if it:
 6. Never acts on a command it did not authorise, whatever it advertised in `NodeCapabilities`.
 7. Sends a full `Inventory` on connect.
 8. Sends `Stream` only for sessions the peer has subscribed to.
+9. Answers every `Browse` exactly once with `Browsed` or `Refused`, and answers none at all unless
+   it accepts commands.
+10. Sends `Browse` only to a peer whose handshake said `browse: true`.
 
-Points 1, 2 and 6 are the security-relevant ones. An implementation failing any of them is not a
-degraded ASCP node; it is an open door.
+Points 1, 2, 6 and 9 are the security-relevant ones. An implementation failing any of them is not a
+degraded ASCP node; it is an open door. Point 10 is the compatibility one: a peer that has never
+heard of the message will drop the connection rather than skip the frame.
 
 ---
 

--- a/docs/ascp/vectors/01-hello.json
+++ b/docs/ascp/vectors/01-hello.json
@@ -2,12 +2,15 @@
   "capabilities": {
     "accepts_approvals": false,
     "accepts_commands": true,
+    "browse": true,
     "projects": [
       {
         "active": true,
         "cwd": "/home/me/src/neosh",
         "key": "git:github.com/neoswarm/neosh",
-        "name": "neosh"
+        "name": "neosh",
+        "running": 1,
+        "sessions": 2
       }
     ],
     "streams": true

--- a/docs/ascp/vectors/02-welcome.json
+++ b/docs/ascp/vectors/02-welcome.json
@@ -2,12 +2,15 @@
   "capabilities": {
     "accepts_approvals": false,
     "accepts_commands": true,
+    "browse": true,
     "projects": [
       {
         "active": true,
         "cwd": "/home/me/src/neosh",
         "key": "git:github.com/neoswarm/neosh",
-        "name": "neosh"
+        "name": "neosh",
+        "running": 1,
+        "sessions": 2
       }
     ],
     "streams": true

--- a/docs/ascp/vectors/04-presence.json
+++ b/docs/ascp/vectors/04-presence.json
@@ -2,12 +2,15 @@
   "capabilities": {
     "accepts_approvals": false,
     "accepts_commands": true,
+    "browse": true,
     "projects": [
       {
         "active": true,
         "cwd": "/home/me/src/neosh",
         "key": "git:github.com/neoswarm/neosh",
-        "name": "neosh"
+        "name": "neosh",
+        "running": 1,
+        "sessions": 2
       }
     ],
     "streams": true

--- a/docs/ascp/vectors/13-browse.json
+++ b/docs/ascp/vectors/13-browse.json
@@ -1,0 +1,5 @@
+{
+  "id": "b1",
+  "prefix": "/home/me/src/",
+  "type": "browse"
+}

--- a/docs/ascp/vectors/14-browsed.json
+++ b/docs/ascp/vectors/14-browsed.json
@@ -1,0 +1,8 @@
+{
+  "id": "b1",
+  "paths": [
+    "/home/me/src/neosh/",
+    "/home/me/src/dotfiles/"
+  ],
+  "type": "browsed"
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -514,8 +514,13 @@ Projects are matched by normalised git remote, not by path — `/Users/me/dev/ne
 the other over HTTPS. A directory with no remote falls back to its name, which is a guess and shown
 as one.
 
-`^N` offers the other machines' checkouts alongside your worktrees, so "start something over there"
-is one key.
+`^N` and `^O` offer the other machines alongside your own worktrees, so "start something over there"
+is one key — and the field completes paths on whichever machine you point it at. See
+[Adding a project](#adding-a-project).
+
+What a machine advertises is the list *its* panel shows, refreshed as it changes rather than fixed
+at the moment you connected — so a project added over there appears here within a couple of seconds,
+and one you cleared out but did not remove is still somewhere you can start something.
 
 `↵` on a remote conversation **opens it**: its history, then everything as it happens. `i` says
 something to it and `^C` asks its turn to stop — because "it feels like it is on this computer" is a
@@ -527,15 +532,39 @@ The protocol is specified in [ascp/SPEC.md](ascp/SPEC.md).
 
 ### Adding a project
 
-`^O` anywhere, `o` in the project panel, or `Enter` on the `+ Add project` row. It offers the
-worktrees of the repository you are in that are not open yet, and drops through to a path field for
-anything else. It is the `project.open` command, so `^K` finds it and `<leader>pa` can be it.
+`^O` anywhere, `o` in the project panel, or `Enter` on the `+ Add project` row. It is the
+`project.open` command, so `^K` finds it and `<leader>pa` can be it.
 
-The path field completes as you type: the list under it is the directories matching what you have
-so far. `<Tab>` takes the highlighted one into the field so you can keep descending, `<C-w>` goes
-back up a whole segment rather than a character, and `<CR>` accepts either the highlighted row or
-exactly what you typed — because the directory you want may not be one it offered. `~` expands, and
-a path with no `/` completes against the conversation's own directory.
+**The filter line is the path field.** There is no row to reach first and no mode to enter: start
+typing `/`, `~` or `./` and the list under it becomes the directories that match. `<Tab>` takes the
+highlighted one into the field so you can keep descending, `<C-w>` goes back up a whole segment
+rather than a character, and `<CR>` accepts either the highlighted row or exactly what you typed —
+because the directory you want may not be one it offered. `~` expands, and a path with no `/`
+completes against the conversation's own directory.
+
+Underneath, as suggestions rather than a menu: `Type a path…` first, then the worktrees of the
+repository you are in that are not open yet, then every computer you have paired.
+
+#### On another computer
+
+Type `linux-box:` and the same field completes directories **over there** — scp's spelling, meaning
+what it means there. With nothing after the colon it lists what that machine offers: the projects it
+works in, filled where somebody has a conversation open and hollow where nobody has, with the counts
+beside them. Keep typing and it is an ordinary directory listing of that machine's disk, one segment
+at a time, `<Tab>` and all.
+
+`<CR>` starts the conversation **there** — the agent runs on that machine, against that machine's
+files — and opens a window onto it here.
+
+Every paired machine is a row whether or not it can be used. One that has not allowed this computer
+yet, or that is disconnected, or that is read-only, says which; `<CR>` on it repeats the reason
+rather than opening an empty list. `^N` asks the same question with the same field, alongside
+`Here` and the worktree options.
+
+Listing a machine's directories follows `accepts_commands`: a machine that will start an agent
+anywhere you name has already given away more than the names of its directories, so there is no
+separate setting. Directory names only — never files, never contents. A machine running a neosh
+older than this says so rather than dropping the connection.
 
 ### Confirmations
 

--- a/plugins/api/src/generated/ApiCall.ts
+++ b/plugins/api/src/generated/ApiCall.ts
@@ -370,6 +370,7 @@ export type ApiCall =
   | { "call": "swarm_reconnect"; node: NodeId }
   | { "call": "swarm_disconnect"; node: NodeId }
   | { "call": "swarm_strangers" }
+  | { "call": "swarm_browse"; node: NodeId; prefix: string }
   | { "call": "quota_list" }
   | { "call": "quota_refresh"; instance?: InstanceId | null }
   | { "call": "quota_report"; snapshot: QuotaSnapshot }

--- a/plugins/api/src/generated/ApiOk.ts
+++ b/plugins/api/src/generated/ApiOk.ts
@@ -107,6 +107,7 @@ export type ApiOk =
   | { "ok": "swarm_nodes"; nodes: Array<SwarmNode> }
   | { "ok": "swarm_agents"; agents: Array<SwarmAgent> }
   | { "ok": "swarm_strangers"; strangers: Array<SwarmStranger> }
+  | { "ok": "swarm_commanded"; session?: SessionId | null }
   | { "ok": "quotas"; quotas: Array<QuotaSnapshot> }
   | { "ok": "quota_history"; samples: Array<QuotaSample> }
   | { "ok": "usage_history"; history: UsageHistory }

--- a/plugins/api/src/generated/AscpMessage.ts
+++ b/plugins/api/src/generated/AscpMessage.ts
@@ -70,4 +70,6 @@ export type AscpMessage =
     session?: SessionId | null;
   }
   | { "type": "refused"; id: string; refusal: Refusal }
+  | { "type": "browse"; id: string; prefix: string }
+  | { "type": "browsed"; id: string; paths: Array<string> }
   | { "type": "goodbye"; message?: string | null };

--- a/plugins/api/src/generated/NodeCapabilities.ts
+++ b/plugins/api/src/generated/NodeCapabilities.ts
@@ -24,6 +24,17 @@ export type NodeCapabilities = {
    */
   streams: boolean;
   /**
+   * Whether [`AscpMessage::Browse`] will be answered.
+   *
+   * Not a permission — it follows `accepts_commands`, for the reason written on `Browse` — but a
+   * *compatibility* flag, and that is why it is here rather than derived. A node built before
+   * `Browse` existed cannot skip a message it has never heard of: the frame parses or the
+   * connection fails, so a new node that sent one on spec would drop an old peer's link every
+   * time somebody opened a directory picker. It defaults to `false`, which is exactly what an
+   * older node's handshake decodes to, so "does not say" and "cannot" are the same answer.
+   */
+  browse: boolean;
+  /**
    * The checkouts this node has, for starting something on it.
    */
   projects: Array<RemoteProject>;

--- a/plugins/api/src/generated/RemoteProject.ts
+++ b/plugins/api/src/generated/RemoteProject.ts
@@ -14,6 +14,24 @@ export type RemoteProject = {
   cwd: string;
   /**
    * Whether this node has a conversation open in it now.
+   *
+   * Meant something for exactly as long as this list was derived from live conversations: every
+   * project on it had one, so every one of them said `true` and a board drawing the flag drew
+   * one colour. A node now advertises the places it *works in* — which is the list its own panel
+   * shows, and includes the project you cleared out this morning — so the two states exist and
+   * the flag is worth reading.
    */
   active: boolean;
+  /**
+   * How many conversations are open in it there.
+   */
+  sessions: number;
+  /**
+   * How many of those are mid-turn.
+   *
+   * Separate from `sessions` because they are different questions and a board answers both in
+   * one row: `3 conversations · 1 working` is what the sidebar says about a local project, and a
+   * remote one should not have to say less.
+   */
+  running: number;
 };

--- a/plugins/api/src/index.ts
+++ b/plugins/api/src/index.ts
@@ -1612,8 +1612,29 @@ export interface SwarmApi {
    * with the owner's reason when it says no. A node may refuse anything; `NodeCapabilities` on its
    * {@link SwarmNode} says in advance what it is likely to accept, so a menu can grey out a verb
    * rather than offering one that will bounce.
+   *
+   * Answers with the conversation a `new_session` created, and `null` for everything else — which
+   * is what makes starting something over there a place you can then go: pass it to
+   * {@link subscribe}, or to `swarm.open`, without waiting for the next inventory to notice it.
    */
-  command(node: NodeId, session: string, command: AgentCommand): Promise<void>;
+  command(node: NodeId, session: string, command: AgentCommand): Promise<string | null>;
+  /**
+   * Which directories on another machine start with `prefix` — `path.complete`, asked over there.
+   *
+   * The same answers in the same shape as the local one: each entry as you would have typed it,
+   * trailing separator and all, so a single field can complete against either machine and the only
+   * thing that changes is which one is asked. Directory names only.
+   *
+   * {@link NodeCapabilities.projects} is what a machine *offers*, and it is the short list of
+   * places it already works in; this is how you reach the directory over there that neither machine
+   * has ever opened. Rejects when the peer is not connected, when it does not accept commands, and
+   * when it is running a neosh too old to have heard of the question — the message says which, and
+   * an empty list is a directory with nothing in it rather than a failure.
+   *
+   * Passing this machine's own node id answers locally, so a picker that walks `nodes()` needs no
+   * special case for the row that is itself.
+   */
+  browse(node: NodeId, prefix?: string): Promise<string[]>;
   /**
    * Watch a remote conversation: its history now, then everything as it happens, delivered to
    * {@link onStream}.
@@ -2080,7 +2101,13 @@ function build(
         return expect(await c({ call: "swarm_hosts_of", project }), "names").names;
       },
       async command(node, session, command) {
-        await c({ call: "swarm_command", node, session, command });
+        const done = await c({ call: "swarm_command", node, session, command });
+        // Only `new_session` says anything, so an `ok` of any other shape is an older peer
+        // answering a command that had nothing to report — which is a success, not a mismatch.
+        return done.ok === "swarm_commanded" ? done.session ?? null : null;
+      },
+      async browse(node, prefix) {
+        return expect(await c({ call: "swarm_browse", node, prefix: prefix ?? "" }), "paths").paths;
       },
       async subscribe(node, session) {
         await c({ call: "swarm_subscribe", node, session });

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -66,7 +66,9 @@ import {
   badgeWidth as badgeColumns,
   decorateRow,
   elapsed,
+  fuzzy,
   type ListRow,
+  type Match,
   mergeDecorations,
   placeSections,
   type SectionItem,
@@ -1635,15 +1637,6 @@ async function newConversation(
     return;
   }
 
-  type Where =
-    | { kind: "here" }
-    | { kind: "scratch" }
-    | { kind: "inside" }
-    | { kind: "new" }
-    | { kind: "elsewhere" }
-    | { kind: "tree"; path: string; label: string }
-    /** On another computer, in a checkout that machine told us it has. */
-    | { kind: "host"; node: string; cwd: string; label: string };
   const rows: Array<PickerItem<Where>> = [
     {
       label: "Here",
@@ -1694,6 +1687,12 @@ async function newConversation(
       value: { kind: "new" },
     });
   }
+  // Somewhere else, before the list of trees rather than after it. Not because it is the commonest
+  // answer — it is not — but because the list above it is unbounded, and a verb that sits under an
+  // unbounded list is a verb whose distance from the cursor depends on how long you have used the
+  // program. It is also the row that says the field completes paths, and a sentence about how to
+  // type is no use once you have already scrolled past it looking for somewhere to type.
+  rows.push(elsewhereRow("Another directory…"));
   for (const t of others) {
     const label = t.branch ?? t.head ?? t.path;
     rows.push({
@@ -1705,38 +1704,8 @@ async function newConversation(
       value: { kind: "tree", path: t.path, label },
     });
   }
-  // The other computers, and the checkouts each of them offered in its handshake. A machine that
-  // does not accept commands is left out rather than shown and refused — a row that cannot work is
-  // worse than no row.
-  for (const n of await neosh.swarm.nodes().catch(() => [])) {
-    if (!n.up || !n.capabilities.accepts_commands) continue;
-    for (const project of n.capabilities.projects) {
-      rows.push({
-        label: `${project.name}`,
-        detail: `on ${n.info.name}  ·  ${project.cwd}`,
-        keywords: `${n.info.name} ${project.cwd} remote host computer`,
-        icon: "→",
-        hl: "Sidebar.Remote",
-        value: {
-          kind: "host",
-          node: n.info.id,
-          cwd: project.cwd,
-          label: `${project.name} on ${n.info.name}`,
-        },
-      });
-    }
-  }
 
-  rows.push({
-    label: "Another directory…",
-    detail: "somewhere else entirely",
-    keywords: "project folder",
-    icon: "…",
-    hl: "Sidebar.Dim",
-    value: { kind: "elsewhere" },
-  });
-
-  const chosen = await picker(neosh, rows, { title: "New conversation", width: 76 });
+  const chosen = await whereTo(neosh, rows, { title: "New conversation" });
   if (chosen === null) return;
   // Every row below that reaches for git names the repository it is about. `^N` from a
   // conversation and `n` from a row on a different project are the same code path, and the only
@@ -1766,21 +1735,361 @@ async function newConversation(
       await neosh.session.create({ cwd: chosen.path });
       return;
     case "host":
-      // Started *there*. The agent will run on that machine, against that machine's files, which
-      // is the point — this is not a way to work on a remote directory from here.
+      await startThere(neosh, chosen);
+      return;
+    case "elsewhere": {
+      const path = chosen.path ?? (await pathPicker(neosh, "New conversation"));
+      if (path === null || path.trim() === "") return;
       try {
-        await neosh.swarm.command(chosen.node, "", {
-          command: "new_session",
-          cwd: chosen.cwd,
-          title: null,
-        });
-        neosh.notify(`started ${chosen.label}`);
+        await neosh.session.create({ cwd: path.trim() });
       } catch (e) {
         neosh.notify(String(e), "warn");
       }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Where — one field for every answer to "which directory, on which computer"
+// ---------------------------------------------------------------------------
+
+/**
+ * Every answer `^N` and `^O` accept.
+ *
+ * `elsewhere` carries its path when the field already produced one, and leaves it off when the row
+ * was chosen from the menu — the difference between "you typed a directory" and "you asked to be
+ * asked for one".
+ */
+type Where =
+  | { kind: "here" }
+  | { kind: "scratch" }
+  | { kind: "inside" }
+  | { kind: "new" }
+  | { kind: "elsewhere"; path?: string }
+  | { kind: "tree"; path: string; label: string }
+  /** On another computer, in one of its directories. */
+  | { kind: "host"; node: string; cwd: string; label: string }
+  /** Look at one machine's directories rather than every machine's projects. */
+  | { kind: "machine"; node: string; name: string }
+  /** A machine that is on the list and cannot be used yet. `↵` says which of those it is. */
+  | { kind: "unreachable"; name: string; why: string };
+
+/** The row that drops through to a path, wherever a caller wants it in the order. */
+function elsewhereRow(label: string): PickerItem<Where> {
+  return {
+    label,
+    // What the field does, said on the row that is about the field. The alternative was a hint
+    // strip nobody reads until they already know what they are looking for.
+    detail: "or type a path — `/`, `~` and `./` complete as you go",
+    keywords: "path folder directory type browse elsewhere",
+    icon: "…",
+    hl: "Sidebar.Dim",
+    value: { kind: "elsewhere" },
+  };
+}
+
+/**
+ * What the field is completing against, read off what has been typed.
+ *
+ * Three states and one field, because the alternative is a mode — and a mode is a thing you have to
+ * be in before you can type, which is the entire complaint this replaced. A path is a path the
+ * moment it starts like one; `<machine>:` is scp's syntax and means there what it means here, which
+ * is the only reason it is worth having a syntax at all.
+ */
+type Field =
+  | { kind: "rows" }
+  | { kind: "local"; path: string }
+  | { kind: "remote"; node: SwarmNode; path: string };
+
+/** Whether a query has started to look like a path rather than a search. */
+function looksLikePath(q: string): boolean {
+  return q.startsWith("/") || q.startsWith("~") || q.startsWith("./") || q.startsWith("../");
+}
+
+/**
+ * Split `linux-box:/home/me/src` into the machine and the path.
+ *
+ * Matched on what the machine is *called here* — the alias if you set one, since that is the name
+ * every panel shows and therefore the only one you could have read off the screen — and on the
+ * start of its id, which is what you have when two machines share a name. A colon in a query that
+ * names no machine is not a host prefix: it is a directory with a colon in it, which is legal on
+ * every filesystem this runs on.
+ */
+function readField(query: string, nodes: SwarmNode[]): Field {
+  const at = query.indexOf(":");
+  if (at > 0) {
+    const who = query.slice(0, at).toLowerCase();
+    const node = nodes.find((n) =>
+      n.info.name.toLowerCase() === who || n.info.id.toLowerCase().startsWith(who)
+    );
+    if (node) return { kind: "remote", node, path: query.slice(at + 1) };
+  }
+  return looksLikePath(query) ? { kind: "local", path: query } : { kind: "rows" };
+}
+
+/** How a machine's rows are prefixed, and what `<Tab>` puts back in the field. */
+function hostPrefix(node: SwarmNode): string {
+  // The name, unless it has a colon or a space in it — in which case the id is the only thing that
+  // round-trips through a field whose separator is a colon.
+  return /[:\s]/.test(node.info.name) ? node.info.id.slice(0, 8) : node.info.name;
+}
+
+/**
+ * The machines, as rows you can go into.
+ *
+ * Every paired machine, including the ones that cannot be used — greyed, with the reason on them.
+ * The list used to skip anything not `up` and not accepting commands, which is right about what can
+ * be *done* and wrong about what should be *said*: somebody who has just paired a computer and is
+ * looking for it finds an empty list and nothing anywhere to explain it, which reads as the feature
+ * not existing rather than as the machine not being ready.
+ */
+function machineRows(nodes: SwarmNode[], ascii: boolean): PickerItem<Where>[] {
+  const out: PickerItem<Where>[] = [];
+  for (const n of nodes) {
+    const usable = n.up && n.capabilities.accepts_commands;
+    const projects = n.capabilities.projects;
+    const conversations = projects.reduce((sum, p) => sum + p.sessions, 0);
+    const working = projects.reduce((sum, p) => sum + p.running, 0);
+    const state = n.link.state === "up"
+      ? [
+        `${projects.length} ${projects.length === 1 ? "project" : "projects"}`,
+        conversations > 0 ? `${conversations} open` : "",
+        working > 0 ? `${working} working` : "",
+        n.capabilities.accepts_commands ? "" : "read-only — nothing can be started there",
+      ].filter(Boolean).join("  ·  ")
+      : n.link.state === "waiting"
+        ? "has not allowed this computer yet — ^J there"
+        : n.link.state === "down"
+          ? "disconnected — ^J to reconnect"
+          : "connecting…";
+    const [icon, hl] = n.link.state === "up"
+      ? usable ? [ascii ? "*" : "●", "Diagnostic.Ok"] : [ascii ? "-" : "◐", "Sidebar.Dim"]
+      : n.link.state === "waiting"
+        ? [ascii ? "!" : "◍", pulseHl("Status.Pending")]
+        : n.link.state === "down"
+          ? [ascii ? "-" : "○", "Sidebar.Dim"]
+          : [spinnerFrame(), "Status.Streaming"];
+    out.push({
+      label: n.info.name,
+      // The prefix on every row, so the syntax is learned by reading rather than by being told.
+      detail: `${state}   ${hostPrefix(n)}:`,
+      keywords: `${n.info.id} ${n.info.os} computer machine remote host ${hostPrefix(n)}`,
+      icon,
+      hl,
+      value: usable
+        ? { kind: "machine", node: n.info.id, name: hostPrefix(n) }
+        // Nothing to go into, so `↵` says why rather than opening an empty list — and stays here,
+        // because being told a machine is not ready is not a reason to lose the list you were in.
+        : { kind: "unreachable", name: n.info.name, why: state },
+    });
+  }
+  return out;
+}
+
+/** One machine's directories, once you are inside it. */
+function projectRows(node: SwarmNode, ascii: boolean): PickerItem<Where>[] {
+  const prefix = hostPrefix(node);
+  return node.capabilities.projects.map((p) => ({
+    // The prefixed path, because `<Tab>` puts a row's *label* back in the field and a bare name
+    // would take the field somewhere that is not a directory on any machine.
+    label: `${prefix}:${p.cwd}`,
+    detail: [
+      p.name,
+      p.sessions > 0
+        ? `${p.sessions} ${p.sessions === 1 ? "conversation" : "conversations"}`
+        : "nothing open",
+      p.running > 0 ? `${p.running} working` : "",
+    ].filter(Boolean).join("  ·  "),
+    keywords: `${p.name} ${p.key} remote`,
+    // Filled when somebody is working in it, hollow when nobody is. The one thing the flag could
+    // not say while every project on the list was one with a conversation in it.
+    icon: p.active ? (ascii ? "*" : "●") : (ascii ? "-" : "○"),
+    hl: p.active ? "Diagnostic.Ok" : "Sidebar.Dim",
+    value: {
+      kind: "host" as const,
+      node: node.info.id,
+      cwd: p.cwd,
+      label: `${p.name} on ${node.info.name}`,
+    },
+  }));
+}
+
+/**
+ * The one question both `^N` and `^O` ask: which directory, on which computer.
+ *
+ * A picker whose filter line **is** the field. Type nothing and it is the menu the caller passed;
+ * type `/`, `~` or `./` and it is a directory completer; type `linux-box:` and it is a directory
+ * completer pointed at that machine. Nothing has to be navigated to first, which was the whole
+ * complaint: the path was a row at the bottom of a list, under an unbounded number of worktrees,
+ * and reaching it meant arrowing past everything the program had ever been told about.
+ *
+ * `<Tab>` walks into the highlighted directory and `↵` takes it, which is `pathPicker`'s bargain
+ * and is why a completion row's label has to be the whole path.
+ *
+ * Choosing a machine reopens this seeded with `<machine>:` rather than descending in place: the
+ * picker owns its own filter line, and a second level whose rows lie about what is in the field is
+ * a `<Tab>` that jumps somewhere nobody asked for.
+ */
+async function whereTo(
+  neosh: Neosh,
+  base: PickerItem<Where>[],
+  opts: { title: string; seed?: string },
+): Promise<Where | null> {
+  const ascii = (await neosh.opt.get<boolean>("ui.ascii_only").catch(() => false)) ?? false;
+  let seed = opts.seed ?? "";
+
+  /**
+   * The machines, and the rows built from them. Reread rather than captured, because the list is
+   * live: a peer connecting, or gaining a project, while this is open has to change the rows under
+   * the cursor. Captured once, `subscribe` would re-rank the same stale array for ever and the
+   * subscription would be a promise the picker was not keeping.
+   */
+  let nodes: SwarmNode[] = [];
+  // Mutated in place, never reassigned: `reload` re-ranks the very array the picker was handed,
+  // so a fresh array here would be a list that never caught up with anything.
+  const rows: PickerItem<Where>[] = [];
+  const refill = async () => {
+    const me = (await neosh.swarm.self().catch(() => null))?.id ?? null;
+    // This machine is in `nodes()` like any other — a fleet plugin walking the list reaches its
+    // own node, which is deliberate — and it is the one row that must not be here: every other row
+    // in this picker already means "on this computer", and `mymac:/tmp` would otherwise start a
+    // local conversation by the remote path and then try to *watch* it over a socket to ourselves.
+    nodes = (await neosh.swarm.nodes().catch(() => [] as SwarmNode[]))
+      .filter((n) => n.info.id !== me);
+    // No `Add a computer…` row, deliberately. The swarm is on by default, so on every
+    // single-machine workspace — which is most of them — that row would be a permanent line in a
+    // menu pressed many times a day, about a thing its reader is not doing. It is the archive-count
+    // argument one panel along. This picker lists the computers you *have*; getting one is `^J`,
+    // which has a key of its own and a line in the legend.
+    const machines = machineRows(nodes, ascii);
+    rows.splice(0, rows.length, ...base, ...machines);
+    return machines.length > 0;
+  };
+
+  for (;;) {
+    const anyMachines = await refill();
+
+    const chosen = await picker<Where>(neosh, rows, {
+      title: opts.title,
+      width: 84,
+      height: 14,
+      query: seed,
+      placeholder: "nothing matches — <CR> takes the path you typed",
+      hints: anyMachines
+        ? "↵ choose   ⇥ into a directory   / a path   name: another computer"
+        : "↵ choose   ⇥ into a directory   / or ~ for a path",
+      source: async (query) => {
+        const field = readField(query, nodes);
+        if (field.kind === "rows") {
+          // Our own ranking, because a `source` replaces the picker's filtering wholesale. Same
+          // fuzzy scorer the picker uses, over the same label-and-keywords, so a query that is not
+          // a path behaves exactly as it would with no source at all.
+          if (query.trim() === "") return rows;
+          return rows
+            .map((item) => ({ item, m: fuzzy(`${item.label} ${item.keywords ?? ""}`, query) }))
+            .filter((r): r is { item: PickerItem<Where>; m: Match } => r.m !== null)
+            .sort((a, b) => b.m.score - a.m.score)
+            .map((r) => r.item);
+        }
+        if (field.kind === "local") {
+          const paths = await neosh.path.complete(field.path).catch(() => []);
+          return paths.map((path) => ({
+            label: path,
+            icon: ascii ? ">" : "▸",
+            hl: "Sidebar.Dim",
+            value: { kind: "elsewhere" as const, path },
+          }));
+        }
+        const prefix = hostPrefix(field.node);
+        // Nothing typed after the colon: what that machine offers, which is a short list of real
+        // places rather than the contents of `/`. Typing on turns it into a directory listing.
+        //
+        // A machine with nothing on that list falls through to its home directory rather than
+        // showing an empty one — a computer you have just paired has never had a project on it,
+        // and "no rows" is the answer least likely to be read as "and here is where to start".
+        const offered = field.path === "" ? projectRows(field.node, ascii) : [];
+        if (offered.length > 0) return offered;
+        const paths = await neosh.swarm
+          .browse(field.node.info.id, field.path === "" ? "~/" : field.path)
+          .catch((e) => {
+            // A peer that went away mid-keystroke, or one too old to answer. Said out loud rather
+            // than drawn as an empty directory, which is the one reading that is never true.
+            neosh.notify(String(e), "warn");
+            return [] as string[];
+          });
+        return paths.map((path) => ({
+          label: `${prefix}:${path}`,
+          detail: field.node.info.name,
+          icon: ascii ? ">" : "▸",
+          hl: "Sidebar.Remote",
+          value: {
+            kind: "host" as const,
+            node: field.node.info.id,
+            cwd: path,
+            label: `${path} on ${field.node.info.name}`,
+          },
+        }));
+      },
+      // What `↵` means when the field holds something no row offered — which for a directory you
+      // know the name of is the ordinary case, not the exception.
+      freeform: (query) => {
+        const field = readField(query, nodes);
+        if (field.kind === "local") return { kind: "elsewhere", path: query.trim() };
+        if (field.kind === "remote" && field.path.trim() !== "") {
+          return {
+            kind: "host",
+            node: field.node.info.id,
+            cwd: field.path.trim(),
+            label: `${field.path.trim()} on ${field.node.info.name}`,
+          };
+        }
+        return null;
+      },
+      // A machine connecting, or gaining a project, while the list is open. Same reason the
+      // computers panel subscribes: a row that only changes on the next press is a row that was
+      // wrong when it was read. `refill` first, or the reload re-ranks the same stale array.
+      subscribe: (reload) => neosh.swarm.onChange(() => void refill().then(reload)),
+    });
+
+    if (chosen === null) return null;
+    if (chosen.kind === "machine") {
+      // Back into the same picker with the machine's prefix already typed, which is exactly the
+      // state somebody would have reached by typing it — so the two routes cannot diverge.
+      seed = `${chosen.name}:`;
+      continue;
+    }
+    if (chosen.kind === "unreachable") {
+      neosh.notify(`${chosen.name}: ${chosen.why}`, "info");
+      seed = "";
+      continue;
+    }
+    return chosen;
+  }
+}
+
+/** Start a conversation on another machine, and go and look at it. */
+async function startThere(
+  neosh: Neosh,
+  chosen: { node: string; cwd: string; label: string },
+): Promise<void> {
+  // Started *there*. The agent runs on that machine, against that machine's files, which is the
+  // point — this is not a way to work on a remote directory from here.
+  try {
+    const session = await neosh.swarm.command(chosen.node, "", {
+      command: "new_session",
+      cwd: chosen.cwd,
+      title: null,
+    });
+    // Opened, not merely reported. Starting a conversation here switches to it, and one started
+    // over there that only produced a toast was the same key doing visibly less for the same
+    // intention — you had to go and find, in `^J`, the thing you had just made.
+    if (session) {
+      await neosh.cmd.exec("swarm.open", [chosen.node, session]).catch(() => {});
       return;
-    case "elsewhere":
-      await neosh.cmd.exec("project.open").catch(() => {});
+    }
+    neosh.notify(`started ${chosen.label}`);
+  } catch (e) {
+    neosh.notify(String(e), "warn");
   }
 }
 
@@ -1844,12 +2153,22 @@ function owningProject(target: Target | undefined): string | null {
 }
 
 /**
- * Which directory to add.
+ * Which directory to add — here, or on another computer.
  *
- * Offers the worktrees of the repository you are in before asking you to type, because that is
- * where the next project usually is and a path typed from memory is a path typed wrong. The
- * runtime has no filesystem, so there is no directory browser to offer — the last entry drops
- * through to a text field, which the host validates.
+ * **The path is the first thing now, not the last.** This was a list of the current repository's
+ * worktrees with `Type a path…` under it, and a path is what somebody pressing this key almost
+ * always has: the row they wanted sat at the bottom of a list they had to read to the end of every
+ * time, and the list was of the one place they were already in. So the filter line *is* the path
+ * field from the first keystroke — `/`, `~` and `./` complete directories as you go — and the
+ * worktrees are suggestions under it rather than a menu in front of it.
+ *
+ * And the machines are on it, because "add a project" never had a reason to mean "on this
+ * computer". `linux-box:` completes over there and `↵` starts the conversation there; the row for
+ * it arrives in the panel the way every other remote conversation's does.
+ *
+ * Answers `null` for anything that was not a local directory — including a remote one, which has
+ * been acted on by then. The caller's job is to open a path here, and a path on somebody else's
+ * disk is not one.
  */
 async function chooseDirectory(neosh: Neosh): Promise<string | null> {
   const [worktrees, sessions] = await Promise.all([
@@ -1857,25 +2176,30 @@ async function chooseDirectory(neosh: Neosh): Promise<string | null> {
     neosh.session.list().catch(() => [] as SessionInfo[]),
   ]);
   const open = new Set(sessions.map((s) => s.cwd));
-  const candidates = worktrees.filter((t) => !open.has(t.path));
-  if (candidates.length === 0) return pathPicker(neosh, "Add project");
 
-  const TYPE = "\u0000type";
-  const chosen = await picker(
-    neosh,
-    [
-      ...candidates.map((t) => ({
-        label: basename(t.path),
-        detail: [t.branch ?? "", t.path].filter(Boolean).join("  ·  "),
-        keywords: t.path,
-        value: t.path,
-      })),
-      { label: "Type a path…", value: TYPE },
-    ],
-    { title: "Add project", width: 76 },
-  );
+  const rows: PickerItem<Where>[] = [elsewhereRow("Type a path…")];
+  for (const t of worktrees.filter((w) => !open.has(w.path))) {
+    rows.push({
+      // The path, not the basename: `<Tab>` puts a row's label back in the field, and a bare
+      // directory name there is a path relative to somewhere nobody chose.
+      label: t.path,
+      detail: [basename(t.path), t.branch ?? ""].filter(Boolean).join("  ·  "),
+      keywords: `${basename(t.path)} worktree`,
+      icon: "⎇",
+      hl: "Git.Branch",
+      value: { kind: "elsewhere", path: t.path },
+    });
+  }
+
+  const chosen = await whereTo(neosh, rows, { title: "Add project" });
   if (chosen === null) return null;
-  return chosen === TYPE ? pathPicker(neosh, "Add project") : chosen;
+  if (chosen.kind === "host") {
+    await startThere(neosh, chosen);
+    return null;
+  }
+  if (chosen.kind !== "elsewhere") return null;
+  // Chosen from the menu rather than typed: that row means "ask me", and this is the asking.
+  return chosen.path ?? (await pathPicker(neosh, "Add project"));
 }
 
 /**


### PR DESCRIPTION
`^O` was a menu of the current repository's worktrees with `Type a path…` under them — a list of the one place you were already in, which you had to read to the end of every time to reach the thing you almost always wanted. `^N` had the same row under an unbounded list of trees, so its distance from the cursor grew with how long you had used the program.

## The field

The filter line **is** the path field now. Type `/`, `~` or `./` and the rows are the directories that match, from the first keystroke; `⇥` walks into the highlighted one, `↵` takes what you typed. `Type a path…` is the first row of `^O` and `Another directory…` is above the trees in `^N` — fallbacks rather than the route.

`<machine>:` points the same field at another computer. scp's spelling, meaning there what it means here, which is what lets one field aim at two machines and is learned by reading a machine's row rather than being told.

```
> bravo:
❯ ● bravo:/home/me/other   other  ·  1 conversation
  ● bravo:/home/me/work    work   ·  1 conversation
  ○ bravo:/home/me/quiet   quiet  ·  nothing open

> bravo:/home/me/
❯ ▸ bravo:/home/me/src/     bravo
  ▸ bravo:/home/me/other/   bravo
```

Filled where somebody has a conversation open, hollow where nobody has.

## Underneath

**`AscpMessage::Browse`/`Browsed`** — `path.complete`, asked over there. `NodeCapabilities::projects` is what a node *offers* and is a short list; the directory neither machine has ever opened could only be reached by typing a path from memory, and you found out it was wrong when the conversation failed to start.

Gated on `accepts_commands`, deliberately not on a permission of its own: a node that will start an agent at any path you name has already given away more than the names of its directories. `NodeCapabilities::browse` is a *compatibility* flag rather than a permission — an unknown tag fails the frame and takes the connection with it, so a picker aimed at an older peer would have knocked it off the board. It defaults to `false`, which is exactly what an older handshake decodes to, so **no version bump**.

**A roster rather than a snapshot.** `publish_inventory` ran when a peer connected and when a peer drove something here, and never once because somebody *sitting at this machine* started, renamed, archived or deleted a conversation — so every other computer's picture of this one was frozen at whenever it last dialled. A timer that recomputes and compares; nothing goes on the wire unless the answer moved. What it advertises is the list its own panel shows (`sidebar.projects`, read the way `question.asking` is), so a project you cleared out is still somewhere you can start something — and `RemoteProject::active` means something for the first time, having been `true` for everything while the list came from live conversations alone.

**`swarm.command` answers with what it started.** The far end knew the id and said it in its `Ack`; the host threw it away, so starting a conversation over there was the same key doing visibly less for the same intention — you had to go and find, in `^J`, the thing you had just made. It opens now.

## Verified

Two real workspaces, paired over a real socket, driven through the stdio protocol: the machine row, the project list with live counts, directory completion over the wire, and `↵` starting a conversation on the far machine and opening a window onto it here.

Suites, on macOS: `neosh-core` 108 ✓, `neosh-swarm` 18 ✓ (+2), `neosh-proto` ✓ (+2), `builtin_plugins` 173 ✓ (+2), `plugin_manager`/`sessions`/`questions`/`approvals` ✓. The three failures are this Mac's known `/var` vs `/private/var` path-comparison baseline and are unchanged. Bindings regenerated, `tsc --noEmit` clean on both projects, clippy warning count unchanged (149 → 149).

## Notes

Every paired machine is a row, including the ones that cannot be used, greyed with the reason on them — skipping them is right about what can be *done* and wrong about what should be *said*, and somebody who has just paired a computer and finds an empty list reads it as the feature not existing.

There is deliberately no `Add a computer…` row: the swarm is on by default, so that would be a permanent line in a menu pressed many times a day about a thing most readers are not doing. `^J` has a key of its own and a line in the legend.