### PR TITLE
feat(models): Fable 5.1 and Gemini 3.8 Flash, and a floor that hid Sonnet 5

### DIFF
--- a/crates/neosh-provider/src/catalog.rs
+++ b/crates/neosh-provider/src/catalog.rs
@@ -254,10 +254,15 @@ pub fn anthropic_models() -> Vec<ModelInfo> {
     use ModelTier::{Balanced, Fast, Frontier};
     const OPUS: &str = "Most capable for complex work";
     const SONNET: &str = "Best for everyday tasks";
+    // What the vendor says Fable is for. It read "Long-form writing and voice" here, which is a
+    // guess from the name — the line is the top of the ladder for reasoning and long-horizon
+    // agentic work, and it is the one row whose price says so.
+    const FABLE: &str = "Deepest reasoning and long-running work";
     vec![
         claude("claude-opus-5", "Claude Opus 5", "opus", Frontier, OPUS, 1_000_000, 128_000, (5.0, 25.0), Some(EFFORT_5), true, false),
-        claude("claude-fable-5", "Claude Fable 5", "fable", Frontier, "Long-form writing and voice", 1_000_000, 128_000, (10.0, 50.0), Some(EFFORT_5), false, false),
-        claude("claude-sonnet-5", "Claude Sonnet 5", "sonnet", Balanced, SONNET, 1_000_000, 128_000, (3.0, 15.0), Some(EFFORT_5), false, false),
+        claude("claude-fable-5-1", "Claude Fable 5.1", "fable", Frontier, FABLE, 1_000_000, 128_000, (10.0, 50.0), Some(EFFORT_5), false, false),
+        claude("claude-fable-5", "Claude Fable 5", "fable", Frontier, FABLE, 1_000_000, 128_000, (10.0, 50.0), Some(EFFORT_5), false, true),
+        claude("claude-sonnet-5", "Claude Sonnet 5", "sonnet", Balanced, SONNET, 1_000_000, 128_000, (2.0, 10.0), Some(EFFORT_5), false, false),
         claude("claude-opus-4-8", "Claude Opus 4.8", "opus", Frontier, OPUS, 1_000_000, 128_000, (5.0, 25.0), Some(EFFORT_5), true, true),
         claude("claude-opus-4-7", "Claude Opus 4.7", "opus", Frontier, OPUS, 1_000_000, 128_000, (5.0, 25.0), Some(EFFORT_5), false, true),
         claude("claude-opus-4-6", "Claude Opus 4.6", "opus", Frontier, OPUS, 1_000_000, 128_000, (5.0, 25.0), Some(EFFORT_46), false, true),
@@ -332,9 +337,11 @@ pub fn claude_cli_models() -> Vec<ModelInfo> {
     use ModelTier::{Balanced, Fast, Frontier};
     const OPUS: &str = "Most capable for complex work";
     const SONNET: &str = "Best for everyday tasks";
+    const FABLE: &str = "Deepest reasoning and long-running work";
     const ENTRIES: &[ClaudeCliEntry] = &[
         ("claude-opus-5", "Claude Opus 5", "opus", Frontier, OPUS, 1_000_000, Some(EFFORT_5), true, Some(true), false),
-        ("claude-fable-5", "Claude Fable 5", "fable", Frontier, "Long-form writing and voice", 1_000_000, Some(EFFORT_5), false, Some(true), false),
+        ("claude-fable-5-1", "Claude Fable 5.1", "fable", Frontier, FABLE, 1_000_000, Some(EFFORT_5), false, Some(true), false),
+        ("claude-fable-5", "Claude Fable 5", "fable", Frontier, FABLE, 1_000_000, Some(EFFORT_5), false, Some(true), true),
         ("claude-sonnet-5", "Claude Sonnet 5", "sonnet", Balanced, SONNET, 1_000_000, Some(EFFORT_5), false, Some(false), false),
         ("claude-haiku-4-5", "Claude Haiku 4.5", "haiku", Fast, "Fastest, for quick answers", 200_000, None, false, None, false),
         ("claude-opus-4-8", "Claude Opus 4.8", "opus", Frontier, OPUS, 1_000_000, Some(EFFORT_5), true, None, true),
@@ -531,10 +538,14 @@ fn seed_models(instance: &str) -> Vec<ModelInfo> {
             ("gpt-5.4", "GPT-5.4", "gpt", Balanced, "Strong for everyday coding", true),
             ("gpt-5.4-mini", "GPT-5.4 Mini", "gpt", Fast, "Small, quick, cheap", true),
         ],
+        // The Flash line moves fastest of anything seeded here — three releases in three months —
+        // which is the argument for seeds being a floor rather than the list: the moment a key is
+        // present, `/v1/models` decides, and a row here only has to be reachable and readable.
         "google" => &[
             ("gemini-3.1-pro-preview", "Gemini 3.1 Pro", "gemini-pro", Frontier, "Most capable Gemini", false),
-            ("gemini-3.7-flash", "Gemini 3.7 Flash", "gemini-flash", Balanced, "Quick, for everyday work", false),
+            ("gemini-3.8-flash", "Gemini 3.8 Flash", "gemini-flash", Balanced, "Quick, for everyday work", false),
             ("gemini-3.1-flash-lite", "Gemini 3.1 Flash Lite", "gemini-flash-lite", Fast, "Cheapest and fastest", false),
+            ("gemini-3.7-flash", "Gemini 3.7 Flash", "gemini-flash", Balanced, "Previous generation", true),
             ("gemini-2.5-pro", "Gemini 2.5 Pro", "gemini-pro", Frontier, "Previous generation", true),
             ("gemini-2.5-flash", "Gemini 2.5 Flash", "gemini-flash", Balanced, "Previous generation", true),
         ],
@@ -764,7 +775,7 @@ pub fn builtin_instances() -> Vec<InstanceConfig> {
         ])),
         instance("gemini-cli", "gemini-cli", "Gemini", None, cli("gemini", "gemini auth login"), acp_models(&[
             ("gemini-3.1-pro-preview", "Gemini 3.1 Pro", ModelTier::Frontier, "Most capable Gemini"),
-            ("gemini-3.7-flash", "Gemini 3.7 Flash", ModelTier::Balanced, "Quick, for everyday work"),
+            ("gemini-3.8-flash", "Gemini 3.8 Flash", ModelTier::Balanced, "Quick, for everyday work"),
             ("gemini-3.1-flash-lite", "Gemini 3.1 Flash Lite", ModelTier::Fast, "Cheapest and fastest"),
         ])),
         // --- API keys: billed per token --------------------------------

--- a/crates/neosh-provider/src/drivers/claude_cli.rs
+++ b/crates/neosh-provider/src/drivers/claude_cli.rs
@@ -115,8 +115,12 @@ pub fn control_mode(mode: PermissionMode) -> &'static str {
 /// today.
 const MIN_VERSION: &[(&str, (u32, u32, u32))] = &[
     ("claude-opus-5", (2, 1, 219)),
-    ("claude-fable-5", (2, 1, 169)),
-    ("claude-sonnet-5", (2, 1, 219)),
+    ("claude-fable-5-1", (2, 1, 255)),
+    ("claude-fable-5", (2, 1, 170)),
+    // 197, not 219. Read off the vendor's own table rather than assumed equal to Opus 5's, which
+    // is what it was — and a floor twenty-two releases too high is a model missing from the picker
+    // on every CLI in that range, with nothing on screen to say it was ever there.
+    ("claude-sonnet-5", (2, 1, 197)),
     ("claude-opus-4-8", (2, 1, 154)),
     ("claude-opus-4-7", (2, 1, 111)),
 ];
@@ -1713,6 +1717,26 @@ mod tests {
     #[test]
     fn an_unknown_version_is_offered_everything() {
         assert!(serves("claude-opus-5", None));
+    }
+
+    /// Every floor here is a number read off the vendor's release notes, and the failure it causes
+    /// is silent in both directions: too high and the model is missing from `^P` with nothing
+    /// saying why, too low and picking it fails the turn after you have typed the question. Pinned
+    /// per model rather than as one "is it recent" check, because they genuinely differ — Sonnet 5
+    /// landed twenty-two releases before Opus 5 and was hidden for all of them by a floor copied
+    /// from its neighbour.
+    #[test]
+    fn each_model_carries_the_release_it_actually_shipped_in() {
+        for (model, floor, before) in [
+            ("claude-fable-5-1", (2, 1, 255), (2, 1, 254)),
+            ("claude-fable-5", (2, 1, 170), (2, 1, 169)),
+            ("claude-sonnet-5", (2, 1, 197), (2, 1, 196)),
+            ("claude-opus-5", (2, 1, 219), (2, 1, 218)),
+            ("claude-opus-4-8", (2, 1, 154), (2, 1, 153)),
+        ] {
+            assert!(serves(model, Some(floor)), "{model} is offered on the release that added it");
+            assert!(!serves(model, Some(before)), "{model} is hidden on the one before");
+        }
     }
 
     #[test]

--- a/docs/config.md
+++ b/docs/config.md
@@ -996,10 +996,10 @@ right.
 Model                                                              ⇧⇥ providers
 > 
  PLANS                  │ ❯ Claude Opus 5         Frontier  Most capable for complex work
-  ✳ Claude            ✓ │   Claude Fable 5        Frontier  Long-form writing and voice
+  ✳ Claude            ✓ │   Claude Fable 5.1      Frontier  Deepest reasoning and long-running work
   ⬢ Codex             ✓ │   Claude Sonnet 5       Balanced  Best for everyday tasks
  API KEYS               │   Claude Haiku 4.5      Fast      Fastest, for quick answers
-  ✳ Anthropic         ! │   ▸ 5 superseded
+  ✳ Anthropic         ! │   ▸ 6 superseded
  LOCAL                  │
   ▲ Ollama              │
 ────────────────────────┴──────────────────────────────────────────────────────────


### PR DESCRIPTION
Both models shipped after the catalogue was last updated — `claude-fable-5-1` (1 Sept) and `gemini-3.8-flash` (2 Sept). IDs and specs are read off the vendors' own model tables, not inferred by incrementing a version.

## What's added

| | ID | Notes |
|---|---|---|
| Claude Fable 5.1 | `claude-fable-5-1` | $10/$50, 1M ctx, 128K out, full effort ladder |
| Gemini 3.8 Flash | `gemini-3.8-flash` | replaces 3.7 as the current Flash in both `google` and `gemini-cli` |

## Bugs found while checking the neighbouring rows

- **`claude-sonnet-5`'s CLI floor was 2.1.219; the vendor says 2.1.197.** A floor 22 releases too high means the model is missing from `^P` on every install in that range with nothing saying why. This is the failure the comment above `MIN_VERSION` warns about, in the direction it calls safe.
- **`claude-fable-5`'s floor was 169 against a release of 170** — the other direction: offered to a CLI that rejects it, failing the turn after you've typed.
- **Fable's tagline** read "Long-form writing and voice", a guess from the name. It's the top of the ladder for reasoning and long-horizon agentic work.
- **Sonnet 5** was still priced at its introductory $3/$15 rather than $2/$10.

A new test pins each model as served on the release that added it and hidden on the one before.

## Deliberately not done

**Mythos 5.1** is Project Glasswing only — a row nobody can select costs every reader a moment and pays back nothing. **OpenRouter** needs no change; it discovers Fable 5.1 from its own endpoint, which is what the seeds are a floor for rather than a copy of.

## Verification

Against the real binary, not the table. `--list-models` shows `anthropic/claude-fable-5-1` and `google/gemini-3.8-flash` — and shows Fable 5.1 **absent** from `claude-cli` on this machine, whose `claude` is 2.1.222, i.e. the gate doing its job in the case it exists for.

`cargo test -p neosh-provider`: 197 passed. `builtin_plugins`: 173 passed, 2 failed — the two known macOS `/var` vs `/private/var` path tests, unchanged from baseline.