### PR TITLE
feat(sidebar): a project row said something had changed, never how far behind

### DIFF
--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -7651,8 +7651,12 @@ fn a_third_party_plugin_can_be_switched_off_from_config() {
     assert!(!s.saw("imports sidebar"), "the plugin should not have run\n{}", s.transcript());
 }
 
-/// A plugin puts a mark on a row the sidebar drew — the git plugin's dirty count on the project
+/// A plugin puts a mark on a row the sidebar drew — the git plugin's stat strip on the project
 /// row — without the sidebar knowing git exists. The badge sits after the name, in the row.
+///
+/// Two changes of two different kinds, because the strip counts them separately: a tracked file
+/// somebody edited is `~1` and a file git has never seen is `?1`. A single count could not tell
+/// them apart, which is the whole reason the badge is a run of parts rather than one.
 #[test]
 fn a_decoration_lands_on_the_project_row() {
     if !have_git() {
@@ -7663,7 +7667,38 @@ fn a_decoration_lands_on_the_project_row() {
     std::fs::write(sb.work().join("new.txt"), "x\n").expect("write");
     std::fs::write(sb.work().join("README.md"), "changed\n").expect("write");
     let mut s = sb.start();
-    s.wait_for("work ●2");
+    s.wait_for("work ~1 ?1");
+}
+
+/// The badge gives way before the name does.
+///
+/// A project name is what the row *is*; the strip is news about it. So in a column too narrow for
+/// both, the git plugin's `short` form — the worst single stat — is what gets drawn, and the name
+/// is left whole. Before this the badge took its columns first and the row read
+/// `neosh-websit… ↓3 ↑12 ~5 ?7`: four facts nobody asked for, bought with the one thing the panel
+/// exists to show.
+///
+/// At the narrowest the panel goes, which is where the rule has to hold if it holds anywhere.
+#[test]
+fn a_badge_gives_up_its_columns_before_the_name_is_clipped() {
+    if !have_git() {
+        return;
+    }
+    let sb = Sandbox::new("badge-yields");
+    sb.write_config("[options]\n\"sidebar.width\" = 16\n");
+    sb.git_init();
+    for i in 0..4 {
+        std::fs::write(sb.work().join(format!("u{i}.txt")), "x\n").expect("write");
+    }
+    std::fs::write(sb.work().join("README.md"), "changed\n").expect("write");
+    let mut s = sb.start();
+    // One tracked file edited and four git has never seen: `~1 ?4` in full, `~1` short. The row
+    // keeps its name and the head of the strip.
+    s.wait_for("work ~1");
+    s.drain_for(Duration::from_secs(2));
+    // The footer says the whole of it — it has the room — so this has to name the row rather than
+    // the count, or it asserts against the status bar instead of the panel.
+    assert!(!s.saw("work ~1 ?4"), "the row should not carry the full strip\n{}", s.transcript());
 }
 
 /// A third-party decoration: a badge on a conversation and a section anchored by name between

--- a/docs/config.md
+++ b/docs/config.md
@@ -254,8 +254,10 @@ In the panel (`<C-t>`): `↑`/`↓`, `j`/`k` or `^N`/`^P` move, `Enter` opens or
 `f` pins, `J`/`K` reorder, `n` new conversation here, `x` archive, `X` delete, `a` the archive,
 `r` rename, `?` every binding, `Esc` leaves. `J`/`K` work from a conversation row too — they move
 the project it is in, because you are looking at the project when you are looking at what is inside
-it. The foot of the panel lists the keys for whatever the cursor is on; set `sidebar.hints = false`
-once they are in your fingers.
+it. `>` and `<` make the column wider and narrower and `=` puts it back — they are the
+`sidebar.width` setting, so this key and `config.toml` say the same number, and the panel's own
+heading says `<> width` while it has the keyboard. The foot of the panel lists the keys for
+whatever the cursor is on; set `sidebar.hints = false` once they are in your fingers.
 
 ### Archiving, and the one verb that deletes
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -531,12 +531,20 @@ await neosh.ext.contribute("sidebar.section", "todo", {
   rows: [{ text: "Ship the thing", command: "acme.open", args: ["thing"] }],
 });
 
-// A mark on a row the panel already draws, keyed by what the row is about. The git plugin's
-// dirty count is exactly this. The name is clipped to make room for the badge; `hl` colours a
+// A mark on a row the panel already draws, keyed by what the row is about. The git plugin's stat
+// strip is exactly this. The name is clipped to make room for the badge; `hl` colours a
 // row the panel left plain; `right` replaces the count or the age on a row that is not busy.
 await neosh.ext.contribute("sidebar.decoration", `prs:${cwd}`, {
   target: { project: cwd },                       // or { session: id }
   badge: { text: "2 PRs", hl: "Accent" },
+});
+
+// A badge is often several facts rather than one, and a strip drawn in a single colour is a string
+// you read rather than a row you glance at. `parts` is the same badge in as many colours as it has
+// things to say — what `↓2 ↑5 ~7` on a project row is — and a part with no `hl` is a separator.
+await neosh.ext.contribute("sidebar.decoration", `ci:${cwd}`, {
+  target: { project: cwd },
+  badge: { parts: [{ text: "✓12", hl: "Git.Added" }, { text: " " }, { text: "✗1", hl: "Git.Conflict" }] },
 });
 
 // A verb on a row. The panel binds the key and invokes your command with the row under the cursor:

--- a/plugins/api/src/ui.ts
+++ b/plugins/api/src/ui.ts
@@ -2755,12 +2755,34 @@ export interface ActionItem {
   on?: string;
 }
 
+/** One coloured run of a badge. A part with no `hl` is the panel's own colour — a separator. */
+export interface BadgePart {
+  text: string;
+  hl?: string;
+}
+
+/**
+ * A mark after a row's name: one coloured run, or several.
+ *
+ * Several, because a badge is often several facts rather than one — `↓2` is not the same news as
+ * `~7`, and a strip of git stats drawn in one colour is a string you have to read rather than a
+ * row you can glance at. The single form stays because most badges *are* one fact.
+ *
+ * `short` is the same badge with less in it, for a row too narrow to carry all of it — the fewest
+ * parts still worth drawing, not a truncation. A panel is what knows how many columns there are;
+ * which fact to give up is the badge's to say, exactly as it is for a status segment. Absent means
+ * there is no shorter true version, and the full badge stands.
+ */
+export type BadgeSpec =
+  | { text: string; hl?: string }
+  | { parts: BadgePart[]; short?: BadgePart[] };
+
 /** A mark on a row a panel already draws, keyed by what the row is about. */
 export interface DecorationItem {
   /** The row it is about, in the panel's own terms: `{ project: cwd }`, `{ task: id }`. */
   target: Record<string, string>;
-  /** A short mark after the name, in `hl`. The name is clipped to make room. */
-  badge?: { text: string; hl?: string };
+  /** A short mark after the name. The name is clipped to make room. */
+  badge?: BadgeSpec;
   /** The row's highlight, when the panel has no opinion of its own. */
   hl?: string;
   /** The right-hand column, on a row that is not busy. */
@@ -2769,9 +2791,41 @@ export interface DecorationItem {
 
 /** Every decoration on one target, merged. */
 export interface Decoration {
-  badge?: { text: string; hl?: string };
+  /** `text` is every part run together — what a caller measuring the badge reads. */
+  badge?: { text: string; hl?: string; parts: BadgePart[]; short: BadgePart[] };
   hl?: string;
   right?: { text: string; hl?: string };
+}
+
+/** A badge in either form, as the run of parts the rest of this file works in. */
+function badgeParts(badge: BadgeSpec | undefined): BadgePart[] {
+  if (!badge || typeof badge !== "object") return [];
+  const many = (badge as { parts?: unknown }).parts;
+  if (Array.isArray(many)) {
+    return many.filter((p): p is BadgePart =>
+      Boolean(p) && typeof p === "object" && typeof (p as BadgePart).text === "string" &&
+      (p as BadgePart).text !== ""
+    );
+  }
+  const one = badge as { text?: unknown; hl?: unknown };
+  if (typeof one.text !== "string" || one.text === "") return [];
+  return [{ text: one.text, hl: typeof one.hl === "string" ? one.hl : undefined }];
+}
+
+/**
+ * A badge's short form, falling back to the whole of it.
+ *
+ * The fallback is what lets several decorations merge without anybody declaring one: a plugin with
+ * nothing to give up keeps all of its parts in both forms, and {@link fitBadge} notices that the
+ * two are the same width and leaves the badge alone.
+ */
+function badgeShort(badge: BadgeSpec | undefined): BadgePart[] {
+  const declared = (badge as { short?: unknown } | undefined)?.short;
+  if (!Array.isArray(declared)) return badgeParts(badge);
+  return declared.filter((p): p is BadgePart =>
+    Boolean(p) && typeof p === "object" && typeof (p as BadgePart).text === "string" &&
+    (p as BadgePart).text !== ""
+  );
 }
 
 /** The key a decoration's `target` files under: `project:/w/x`, `task:17`. */
@@ -2797,11 +2851,16 @@ export function mergeDecorations(
     const key = decorationKey(c.item?.target);
     if (key === null) continue;
     const d = out.get(key) ?? {};
-    const badge = c.item.badge;
-    if (typeof badge?.text === "string" && badge.text !== "") {
-      d.badge = d.badge
-        ? { text: `${d.badge.text} ${badge.text}`, hl: d.badge.hl }
-        : { text: badge.text, hl: badge.hl };
+    const parts = badgeParts(c.item.badge);
+    if (parts.length > 0) {
+      const short = badgeShort(c.item.badge);
+      const merged = d.badge ? [...d.badge.parts, { text: " " }, ...parts] : parts;
+      d.badge = {
+        text: merged.map((p) => p.text).join(""),
+        hl: d.badge?.hl ?? parts[0]?.hl,
+        parts: merged,
+        short: d.badge ? [...d.badge.short, { text: " " }, ...short] : short,
+      };
     }
     if (d.hl === undefined && typeof c.item.hl === "string") d.hl = c.item.hl;
     if (d.right === undefined && typeof c.item.right?.text === "string") {
@@ -2812,9 +2871,41 @@ export function mergeDecorations(
   return out;
 }
 
-/** How many columns a decoration's badge will take, for a row builder to leave free. */
+/**
+ * How many columns a decoration's badge will take, for a row builder to leave free.
+ *
+ * Columns rather than bytes, which is what a row builder is subtracting this from: `●3` is four
+ * bytes and two columns, and a strip of arrows is three bytes each — measured in bytes, a badge
+ * that says `↓2 ↑5 ~7` takes eleven columns off a name to occupy nine.
+ */
 export function badgeWidth(d: Decoration | undefined): number {
-  return d?.badge ? byteLength(` ${d.badge.text}`) : 0;
+  return d?.badge ? width(` ${d.badge.text}`) : 0;
+}
+
+/**
+ * The badge as this row can actually afford it: the whole of it, or its short form.
+ *
+ * **The badge yields before the name does.** A row's name is what the row *is* — a project you
+ * cannot read the name of is not a row you can use — and a badge is news about it. So the full
+ * strip is drawn whenever the name fits beside it, and a name that would be clipped by the badge
+ * gets the short form instead. Only if it still does not fit is the name clipped, which is the
+ * panel's own business and unchanged.
+ *
+ * `room` is every column the name and the badge have between them, `name` the columns the name
+ * wants. A badge whose short form saves nothing is left alone, which is what makes the fallback in
+ * {@link badgeShort} safe: a plugin that declared no short form never has one chosen for it.
+ */
+export function fitBadge(
+  d: Decoration | undefined,
+  room: number,
+  name: number,
+): Decoration | undefined {
+  if (!d?.badge) return d;
+  const full = badgeWidth(d);
+  if (name + full <= room) return d;
+  const short = { ...d.badge, text: d.badge.short.map((p) => p.text).join("") };
+  if (width(` ${short.text}`) >= full) return d;
+  return { ...d, badge: { ...short, parts: d.badge.short } };
 }
 
 /**
@@ -2833,12 +2924,18 @@ export function decorateRow<T>(
   if (!d) return row;
   if (d.badge) {
     const mark = ` ${d.badge.text}`;
-    const from = byteLength(row.text);
+    // Past the space this puts between the name and the badge: it is the panel's colour, not the
+    // badge's, and a span over it would be one colour claiming a column it does not fill.
+    let at = byteLength(row.text) + 1;
     row.text = `${row.text}${mark}`;
     if (row.full !== undefined) row.full = `${row.full}${mark}`;
-    if (d.badge.hl) {
-      row.spans = [...(row.spans ?? []), { from, to: from + byteLength(mark), hl: d.badge.hl }];
+    const spans = [...(row.spans ?? [])];
+    for (const part of d.badge.parts) {
+      const to = at + byteLength(part.text);
+      if (part.hl) spans.push({ from: at, to, hl: part.hl });
+      at = to;
     }
+    if (spans.length > 0) row.spans = spans;
   }
   if (d.hl && row.hl === undefined) row.hl = d.hl;
   if (d.right && !busy) row.right = { text: `${d.right.text} `, hl: d.right.hl };

--- a/plugins/builtin/git/main.ts
+++ b/plugins/builtin/git/main.ts
@@ -214,10 +214,12 @@ two-word scratch name it was created with.",
   await neosh.keymap.set("chat", "<C-g>", "git.status", { desc: "Git status" });
   await neosh.keymap.set("chat", "<C-d>", "git.diff", { desc: "Show what changed" });
 
-  // What changed, on the project's own row. A decoration rather than a section of our own: the
-  // row already exists, the sidebar already knows how to draw a mark on it, and the whole point of
-  // the point is that this plugin never imports the panel. Keyed by the project's directory, and
-  // withdrawn when the tree is clean — a `0` on every row is a column of noise.
+  // Where this checkout stands, on the project's own row. A decoration rather than a section of
+  // our own: the row already exists, the sidebar already knows how to draw a mark on it, and the
+  // whole point of the point is that this plugin never imports the panel. Keyed by the project's
+  // directory — which is a worktree's directory too, so a nested tree reports its own branch's
+  // divergence rather than its repository's — and withdrawn when there is nothing to say, because
+  // a `0` on every row is a column of noise.
   const decorate = async () => {
     const projects = await neosh.vars
       .get<unknown>({ scope: "global" }, "sidebar.projects")
@@ -225,16 +227,20 @@ two-word scratch name it was created with.",
     const cwds = Array.isArray(projects)
       ? projects.filter((p): p is string => typeof p === "string")
       : [];
+    const ascii = (await neosh.opt.get<boolean>("ui.ascii_only").catch(() => false)) ?? false;
     for (const cwd of cwds) {
       const status = await neosh.git.status({ cwd }).catch(() => null);
-      const dirty = status?.changes.length ?? 0;
-      if (dirty === 0) {
+      const parts = status ? statParts(status, ascii) : [];
+      if (parts.length === 0) {
         await neosh.ext.remove("sidebar.decoration", `dirty:${cwd}`).catch(() => {});
         continue;
       }
       await neosh.ext.contribute("sidebar.decoration", `dirty:${cwd}`, {
         target: { project: cwd },
-        badge: { text: `${dirty === 1 ? "●" : `●${dirty}`}`, hl: "Git.Modified" },
+        // The strip is ordered worst-first, so what to give up on a narrow row is already decided:
+        // everything but the head of it. A project name the panel had to clip to make room for
+        // `?7` is a row that gave up what it is to say something you did not ask for.
+        badge: { parts, short: parts.slice(0, 1) },
       }).catch(() => {});
     }
   };
@@ -254,19 +260,30 @@ two-word scratch name it was created with.",
   await decorate();
 
   // Which branch you are on belongs beside the model: both answer "where is what I type going".
+  // The same vocabulary as the panel's badge, in one colour rather than several — a status segment
+  // is one span, and the strip is short enough that the worst thing true of it is the right answer
+  // to what colour it should be.
   const footer = async () => {
     const status = await neosh.git.status().catch(() => null);
     if (!status) {
       await neosh.status.clear("branch");
       return;
     }
+    const ascii = (await neosh.opt.get<boolean>("ui.ascii_only").catch(() => false)) ?? false;
     const head = status.repo.detached
       ? `detached ${status.repo.head ?? ""}`.trim()
       : (status.repo.branch ?? "no branch");
-    const dirty = status.changes.length;
+    const parts = statParts(status, ascii);
+    const stats = parts.map((p) => p.text).join("");
+    // The strip is ordered worst-first, so its head is both the colour the segment should be and
+    // the one stat worth keeping when the terminal is too narrow for all of them. A segment with
+    // no short form is dropped whole — which is how the branch name itself disappeared off a
+    // 110-column footer the moment this said four things instead of one.
+    const worst = parts[0];
     await neosh.status.set("branch", {
-      text: `${head}${dirty ? ` ●${dirty}` : ""}`,
-      hl: dirty ? "Git.Modified" : "Git.Branch",
+      text: `${head}${stats === "" ? "" : ` ${stats}`}`,
+      short: worst ? `${head} ${worst.text}` : head,
+      hl: worst?.hl ?? "Git.Branch",
       priority: 20,
     });
   };
@@ -280,6 +297,50 @@ two-word scratch name it was created with.",
   );
   // The working tree changes whenever anything writes a file, including the agent.
   subscriptions.push(neosh.timer.every(5000, () => void footer()));
+}
+
+// ---------------------------------------------------------------------------
+// Where a checkout stands, in five columns or fewer per fact
+// ---------------------------------------------------------------------------
+
+/**
+ * A repository's state as a run of coloured stats, worst first, nothing said about zero.
+ *
+ * It replaced a single amber `●3`. A dot with a number on it is one fact — *something* here has
+ * been touched — drawn in the one colour the panel uses for "act now", on the rows you look at
+ * most; and the thing it did not say is the thing you actually want off a project row, which is
+ * whether this checkout has drifted from the remote. Ahead and behind are already in `RepoStatus`,
+ * from the branch header `git status --porcelain=v2 --branch` prints, so this costs no extra call.
+ *
+ * The order is what would stop you: a conflict is a tree you cannot commit from, behind is work
+ * you have not got yet, ahead is work nobody else has, and the two dirty counts are yours and
+ * undecided. Each fact keeps its own colour — a strip drawn in one colour is a string you read
+ * rather than a row you glance at — and every one of them is a glyph and a number, so the whole
+ * strip is at most a handful of columns even when all five are true.
+ *
+ * `↑` and `↓` are the direction the *commits* would travel, which is the way every git prompt in
+ * the world draws it: `↓2` is two waiting for you.
+ */
+function statParts(status: RepoStatus, ascii: boolean): Array<{ text: string; hl?: string }> {
+  const parts: Array<{ text: string; hl?: string }> = [];
+  const say = (text: string, hl: string) => {
+    // The separator is a part of its own with no highlight: it belongs to neither side, and giving
+    // it to the run before it would colour a column that has nothing in it.
+    if (parts.length > 0) parts.push({ text: " " });
+    parts.push({ text, hl });
+  };
+  const is = (c: (typeof status.changes)[number], state: string) =>
+    c.staged === state || c.unstaged === state;
+  const conflicted = status.changes.filter((c) => is(c, "conflicted")).length;
+  const untracked = status.changes.filter((c) => !is(c, "conflicted") && is(c, "untracked")).length;
+  const dirty = status.changes.length - conflicted - untracked;
+
+  if (conflicted > 0) say(`${ascii ? "!" : "✗"}${conflicted}`, "Git.Conflict");
+  if (status.repo.behind > 0) say(`${ascii ? "v" : "↓"}${status.repo.behind}`, "Git.Behind");
+  if (status.repo.ahead > 0) say(`${ascii ? "^" : "↑"}${status.repo.ahead}`, "Git.Ahead");
+  if (dirty > 0) say(`~${dirty}`, "Git.Modified");
+  if (untracked > 0) say(`?${untracked}`, "Git.Untracked");
+  return parts;
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -66,6 +66,7 @@ import {
   badgeWidth as badgeColumns,
   decorateRow,
   elapsed,
+  fitBadge,
   fuzzy,
   type ListRow,
   type Match,
@@ -3160,7 +3161,13 @@ async function collect(
   // any of them by name, and the foot is whatever lands after the last one.
   const blocks: Record<Slot, () => void> = {
     projects: () => {
-      rows.push(...heading("PROJECTS", opts.width));
+      // How to make the column wider, on the heading of the column it makes wider — the idiom the
+      // plan block already uses for `^L`, and it costs no row of a panel whose rows are its whole
+      // job. It has to be *somewhere*: a project name clipped to `neosh-websit…` is a row asking
+      // to be widened, and `>` was bound, documented and invisible — advertised on contributed
+      // rows only, which is the one kind of row most people never stand on. Only while the panel
+      // has the keyboard, because that is when the key does anything.
+      rows.push(...heading("PROJECTS", opts.width, opts.focused ? "<> width" : undefined));
       for (const p of projects) {
         rows.push(projectRow(p, arrangement, opts, now));
         if (arrangement.isFolded(p.cwd)) continue;
@@ -3348,14 +3355,16 @@ function projectRow(
   // project under it still end in the same place — clipping the name is what a panel this narrow
   // does, and letting the mark run two columns past everything else is not.
   const target: Target = { kind: "project", cwd: p.cwd };
-  const name = clip(
-    p.name,
-    Math.max(
-      6,
-      opts.width - 8 - byteLength(mark) - byteLength(star) - (elsewhere.length ? 8 : 0) -
-        badgeColumns(opts.decorations.get(targetKey(target) ?? "")),
-    ),
+  // Everything the name and the badge have to share. The badge gives up its least important parts
+  // before a single character comes off the name — a project you cannot read the name of is not a
+  // row you can use, and how far behind the remote it is keeps until you widen the panel with `>`.
+  const room = opts.width - 8 - byteLength(mark) - byteLength(star) - (elsewhere.length ? 8 : 0);
+  const decoration = fitBadge(
+    opts.decorations.get(targetKey(target) ?? ""),
+    room,
+    Array.from(p.name).length,
   );
+  const name = clip(p.name, Math.max(6, room - badgeColumns(decoration)));
   const spans: Array<{ from: number; to: number; hl: string }> = [];
   if (star !== "") {
     const from = byteLength(` ${arrow} ${name}`);
@@ -3374,7 +3383,7 @@ function projectRow(
     full: ` ${arrow} ${p.name}`,
     indent: 3,
     // `here` is this panel's opinion; everything else is a decorator's to colour.
-    hl: here ? "Directory" : opts.decorations.get(targetKey(target) ?? "")?.hl ?? "Sidebar.Dim",
+    hl: here ? "Directory" : decoration?.hl ?? "Sidebar.Dim",
     spans: spans.length > 0 ? spans : undefined,
     right: elsewhere.length > 0
       // The machines take the column the count would have used. A project that is in two places is
@@ -3382,7 +3391,7 @@ function projectRow(
       ? { text: `${clip(elsewhere.join(" "), 14)} `, hl: "Sidebar.Remote" }
       : right,
     value: target,
-  }, opts.decorations.get(targetKey(target) ?? ""), Boolean(busy) || elsewhere.length > 0);
+  }, decoration, Boolean(busy) || elsewhere.length > 0);
 }
 
 /**
@@ -3427,10 +3436,15 @@ function worktreeRow(
   // nesting read as two levels where there is one.
   const pad = "   ";
   const target: Target = { kind: "project", cwd: p.cwd };
-  const name = clip(
-    p.name,
-    Math.max(6, opts.width - 8 - byteLength(glyph) - byteLength(mark) - badgeColumns(opts.decorations.get(targetKey(target) ?? ""))),
+  // As on a project row, and two columns tighter: the branch name is what this row is, so the
+  // badge is what gives way. See `projectRow`.
+  const room = opts.width - 8 - byteLength(glyph) - byteLength(mark);
+  const decoration = fitBadge(
+    opts.decorations.get(targetKey(target) ?? ""),
+    room,
+    Array.from(p.name).length,
   );
+  const name = clip(p.name, Math.max(6, room - badgeColumns(decoration)));
   const spans: Array<{ from: number; to: number; hl: string }> = [];
   if (glyph !== "") {
     const at = byteLength(`${pad}${arrow} `);
@@ -3451,11 +3465,11 @@ function worktreeRow(
     // already on the row.
     full: `${pad}${arrow} ${glyph}${p.name}`,
     indent: byteLength(`${pad}${arrow} `),
-    hl: here ? "Directory" : opts.decorations.get(targetKey(target) ?? "")?.hl ?? "Sidebar.Dim",
+    hl: here ? "Directory" : decoration?.hl ?? "Sidebar.Dim",
     spans: spans.length > 0 ? spans : undefined,
     right,
     value: target,
-  }, opts.decorations.get(targetKey(target) ?? ""), Boolean(busy));
+  }, decoration, Boolean(busy));
 }
 
 /**
@@ -3639,19 +3653,23 @@ function turnFor(s: SessionInfo, now: number): string {
  */
 function hints(opts: DrawOptions): ListRow<Target>[] {
   const kind = opts.selected?.kind;
-  const lines = !opts.focused
-    // `^O` is not here and `+ Add project` is a row you can see: a key strip has two lines, and the
-    // verb with a row of its own is the one that can afford to give up its place on them.
-    ? ["^T projects  ^N new   ^F archive", "^K palette   ^B hide  ^Z keys"]
-    : kind === "custom"
-      ? ["↵ open it     <> width", "esc back      ? keys"]
-    : kind === "project"
-      // `X` is on the strip because a list you cannot shorten is a list that grows forever, and a
-      // project that outlives its conversations — which is the point of it — has to have a way off.
-      ? ["↵ fold   f ★       JK move", "n new    y path     X remove  ? keys"]
-      : kind === "session"
-        ? ["↵ open   r rename   x archive", "X delete y path     ? keys"]
-        : ["↵ add project", "esc back         ? keys"];
+  const lines = strip(
+    !opts.focused
+      // `^O` is not here and `+ Add project` is a row you can see: a key strip has two lines, and
+      // the verb with a row of its own is the one that can afford to give up its place on them.
+      ? ["^T projects", "^N new", "^F archive", "^K palette", "^B hide", "^Z keys"]
+      : kind === "custom"
+        ? ["↵ open it", "esc back", "? keys"]
+      : kind === "project"
+        // `X` is on the strip because a list you cannot shorten is a list that grows forever, and
+        // a project that outlives its conversations — which is the point of it — has to have a way
+        // off.
+        ? ["↵ fold", "f ★", "JK move", "n new", "y path", "X remove", "? keys"]
+        : kind === "session"
+          ? ["↵ open", "r rename", "x archive", "X delete", "y path", "? keys"]
+          : ["↵ add project", "esc back", "? keys"],
+    opts.width,
+  );
 
   // Contributed verbs get their own line rather than being squeezed onto ours, because ours are
   // laid out in columns that a third party's label of unknown length would break — and because a
@@ -3673,6 +3691,52 @@ function hints(opts: DrawOptions): ListRow<Target>[] {
     })),
     ...(mine === "" ? [] : [{ text: ` ${mine}`, hl: "Sidebar.Dim", inert: true }]),
   ];
+}
+
+/**
+ * A key strip packed into the column it is actually drawn in.
+ *
+ * These lines used to be written out by hand with their columns lined up by eye, which is a layout
+ * that is right at exactly one width: the project row's second line came to thirty-six columns in
+ * a panel that is thirty-four wide by default, and what fell off the end was `? keys` — clipped to
+ * `? k`. A strip that truncates its own escape hatch is worse than one that never mentioned it.
+ *
+ * So: verbs in order of how much you need them, packed greedily onto two lines, and whatever does
+ * not fit is dropped. The **last** cell is the way to everything dropped — `? keys`, or `^Z keys`
+ * when the panel does not have the keyboard — so if anything was dropped it takes the final slot.
+ * Greedy rather than even columns because these cells are three columns wide (`f ★`) and eight
+ * (`X remove`), and a grid sized for the widest fits four fewer verbs than the panel has room for.
+ */
+function strip(cells: string[], width: number): string[] {
+  const cols = (s: string) => Array.from(s).length;
+  const room = Math.max(1, width - 1);
+  const last = cells[cells.length - 1] ?? "";
+  const lines: string[] = [];
+  let placed = 0;
+  for (const cell of cells) {
+    const open = lines.length === 0 ? "" : lines[lines.length - 1] ?? "";
+    if (open !== "" && cols(`${open}  ${cell}`) <= room) {
+      lines[lines.length - 1] = `${open}  ${cell}`;
+    } else if (lines.length < 2 && cols(cell) <= room) {
+      lines.push(cell);
+    } else {
+      break;
+    }
+    placed++;
+  }
+  // Anything left unplaced means the strip is incomplete, so its last line has to end at the way in
+  // to the rest. Verbs come off the tail to make room for it rather than it being appended, because
+  // appending is exactly what overflowed — this is counting the same columns the loop above did.
+  if (placed < cells.length && lines.length > 0) {
+    const at = lines.length - 1;
+    let tail = lines[at] ?? "";
+    while (tail !== "" && cols(`${tail}  ${last}`) > room) {
+      const cut = tail.lastIndexOf("  ");
+      tail = cut < 0 ? "" : tail.slice(0, cut);
+    }
+    lines[at] = tail === "" ? last : `${tail}  ${last}`;
+  }
+  return lines;
 }
 
 /** The contributed verbs that apply to the row under the cursor, clipped to the column. */


### PR DESCRIPTION
A single amber `●3` after a project name is one fact — *something* in here has been touched — drawn
in the colour the panel keeps for "act now", on the rows you look at most. What it could not say is
the thing you actually want off a project row: whether the checkout has drifted from the remote.

```
▾ neosh-website-redesign ↓3 ↑12 ~5 ?7     3 behind, 12 ahead, 5 changed, 7 untracked
```

Worst first, nothing said about zero: `✗` conflicted, `↓` behind, `↑` ahead, `~` tracked files
changed, `?` untracked. Ahead and behind were already in `RepoStatus` — the branch header
`git status --porcelain=v2 --branch` prints — so this costs no extra call. A clean, in-sync
repository gets no badge at all, and a worktree reports its own branch's divergence rather than its
repository's. ASCII mode falls back to `^`/`v`/`!`.

### A badge can be several facts

Each keeps its own colour, which the decoration point could not express: a badge was one string and
one highlight, and a strip drawn in one colour is a string you read rather than a row you glance at.
`badge: { parts }` is the same badge in as many colours as it has things to say, and a part with no
`hl` is a separator. Documented in `docs/plugins.md` as the public thing it is.

### The badge yields before the name does

A project you cannot read the name of is not a row you can use. At the default width of 34 the full
strip clipped `neosh-website-redesign` to `neosh-websit…` to make room for four facts nobody asked
for. So a badge carries a `short` form — the fewest parts still worth drawing, its author's to
choose and not a truncation, exactly as `StatusSegment::short` already is — and the panel draws the
full strip only when the name fits beside it. Widening the default column instead would have spent
columns of transcript on every screen, forever, to fix a row that is rare.

### Which needs the key that widens it to be findable

`>`, `<` and `=` were bound, documented, and advertised on contributed rows only — the one kind of
row most people never stand on. `<> width` now sits on the panel's own heading while it has the
keyboard, the idiom the plan block already uses for `^L`, and it costs no row of a panel whose rows
are its whole job.

And the strip that was supposed to advertise them was already overflowing: the project row's second
line came to thirty-six columns in a panel thirty-four wide, and what fell off the end was
`? keys` — clipped to `? k`. A strip truncating its own escape hatch. The lines are packed to the
width they are drawn in now, and the way in to everything dropped is the one cell that always
survives.

`badgeWidth` counted bytes where its callers subtract columns — nine columns of arrows taking
nineteen off a name.

### Checked on screen

`scripts/shot.py` at 16 / 24 / 34 / 42 / 48 columns, `--color` to confirm `↓` is amber and `↑`
green, and `>` pressed live to watch the full strip come back as the column grows.

New test `a_badge_gives_up_its_columns_before_the_name_is_clipped` pins the rule at the narrowest
width the panel allows; `a_decoration_lands_on_the_project_row` now asserts `work ~1 ?1`, two kinds
of change a single count could not tell apart. Suite is 174 passed / 2 failed — the two
`/var` vs `/private/var` path comparisons that fail on this machine regardless of the change.
