### PR TITLE
fix(google): the Gemini API key path could not run a turn, and the Gemini plan no longer exists

### DIFF
--- a/crates/neosh-proto/src/provider.rs
+++ b/crates/neosh-proto/src/provider.rs
@@ -349,10 +349,19 @@ pub enum AuthRef {
     /// at you when it is missing. neosh never holds a token for these — that is the point. An
     /// account subscription and an API key are different things to buy, bill and revoke, and a
     /// picker that lists them as one flat set cannot tell you which one you are about to spend.
+    ///
+    /// `retired` is the sentence to say when the **vendor** has stopped serving this plan. A plan
+    /// can end without its CLI going anywhere: the program is installed, it runs, and the account
+    /// behind it is no longer served — which is a different problem from "install it" and needs a
+    /// different sentence, because the fix is somewhere else entirely. It is a note rather than a
+    /// flag so the note can name the date, the tiers that still work and where to go instead; a
+    /// bare boolean would leave every reader inventing that sentence for itself.
     Cli {
         program: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         login: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        retired: Option<String>,
     },
     /// The driver authenticates itself and will not say how.
     ///
@@ -472,6 +481,19 @@ pub enum CredentialSource {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         hint: Option<String>,
     },
+    /// A plan the **vendor** has stopped serving. `note` says what happened and what to use now.
+    ///
+    /// Distinct from [`Self::PlanMissing`] because the CLI is fine — it is installed, it runs, and
+    /// the account behind it is no longer served. Telling somebody to install a program they
+    /// already have is the one answer that sends them looking in the wrong place.
+    ///
+    /// Not usable, so nothing defaults here, and **not hidden**, because a plan can end for one
+    /// tier and not another: the note is what carries that, and a provider that simply vanished
+    /// would ask "where did Gemini go" instead of answering it.
+    PlanRetired {
+        program: String,
+        note: String,
+    },
     /// This environment variable, which is set.
     Env { var: String },
     /// The OS keychain, via its command-line helper. Survives a restart.
@@ -502,6 +524,7 @@ impl CredentialSource {
                 Some(cmd) => format!("{program} is not installed — then `{cmd}`"),
                 None => format!("{program} is not installed"),
             },
+            Self::PlanRetired { note, .. } => note.clone(),
             Self::Env { var } => format!("${var}"),
             Self::Keychain => "key in the keychain".into(),
             Self::Session => "key entered this run".into(),
@@ -516,13 +539,20 @@ impl CredentialSource {
     }
 
     /// Whether a turn sent to this instance can authenticate.
+    ///
+    /// A retired plan says no, which is what keeps a fresh install from defaulting into one. It is
+    /// not a refusal: an account on a tier the vendor still serves picks it in the usual way and
+    /// the turn goes through — this only decides what happens when nobody has chosen.
     pub fn is_usable(&self) -> bool {
-        !matches!(self, Self::Missing | Self::PlanMissing { .. })
+        !matches!(self, Self::Missing | Self::PlanMissing { .. } | Self::PlanRetired { .. })
     }
 
     /// Whether it will still be there after a restart.
     pub fn is_durable(&self) -> bool {
-        !matches!(self, Self::Session | Self::Missing | Self::PlanMissing { .. })
+        !matches!(
+            self,
+            Self::Session | Self::Missing | Self::PlanMissing { .. } | Self::PlanRetired { .. }
+        )
     }
 }
 
@@ -991,8 +1021,18 @@ mod tests {
     #[test]
     fn a_plan_is_not_a_key_and_a_key_is_not_a_plan() {
         assert_eq!(
-            AuthRef::Cli { program: "claude".into(), login: None }.account_kind(),
+            AuthRef::Cli { program: "claude".into(), login: None, retired: None }.account_kind(),
             AccountKind::Plan
+        );
+        assert_eq!(
+            AuthRef::Cli {
+                program: "gemini".into(),
+                login: None,
+                retired: Some("the vendor stopped serving it".into()),
+            }
+            .account_kind(),
+            AccountKind::Plan,
+            "a plan that ended is still a plan — it is filed under what it was, not hidden"
         );
         assert_eq!(AuthRef::Inherited.account_kind(), AccountKind::Plan);
         assert_eq!(AuthRef::Env { var: "K".into() }.account_kind(), AccountKind::ApiKey);
@@ -1007,5 +1047,45 @@ mod tests {
         let json = serde_json::to_string(&CredentialSource::Plan { via: "claude".into() })
             .expect("serialises");
         assert_eq!(json, r#"{"kind":"plan","via":"claude"}"#);
+    }
+
+    #[test]
+    fn a_retired_plan_is_never_what_a_fresh_install_lands_on() {
+        // The whole of what "unavailable" means here. It is not a refusal — an account on a tier
+        // the vendor still serves picks it in the usual way — it only keeps `ready_instances` from
+        // choosing it for somebody who has expressed no preference at all.
+        let retired = CredentialSource::PlanRetired {
+            program: "gemini".into(),
+            note: "ended for individual accounts".into(),
+        };
+        assert!(!retired.is_usable());
+        assert!(!retired.is_durable());
+    }
+
+    #[test]
+    fn a_retired_plan_says_what_happened_rather_than_where_to_install_something() {
+        // The distinction the extra variant exists for: the CLI is installed and works, so
+        // `PlanMissing`'s sentence would send somebody to fix a machine that is fine.
+        let auth = AuthRef::Cli { program: "gemini".into(), login: None, retired: None };
+        let note = "Google ended it on 18 June 2026 — use a key.";
+        let summary = CredentialSource::PlanRetired {
+            program: "gemini".into(),
+            note: note.into(),
+        }
+        .summary(&auth);
+        assert_eq!(summary, note);
+        assert!(!summary.contains("not installed"));
+    }
+
+    #[test]
+    fn an_auth_ref_written_before_plans_could_retire_still_decodes() {
+        // `retired` is a later field on a type that is in every user's `config.toml`. Absent has to
+        // mean "serving", or upgrading neosh would retire every hand-written plan on the machine.
+        let auth: AuthRef = serde_json::from_str(r#"{"kind":"cli","program":"claude"}"#)
+            .expect("an older spelling still decodes");
+        assert_eq!(
+            auth,
+            AuthRef::Cli { program: "claude".into(), login: None, retired: None }
+        );
     }
 }

--- a/crates/neosh-provider/src/catalog.rs
+++ b/crates/neosh-provider/src/catalog.rs
@@ -711,7 +711,18 @@ fn env(var: &str) -> AuthRef {
 
 /// A plan: a vendor CLI that carries its own login.
 fn cli(program: &str, login: &str) -> AuthRef {
-    AuthRef::Cli { program: program.into(), login: Some(login.into()) }
+    AuthRef::Cli { program: program.into(), login: Some(login.into()), retired: None }
+}
+
+/// A plan the vendor has stopped serving, and the sentence saying so.
+///
+/// Listed rather than deleted, for the reason an uninstalled CLI is listed: a provider that simply
+/// disappeared asks "where did it go" instead of answering it, and the answer here is one most
+/// people will otherwise go and look for in our bug tracker. The entry is not usable, so nothing
+/// defaults into it, and it is not *disabled* either — a plan can end for one tier and not another,
+/// and an account the vendor still serves must still be able to pick a model on it.
+fn retired_cli(program: &str, note: &str) -> AuthRef {
+    AuthRef::Cli { program: program.into(), login: None, retired: Some(note.into()) }
 }
 
 /// How each provider is drawn.
@@ -773,7 +784,23 @@ pub fn builtin_instances() -> Vec<InstanceConfig> {
             ("grok-4.6", "Grok 4.6", ModelTier::Frontier, "Latest Grok"),
             ("grok-4.5", "Grok 4.5", ModelTier::Balanced, "Previous generation"),
         ])),
-        instance("gemini-cli", "gemini-cli", "Gemini", None, cli("gemini", "gemini auth login"), acp_models(&[
+        // Google stopped serving Gemini CLI for individual accounts on 18 June 2026 — Code Assist
+        // for individuals, AI Pro and AI Ultra all at once — and withdrew "Login with Google"
+        // along with them; Code Assist Standard and Enterprise are unchanged, and everyone else is
+        // pointed at Antigravity. Which is why this is a note and not a deletion: the `gemini` on
+        // an Enterprise machine still works, and telling that user their CLI is missing would be
+        // the second wrong answer in a row. Not to be confused with the earlier crackdown on
+        // third-party software *borrowing* Gemini CLI's OAuth credentials — that never described
+        // us, because what is spawned here is Google's own binary doing its own login.
+        instance("gemini-cli", "gemini-cli", "Gemini", None, retired_cli(
+            "gemini",
+            // Front-loaded on purpose. Only the row under the cursor wraps its detail and this row
+            // is never under the cursor, so what a picker shows of this is the first thirty-odd
+            // columns of it — which have to be a whole clause rather than the first half of one.
+            // `^S` on the provider is where the rest of it is said.
+            "Individual accounts ended 18 June 2026 — Code Assist Standard and Enterprise still \
+             work. Use a Gemini API key instead.",
+        ), acp_models(&[
             ("gemini-3.1-pro-preview", "Gemini 3.1 Pro", ModelTier::Frontier, "Most capable Gemini"),
             ("gemini-3.8-flash", "Gemini 3.8 Flash", ModelTier::Balanced, "Quick, for everyday work"),
             ("gemini-3.1-flash-lite", "Gemini 3.1 Flash Lite", ModelTier::Fast, "Cheapest and fastest"),
@@ -853,6 +880,38 @@ mod tests {
         assert_eq!(merge(vec![], &seeds).len(), seeds.len());
     }
 
+
+    #[test]
+    fn a_plan_the_vendor_withdrew_is_still_in_the_catalogue() {
+        // Deleting the entry is the tempting fix and the wrong one twice over: Code Assist Standard
+        // and Enterprise still reach `gemini`, and somebody whose provider silently disappeared
+        // between two releases has nowhere to read why.
+        let g = builtin_instances().into_iter().find(|i| i.id.0 == "gemini-cli").unwrap();
+        let neosh_proto::AuthRef::Cli { retired, .. } = &g.auth else {
+            panic!("gemini-cli is still a plan");
+        };
+        let note = retired.as_deref().expect("says why it is no longer served");
+        assert!(note.contains("18 June 2026"), "a retirement without a date is a rumour");
+        assert!(!g.models.is_empty(), "and still lists what it offered");
+
+        let source = crate::credentials::credentials().source(&g);
+        assert!(!source.is_usable(), "so nothing defaults into it");
+        assert_eq!(source.summary(&g.auth), note, "and the note is what every reader shows");
+    }
+
+    #[test]
+    fn a_plan_that_is_merely_uninstalled_is_not_reported_as_retired() {
+        // The two states share a heading and need opposite sentences, so the one that is somebody's
+        // own machine must not start reading as the one that is Google's decision.
+        for id in ["claude-cli", "codex-cli", "cursor-cli", "grok-cli"] {
+            let inst = builtin_instances().into_iter().find(|i| i.id.0 == id).unwrap();
+            let neosh_proto::AuthRef::Cli { retired, login, .. } = &inst.auth else {
+                panic!("{id} is a plan");
+            };
+            assert!(retired.is_none(), "{id} is still served");
+            assert!(login.is_some(), "{id} needs the command that signs you in");
+        }
+    }
 
     #[test]
     fn every_builtin_instance_has_a_unique_id() {

--- a/crates/neosh-provider/src/credentials.rs
+++ b/crates/neosh-provider/src/credentials.rs
@@ -311,7 +311,14 @@ impl Credentials {
             // them would send you to the wrong page. Whether you are signed *in* is deliberately
             // not claimed — finding out means running it, and a wrong guess either way is worse
             // than saying where to look.
-            AuthRef::Cli { program, login } => match which(program) {
+            // A plan the vendor has stopped serving is answered before anything is looked up on
+            // this machine, because nothing on this machine is what went wrong. Whether the program
+            // is installed is not the question and "install it" is not the fix.
+            AuthRef::Cli { program, retired: Some(note), .. } => CredentialSource::PlanRetired {
+                program: program.clone(),
+                note: note.clone(),
+            },
+            AuthRef::Cli { program, login, .. } => match which(program) {
                 Some(_) => CredentialSource::Plan { via: program.clone() },
                 None => CredentialSource::PlanMissing {
                     program: program.clone(),

--- a/crates/neosh-provider/src/drivers/google.rs
+++ b/crates/neosh-provider/src/drivers/google.rs
@@ -5,9 +5,11 @@
 //! text parts flagged `thought: true`. Everything is normalized into [`ProviderEvent`] by
 //! [`crate::sse::gemini`] so the agent loop sees one shape.
 
+use std::collections::HashMap;
+
 use neosh_proto::{
     ContentBlock, DriverKind, InstanceConfig, Message, ModelInfo, ProviderEvent, Role,
-    ToolDef, TurnRequest,
+    ToolCallId, ToolDef, TurnRequest,
 };
 use secrecy::ExposeSecret;
 use serde_json::{Value, json};
@@ -18,6 +20,89 @@ use crate::drivers::http;
 use crate::{Provider, ProviderError, ProviderStream, resolve_auth, sse};
 
 const DEFAULT_BASE: &str = "https://generativelanguage.googleapis.com/v1beta";
+
+/// A tool's parameters, in the only schema dialect Gemini will accept.
+///
+/// `functionDeclarations[].parameters` is an **OpenAPI 3.0 `Schema`**, not JSON Schema, and the
+/// endpoint rejects the whole request over a field it does not know rather than ignoring it:
+/// `Invalid JSON payload received. Unknown name "additionalProperties" at
+/// 'tools[0].function_declarations[0].parameters'`. That is a provider that cannot run a single
+/// turn, not a tool that degrades — and it needs no unusual setup to hit, because `read_file`, the
+/// built-in, ends its schema with `additionalProperties: false`.
+///
+/// So the wire shape is built by **allowing** the fields Gemini documents rather than by stripping
+/// the ones we have watched it reject. The schemas arriving here are not ours: a plugin's tool and
+/// an MCP server's tool land in this field too, and a deny-list is a list somebody has to extend
+/// the first time one of them uses `$ref`, `propertyNames` or `patternProperties` — where the cost
+/// of having forgotten is the 400 above rather than a slightly loose parameter.
+///
+/// Dropping a constraint loosens what the model may send, which the tool validates on arrival
+/// anyway. Keeping one fails the request outright. Only one direction of that trade is recoverable.
+fn schema(v: &Value) -> Value {
+    // JSON Schema's boolean form (`true`/`false` in place of a schema object) has no spelling here
+    // at all, so it becomes the empty schema rather than a `parameters` of `true`.
+    let Some(obj) = v.as_object() else { return json!({}) };
+    let mut out = serde_json::Map::new();
+    for (k, val) in obj {
+        match k.as_str() {
+            // Taken as written.
+            "description" | "title" | "format" | "pattern" | "example" | "default" | "nullable"
+            | "enum" | "required" | "minimum" | "maximum" | "minLength" | "maxLength"
+            | "minItems" | "maxItems" | "minProperties" | "maxProperties" | "propertyOrdering" => {
+                out.insert(k.clone(), val.clone());
+            }
+            // `type` is an enum on Gemini's side, so it is spelled in the enum's own case. A JSON
+            // Schema *union* — `["string", "null"]`, which is how most generators write an optional
+            // field — is not a value that enum has; the nullable half of it is a separate field
+            // here, and the rest of the union is information this dialect cannot carry.
+            "type" => match val {
+                Value::String(t) => {
+                    out.insert("type".into(), json!(t.to_uppercase()));
+                }
+                Value::Array(types) => {
+                    if types.iter().any(|t| t.as_str() == Some("null")) {
+                        out.insert("nullable".into(), json!(true));
+                    }
+                    if let Some(t) =
+                        types.iter().filter_map(Value::as_str).find(|t| *t != "null")
+                    {
+                        out.insert("type".into(), json!(t.to_uppercase()));
+                    }
+                }
+                _ => {}
+            },
+            "properties" => {
+                let props: serde_json::Map<_, _> = val
+                    .as_object()
+                    .into_iter()
+                    .flatten()
+                    .map(|(name, p)| (name.clone(), schema(p)))
+                    .collect();
+                out.insert("properties".into(), props.into());
+            }
+            "items" => {
+                out.insert("items".into(), schema(val));
+            }
+            "anyOf" => {
+                let any: Vec<Value> =
+                    val.as_array().into_iter().flatten().map(schema).collect();
+                out.insert("anyOf".into(), any.into());
+            }
+            // `const` is JSON Schema's single-value enum, and an enum is exactly how Gemini spells
+            // it — so this one constraint survives translation instead of being dropped.
+            "const" => {
+                out.insert("enum".into(), json!([val]));
+            }
+            // Everything else. `$schema`, `$ref`, `$defs`, `definitions`, `allOf`, `oneOf`, `not`,
+            // `additionalProperties`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`,
+            // `patternProperties`, `propertyNames`, `uniqueItems`, `additionalItems` and
+            // `if`/`then`/`else` have no field on Gemini's `Schema`, and a keyword invented after
+            // this was written lands here too rather than in a 400.
+            _ => {}
+        }
+    }
+    out.into()
+}
 
 #[derive(Debug, Default)]
 pub struct GoogleProvider;
@@ -33,6 +118,20 @@ impl GoogleProvider {
     }
 
     pub fn contents(msgs: &[Message]) -> Vec<Value> {
+        // Gemini keys a tool result by the **function's name**, not by the id of the call it
+        // answers, so the name has to be carried forward from the `functionCall` that asked for it.
+        // Sending a literal `"tool"` — which is what this did — tells the model that a function it
+        // never called has returned, and the reply it writes is about nothing that happened. A
+        // parallel call to the same tool still cannot be disambiguated, because the wire format has
+        // no id to disambiguate it with; naming the function is as close as the shape allows.
+        let names: HashMap<&ToolCallId, &str> = msgs
+            .iter()
+            .flat_map(|m| &m.content)
+            .filter_map(|b| match b {
+                ContentBlock::ToolUse { id, name, .. } => Some((id, name.as_str())),
+                _ => None,
+            })
+            .collect();
         msgs.iter()
             .filter_map(|m| {
                 let parts: Vec<Value> = m
@@ -43,14 +142,21 @@ impl GoogleProvider {
                         ContentBlock::ToolUse { name, input, .. } => {
                             Some(json!({"functionCall": {"name": name, "args": input}}))
                         }
-                        ContentBlock::ToolResult { content, .. } => Some(json!({
-                            "functionResponse": {
-                                // Gemini keys responses by function name, not call id, so a
-                                // parallel call to the same tool cannot be disambiguated here.
-                                "name": "tool",
-                                "response": {"content": content},
-                            }
-                        })),
+                        ContentBlock::ToolResult { tool_use_id, content, is_error } => {
+                            Some(json!({
+                                "functionResponse": {
+                                    "name": names.get(tool_use_id).copied().unwrap_or("tool"),
+                                    // A `functionResponse` has no error channel, so a failure that
+                                    // is not said in the payload is a stack trace the model reads
+                                    // as the answer.
+                                    "response": if *is_error {
+                                        json!({"error": content})
+                                    } else {
+                                        json!({"content": content})
+                                    },
+                                }
+                            }))
+                        }
                         ContentBlock::Image { path, media_type } => Some(json!({
                             "inlineData": {
                                 "mimeType": media_type,
@@ -74,11 +180,21 @@ impl GoogleProvider {
 
     fn tools(tools: &[ToolDef]) -> Value {
         json!([{
-            "functionDeclarations": tools.iter().map(|t| json!({
-                "name": t.name,
-                "description": t.description,
-                "parameters": t.input_schema,
-            })).collect::<Vec<_>>()
+            "functionDeclarations": tools.iter().map(|t| {
+                let mut decl = json!({"name": t.name, "description": t.description});
+                let params = schema(&t.input_schema);
+                // A tool that takes nothing omits `parameters` rather than sending an object with
+                // no properties in it — which is what Google's guidance says, and what a schema of
+                // `{"type": "object"}` becomes once there is nothing else in it.
+                let has_params = params
+                    .get("properties")
+                    .and_then(Value::as_object)
+                    .is_some_and(|p| !p.is_empty());
+                if has_params {
+                    decl["parameters"] = params;
+                }
+                decl
+            }).collect::<Vec<_>>()
         }])
     }
 
@@ -344,6 +460,155 @@ mod tests {
         ]));
         assert_eq!(b["contents"][0]["parts"][0]["functionCall"]["name"], "read_file");
         assert_eq!(b["contents"][1]["parts"][0]["functionResponse"]["response"]["content"], "data");
+    }
+
+    fn tool(input_schema: Value) -> ToolDef {
+        ToolDef {
+            name: "read_file".into(),
+            description: "d".into(),
+            input_schema,
+            source: neosh_proto::ToolSource::Builtin,
+        }
+    }
+
+    fn params(input_schema: Value) -> Value {
+        let mut r = req(vec![]);
+        r.tools = vec![tool(input_schema)];
+        GoogleProvider::body(&r)["tools"][0]["functionDeclarations"][0].clone()
+    }
+
+    #[test]
+    fn a_schema_gemini_does_not_know_a_field_of_is_not_sent_verbatim() {
+        // The reported bug, end to end: `read_file`'s own schema, which ends in
+        // `additionalProperties: false`, used to reach the wire and 400 the whole turn.
+        let d = params(json!({
+            "type": "object",
+            "properties": {"path": {"type": "string", "description": "where"}},
+            "required": ["path"],
+            "additionalProperties": false,
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+        }));
+        let p = &d["parameters"];
+        assert!(p.get("additionalProperties").is_none(), "the field that 400s the request");
+        assert!(p.get("$schema").is_none());
+        assert_eq!(p["type"], "OBJECT");
+        assert_eq!(p["properties"]["path"]["type"], "STRING");
+        assert_eq!(p["properties"]["path"]["description"], "where");
+        assert_eq!(p["required"][0], "path");
+    }
+
+    #[test]
+    fn a_keyword_nobody_here_has_heard_of_is_dropped_rather_than_forwarded() {
+        // The allow-list is the point: an MCP server's schema is not ours to predict, and the cost
+        // of guessing wrong has to be a loose parameter rather than a provider that cannot answer.
+        let p = &params(json!({
+            "type": "object",
+            "properties": {
+                "a": {"type": "string", "patternProperties": {"^x": {}}, "propertyNames": {}},
+            },
+            "unevaluatedProperties": false,
+            "$defs": {"x": {"type": "string"}},
+            "allOf": [{"type": "object"}],
+        }))["parameters"];
+        for gone in ["unevaluatedProperties", "$defs", "allOf"] {
+            assert!(p.get(gone).is_none(), "{gone} reached the wire");
+        }
+        assert_eq!(p["properties"]["a"].as_object().unwrap().len(), 1, "only `type` survives");
+    }
+
+    #[test]
+    fn an_optional_field_written_as_a_union_becomes_a_nullable_one() {
+        // `["string", "null"]` is how most generators spell optional, and `type` is an enum here —
+        // so the array is not a value it has, and the request fails on the field before this one
+        // even gets looked at.
+        let p = &params(json!({
+            "type": "object",
+            "properties": {"note": {"type": ["string", "null"]}},
+        }))["parameters"];
+        assert_eq!(p["properties"]["note"]["type"], "STRING");
+        assert_eq!(p["properties"]["note"]["nullable"], true);
+    }
+
+    #[test]
+    fn nesting_is_walked_all_the_way_down() {
+        let p = &params(json!({
+            "type": "object",
+            "properties": {
+                "edits": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {"line": {"type": "integer", "exclusiveMinimum": 0}},
+                        "additionalProperties": false,
+                    },
+                },
+            },
+        }))["parameters"];
+        let item = &p["properties"]["edits"]["items"];
+        assert_eq!(item["type"], "OBJECT");
+        assert!(item.get("additionalProperties").is_none());
+        assert_eq!(item["properties"]["line"]["type"], "INTEGER");
+        assert!(item["properties"]["line"].get("exclusiveMinimum").is_none());
+    }
+
+    #[test]
+    fn a_single_valued_constraint_survives_as_the_enum_it_is() {
+        let p = &params(json!({
+            "type": "object",
+            "properties": {"mode": {"const": "read"}},
+        }))["parameters"];
+        assert_eq!(p["properties"]["mode"]["enum"], json!(["read"]));
+    }
+
+    #[test]
+    fn a_tool_that_takes_nothing_sends_no_parameters_at_all() {
+        // Rather than an OBJECT with an empty `properties`, which is what a bare `{"type":
+        // "object"}` would otherwise become.
+        let d = params(json!({"type": "object"}));
+        assert!(d.get("parameters").is_none());
+        assert_eq!(d["name"], "read_file");
+    }
+
+    #[test]
+    fn a_tool_result_is_named_by_the_call_it_answers() {
+        // Gemini keys a response by function name. A literal `"tool"` is a name nothing declared,
+        // so the model was being told that a function it never called had returned.
+        let b = GoogleProvider::body(&req(vec![
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::ToolUse {
+                    id: ToolCallId("c".into()),
+                    name: "read_file".into(),
+                    input: json!({"path": "a"}),
+                }],
+            },
+            Message {
+                role: Role::User,
+                content: vec![ContentBlock::ToolResult {
+                    tool_use_id: ToolCallId("c".into()),
+                    content: "data".into(),
+                    is_error: false,
+                }],
+            },
+        ]));
+        assert_eq!(b["contents"][1]["parts"][0]["functionResponse"]["name"], "read_file");
+    }
+
+    #[test]
+    fn a_failed_call_says_so_in_the_payload() {
+        // There is no error flag on a `functionResponse`, so a failure not said here is a stack
+        // trace the model reads as the answer.
+        let b = GoogleProvider::body(&req(vec![Message {
+            role: Role::User,
+            content: vec![ContentBlock::ToolResult {
+                tool_use_id: ToolCallId("c".into()),
+                content: "no such file".into(),
+                is_error: true,
+            }],
+        }]));
+        let r = &b["contents"][0]["parts"][0]["functionResponse"]["response"];
+        assert_eq!(r["error"], "no such file");
+        assert!(r.get("content").is_none());
     }
 
     #[test]

--- a/docs/config.md
+++ b/docs/config.md
@@ -1263,6 +1263,19 @@ setting that does not work.
 for a plan behind a vendor CLI, or `{ kind = "none" }` for a local endpoint that wants none.
 Nothing writes a secret to this file, and nothing reads one from it.
 
+A `cli` plan also takes `retired = "…"`, for when the **vendor** has stopped serving it. A plan can
+end without its CLI going anywhere — the program is installed, it runs, and the account behind it is
+no longer served — which needs a different sentence from "install it" because the fix is somewhere
+else entirely. It is the sentence rather than a flag so it can name the date, the tiers that still
+work and where to go instead. The instance stays listed and its models stay selectable, because a
+plan can end for one tier and not another and nothing here knows which one is reading; what changes
+is that nothing *defaults* into it and every list says why.
+
+`gemini-cli` ships this way: Google ended Gemini CLI for individual accounts on 18 June 2026 — Code
+Assist for individuals, AI Pro and AI Ultra together, with "Login with Google" withdrawn alongside
+them — while Code Assist Standard and Enterprise are unchanged. Use the `google` instance and a
+`GEMINI_API_KEY` unless you are on one of those.
+
 ## Options
 
 Options are declared, typed, and owned. You cannot set one that does not exist, and you cannot set

--- a/plugins/api/src/generated/AuthRef.ts
+++ b/plugins/api/src/generated/AuthRef.ts
@@ -9,6 +9,11 @@
 export type AuthRef =
   | { "kind": "env"; var: string }
   | { "kind": "command"; argv: Array<string> }
-  | { "kind": "cli"; program: string; login?: string | null }
+  | {
+    "kind": "cli";
+    program: string;
+    login?: string | null;
+    retired?: string | null;
+  }
   | { "kind": "inherited" }
   | { "kind": "none" };

--- a/plugins/api/src/generated/CredentialSource.ts
+++ b/plugins/api/src/generated/CredentialSource.ts
@@ -9,6 +9,7 @@
 export type CredentialSource =
   | { "kind": "plan"; via: string }
   | { "kind": "plan_missing"; program: string; hint?: string | null }
+  | { "kind": "plan_retired"; program: string; note: string }
   | { "kind": "env"; var: string }
   | { "kind": "keychain" }
   | { "kind": "session" }

--- a/plugins/builtin/model/main.ts
+++ b/plugins/builtin/model/main.ts
@@ -255,6 +255,10 @@ function describe(source: CredentialSource): string {
       return source.hint
         ? `${source.program} is not installed — then \`${source.hint}\``
         : `${source.program} is not installed`;
+    // Already a whole sentence, and deliberately: what a retired plan needs said is the date, the
+    // accounts it still serves and where to go instead, and none of that can be assembled here.
+    case "plan_retired":
+      return source.note;
     case "inherited":
       return "signs in on its own";
     // A key, and which of the four places it is coming from.
@@ -332,10 +336,17 @@ async function pickModel(neosh: Neosh): Promise<void> {
       const entries = await neosh.agent.listModels(c.instance).catch(() => [] as ModelEntry[]);
       // Why nothing here can be chosen, at the top, where it will be read before the list it is
       // about. `⨯` on the rail says *that* it is unavailable; this says what to do.
-      const blocked: PaneItem<ModelEntry>[] = c.driver_available
+      //
+      // A retired plan gets the same row and keeps its models selectable, which is the one place
+      // the two states differ. A missing CLI means nothing below can run; a plan the vendor
+      // withdrew from one tier still runs for the tiers it did not, and we cannot tell from here
+      // which one is reading. Disabling the list would be this program guessing about somebody
+      // else's billing and taking their working setup away on the guess.
+      const retired = c.source.kind === "plan_retired";
+      const blocked: PaneItem<ModelEntry>[] = c.driver_available && !retired
         ? []
         : [{
-            label: "unavailable",
+            label: retired ? "no longer served" : "unavailable",
             detail: describe(c.source),
             disabled: true,
             value: undefined as unknown as ModelEntry,
@@ -372,6 +383,13 @@ async function pickModel(neosh: Neosh): Promise<void> {
       const pressed = key.key.code.c.toLowerCase();
       if (pressed === "s") {
         if (!c) return "handled";
+        // Where the rest of a retired plan's sentence is said. The row in the pane is clipped to
+        // whatever the detail column has room for, and this key — which the hint row already
+        // advertises — is the one thing you would press on a provider that will not answer.
+        if (c.source.kind === "plan_retired") {
+          neosh.notify(`${c.display_name}: ${c.source.note}`, "warn");
+          return "handled";
+        }
         if (!c.accepts_key) {
           neosh.notify(`${c.display_name}: ${describe(c.source)}`, "info");
           return "handled";
@@ -561,6 +579,10 @@ function badgeFor(
     case "missing":
     case "plan_missing":
       return { text: "!", hl: "Account.Missing" };
+    // Not `!`, which means "you can fix this". Nobody here can: the vendor stopped serving it, and
+    // the only thing to do about it is read the row.
+    case "plan_retired":
+      return { text: glyphs.ascii ? "-" : "⨯", hl: "Comment" };
     case "not_needed":
       return undefined;
     case "plan":
@@ -756,6 +778,13 @@ async function pickProvider(neosh: Neosh): Promise<void> {
         : `${program} is not installed.`,
       "warn",
     );
+    return;
+  }
+  // Before the `accepts_key` branch below, which would say the same sentence at `info`. This is
+  // not an ordinary fact about a working provider — it is the reason the one you just chose will
+  // not answer — and the two read very differently going past.
+  if (chosen.source.kind === "plan_retired") {
+    neosh.notify(`${chosen.display_name}: ${chosen.source.note}`, "warn");
     return;
   }
   if (!chosen.accepts_key) {


### PR DESCRIPTION
Two Gemini problems that look like one and are not. #74 is the API-key path, which is the one Gemini route Google did *not* touch; the plan is the one that ended. Fixing either does nothing for the other.

## The bug — #74

```
Invalid JSON payload received. Unknown name "additionalProperties"
at 'tools[0].function_declarations[0].parameters': Cannot find field.
```

`functionDeclarations[].parameters` is an **OpenAPI 3.0 `Schema`**, not JSON Schema, and the endpoint rejects the whole request over a field it does not know rather than ignoring it. `GoogleProvider::tools` forwarded `input_schema` verbatim, and `read_file` — the built-in — ends its schema with `additionalProperties: false`. So this was **every turn with tools enabled, on a stock install**, not something the reporter had configured wrong.

The wire shape is now built by **allowing** the fields Gemini documents rather than by stripping the ones we have watched it reject. The schemas arriving there are not ours: a plugin's tool and an MCP server's tool land in the same field, and a deny-list is a list somebody has to extend the first time one of them uses `$ref`, `propertyNames` or `patternProperties` — where the cost of having forgotten is the 400 rather than a slightly loose parameter. Dropping a constraint loosens what the model may send, which the tool validates on arrival anyway. Keeping one fails the request outright. Only one direction of that trade is recoverable.

Two more the first fix would have walked straight into:

- **`type` is an enum on Gemini's side.** A JSON Schema union — `["string", "null"]`, which is how most generators spell an optional field — is not a value it has; the nullable half is a separate field here.
- **A `functionResponse` is keyed by the function's *name*.** This sent the literal `"tool"`. Fixing the schema alone would have got the first request through and then told the model that a function it never called had returned — a turn that reads as ignored rather than one that fails. The name is carried forward from the `ToolUse` that asked, and a failure now says so in the payload, since a response has no error channel.

Also: `const` survives as the single-value enum it is, and a tool that takes nothing omits `parameters` rather than sending an empty object.

## The plan

Google [ended Gemini CLI for individual accounts on 18 June 2026](https://developers.google.com/gemini-code-assist/docs/deprecations/code-assist-individuals) — Code Assist for individuals, AI Pro and AI Ultra together, with "Login with Google" withdrawn alongside them ([announcement](https://github.com/google-gemini/gemini-cli/discussions/28017)). Code Assist Standard and Enterprise are unchanged. So `gemini-cli` sat in the plans section telling most people to run `gemini auth login`, a command that no longer exists for their account.

Not to be confused with the [earlier crackdown](https://github.com/google-gemini/gemini-cli/discussions/22970) on third-party software *borrowing* Gemini CLI's OAuth credentials — that never described us, because what is spawned here is Google's own binary doing its own login. The distinction is written into the catalogue so it does not have to be re-derived.

`AuthRef::Cli` gains `retired` and `CredentialSource` gains `PlanRetired`. A note rather than a flag, because what has to be said is the date, the tiers that still work and where to go instead — a boolean would leave every reader inventing that sentence. Distinct from `PlanMissing` because the CLI is *fine*: it is installed, it runs, and the account behind it is not served. Telling somebody to install a program they already have is the one answer that sends them looking in the wrong place.

**Listed rather than deleted**, for the reason an uninstalled CLI is listed — a provider that silently disappeared asks "where did Gemini go" instead of answering it. **Not usable**, so nothing defaults into it. And **not disabled**: a plan can end for one tier and not another, nothing here knows which one is reading, and taking somebody's working setup away on that guess is the worse mistake.

```
 PLANS                  │   no longer served           Individual accounts ended 18 June
  ✳ Claude            ✓ │   Gemini 3.1 Pro        Frontier  Most capable Gemini
  ⬢ Codex             ✓ │   Gemini 3.8 Flash      Balanced  Quick, for everyday work
  ◩ Cursor            ! │   Gemini 3.1 Flash Lite Fast      Cheapest and fastest
❯ ◆ Gemini            ⨯ │
  ✕ Grok              ! │
```

`⨯` where an uninstalled CLI draws `!` — "nobody here can fix this" against "you can". The note is front-loaded because only the row under the cursor wraps its detail and this row never takes the cursor, so a picker shows the first thirty-odd columns and those have to be a whole clause. `^S`, which the hint row already advertises, prints the rest.

## Verification

`neosh-proto` 203 · `neosh-provider` 207 (13 google, 10 of them new) · `neosh` unit 290 · `neosh-core` 157 · `builtin_plugins` model subset 16 — all pass. Generated TS regenerates to two files and re-running produces no drift; `plugins/api` typechecks; zero build warnings.

The picker screenshot above is `scripts/shot.py` against the real binary in a sandboxed `--config-dir`, which is also what established the clipping rule the note is worded around.

Full `builtin_plugins` is 175 passed / 2 failed: `a_turn_runs_in_the_project…` and `switching_conversations_moves_the_working_directory_too`, the documented macOS `/private` symlink artefact — the same pair #79 names, and both pass on Linux.

Closes #74.
