### PR TITLE
fix(tabline): the bar dropped the one tab it exists to tell you about

### DIFF
--- a/crates/neosh-core/src/palette.rs
+++ b/crates/neosh-core/src/palette.rs
@@ -509,7 +509,12 @@ pub fn groups(variant: Variant) -> Vec<(&'static str, HighlightDef)> {
         // from the corner of your eye, and a separator one step up the same ramp is not.
         ("Pane.Active", spec(fg(r.accent))),
         ("Tabline.Tab", link("Comment")),
-        ("Tabline.Active", spec(bold(fg(r.fg)))),
+        // The accent, for the reason [`Pane.Active`] above wears it: the argument against a
+        // brighter grey does not stop being true one level up. Every tab in a project you have just
+        // started is called `new`, so the name distinguishes nothing and the colour is the whole
+        // answer to "which one am I in" — and bold-on-default against dim-grey is a difference you
+        // have to compare two labels to see, on a row whose job is to be glanced at.
+        ("Tabline.Active", spec(bold(fg(r.accent)))),
         // The keys, which wear what every other key in the workspace wears. A legend whose keys are
         // dimmer than its words is a legend nobody reads twice.
         ("Tabline.Key", link("Key")),

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -4997,34 +4997,112 @@ impl Host {
         let cost = |(k, l): &(String, String)| display_width(k) + display_width(l) + 2;
         // Two spaces between the keys and the last tab, so the bar never reads as one long run.
         let reserved = keys.first().map(cost).unwrap_or(0) + 2;
+
+        // `1` rather than `0`: the key is `<C-w>1`, and a bar counting from zero is a bar whose
+        // numbers are not the numbers you type.
+        let labels: Vec<String> = tabs
+            .iter()
+            .enumerate()
+            .map(|(n, tab)| format!(" {} {} ", n + 1, self.tab_title(view, tab)))
+            .collect();
+        let here = active
+            .and_then(|id| tabs.iter().position(|t| t.id == id))
+            .unwrap_or(0);
+        let mine = labels.get(here).map(|l| display_width(l)).unwrap_or(0);
         let room = match known {
-            true => width.saturating_sub(reserved),
+            // The reservation gives way rather than the tab you are in. `<C-w> windows` is fourteen
+            // columns, and a pane narrow enough that holding them leaves nothing behind is a pane
+            // where the bar read `+2` — three tabs open and not one of them named, the hint about
+            // the bar having crowded out the bar. A legend that does not fit is dropped by its own
+            // fitting below, so taking the room back here costs it nothing it could have used.
+            true => width.saturating_sub(reserved).max(mine.min(width)),
             false => usize::MAX,
         };
-
-        for (n, tab) in tabs.iter().enumerate() {
-            let name = self.tab_title(view, tab);
-            // `1` rather than `0`: the key is `<C-w>1`, and a bar counting from zero is a bar whose
-            // numbers are not the numbers you type.
-            let label = format!(" {} {} ", n + 1, name);
-            // Nothing is half-drawn. A tab label cut in the middle reads as a conversation with a
-            // different name, so the ones that do not fit are dropped and counted instead.
-            if display_width(&text) + display_width(&label) > room {
-                let more = format!(" +{} ", tabs.len() - n);
-                if display_width(&text) + display_width(&more) <= room {
-                    let from = text.len();
-                    text.push_str(&more);
-                    marks.push((from, text.len(), "Tabline.Tab".into()));
-                }
-                break;
+        // What was left out, on the side it was left out from. `+2` on the left and `+2` on the
+        // right are different sentences about where the tabs you cannot see are, and one counter at
+        // the end can only ever say the second of them.
+        let more = |n: usize| format!(" +{n} ");
+        // The room a window of tabs needs, counting what it leaves behind on either side.
+        let need = |lo: usize, hi: usize| -> usize {
+            let mut w: usize = labels[lo..=hi].iter().map(|l| display_width(l)).sum();
+            if lo > 0 {
+                w += display_width(&more(lo));
             }
-            let from = text.len();
-            text.push_str(&label);
-            let group = match Some(tab.id) == active {
-                true => "Tabline.Active",
-                false => "Tabline.Tab",
+            if hi + 1 < labels.len() {
+                w += display_width(&more(labels.len() - hi - 1));
+            }
+            w
+        };
+
+        // The tab you are in is what the room is spent on first, and the rest grow outward from it.
+        //
+        // Filled left to right and cut at the end, the bar dropped the one tab it exists to tell
+        // you about: four tabs open with the keyboard in the fourth read `1 foo  2 bar  +2`, which
+        // says where you are not. Nothing else on screen answers "which tab is this", so the answer
+        // has to survive the fitting rather than be the first thing it discards.
+        if !labels.is_empty() {
+            let (mut lo, mut hi) = (here, here);
+            loop {
+                let mut grew = false;
+                // Leftwards first, so the numbers on the bar keep counting up from wherever it
+                // starts rather than jumping.
+                if lo > 0 && need(lo - 1, hi) <= room {
+                    lo -= 1;
+                    grew = true;
+                }
+                if hi + 1 < labels.len() && need(lo, hi + 1) <= room {
+                    hi += 1;
+                    grew = true;
+                }
+                if !grew {
+                    break;
+                }
+            }
+
+            let left = (lo > 0).then(|| more(lo));
+            let right = (hi + 1 < labels.len()).then(|| more(labels.len() - hi - 1));
+            // What everything other than the tab you are in takes. The counters are dropped before
+            // that label is: a bar reading `+2` and nothing else has spent its only row saying how
+            // many answers it is not giving, and the number on the label — `3` — already says there
+            // are at least three tabs.
+            let others = need(lo, hi) - mine;
+            let counters: usize = [&left, &right]
+                .iter()
+                .flat_map(|m| m.iter())
+                .map(|m| display_width(m))
+                .sum();
+            let (left, right, others) = match room >= others + 1 {
+                true => (left, right, others),
+                false => (None, None, others - counters),
             };
-            marks.push((from, text.len(), group.into()));
+            if let Some(left) = left {
+                let from = text.len();
+                text.push_str(&left);
+                marks.push((from, text.len(), "Tabline.Tab".into()));
+            }
+            // Nothing is half-drawn. A tab label cut in the middle reads as a conversation with a
+            // different name — so every tab but the one you are in is dropped whole and counted.
+            // The one you are in is the exception, because dropping it is what this fitting exists
+            // to prevent: it is elided, with the `…` that says so, rather than left out.
+            let spare = room.saturating_sub(others);
+            for (n, label) in labels.iter().enumerate().take(hi + 1).skip(lo) {
+                let label = match n == here {
+                    true => elide(label, spare),
+                    false => label.clone(),
+                };
+                let from = text.len();
+                text.push_str(&label);
+                let group = match n == here {
+                    true => "Tabline.Active",
+                    false => "Tabline.Tab",
+                };
+                marks.push((from, text.len(), group.into()));
+            }
+            if let Some(right) = right {
+                let from = text.len();
+                text.push_str(&right);
+                marks.push((from, text.len(), "Tabline.Tab".into()));
+            }
         }
 
         // The legend, hard against the right edge. What it says depends on where you are, because a
@@ -14188,6 +14266,31 @@ fn chunk(text: impl Into<String>, hl: &str) -> neosh_proto::VirtChunk {
 fn display_width(s: &str) -> usize {
     use unicode_width::UnicodeWidthStr;
     s.width()
+}
+
+/// `s`, or as much of it as fits in `room` columns with an `…` saying so.
+///
+/// By grapheme cluster and by display width, not by `char`: a byte slice can land mid-character and
+/// a `char` count is wrong about the first emoji it meets. Room for nothing but the ellipsis gives
+/// the ellipsis, and a `room` of zero gives an empty string — a caller with no space left is not
+/// helped by one column of something.
+fn elide(s: &str, room: usize) -> String {
+    if display_width(s) <= room {
+        return s.to_string();
+    }
+    let Some(budget) = room.checked_sub(1) else { return String::new() };
+    let mut out = String::new();
+    let mut used = 0usize;
+    for g in s.graphemes(true) {
+        let w = display_width(g);
+        if used + w > budget {
+            break;
+        }
+        out.push_str(g);
+        used += w;
+    }
+    out.push('\u{2026}');
+    out
 }
 
 /// What the host learned about a directory the first time it looked: the display name, and the

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -8609,6 +8609,56 @@ fn a_tab_can_be_reached_by_its_number() {
     );
 }
 
+/// The bar is fitted to its width, and the one tab it must never drop is the one you are in.
+///
+/// Filled left to right and cut at the end, four tabs with the keyboard in the fourth read
+/// `1 new  2 new` — the row whose whole job is saying which conversations are open spending itself
+/// on the ones you are not in. Nothing else on screen answers "which tab is this", so the answer
+/// has to survive the fitting rather than be the first thing it discards. The tabs are all called
+/// `new` here, which is exactly the case that makes this matter: with no titles to tell them apart,
+/// the number on the bar is the only answer there is.
+#[test]
+fn the_bar_always_names_the_tab_you_are_in() {
+    let sb = Sandbox::new("tabline-keeps-active");
+    let mut s = sb.start();
+    s.wait_for("PROJECTS");
+
+    // Four tabs, landing in the fourth. `3` is this conversation again, which is the cheap one —
+    // what is being tested is the bar, not what the tabs hold.
+    for n in 2..=4 {
+        s.window_key("t");
+        assert!(s.pump(|s| s.buffer_named("[new tab]").is_some()), "the panel is up");
+        s.key("3");
+        assert!(
+            s.pump(|s| s.tabline_now().contains(&format!(" {n} "))),
+            "there are {n} tabs: {:?}",
+            s.tabline_now()
+        );
+    }
+
+    // Narrow enough that not all four can be on it. A stdio frontend reports no geometry of its
+    // own, so until this is said the bar has infinite room and nothing is ever dropped.
+    s.viewport("[tabs]", 30, 1);
+    assert!(
+        s.pump(|s| s.tabline_now().contains('+')),
+        "the bar had to leave something out: {:?}",
+        s.tabline_now()
+    );
+    assert!(
+        s.pump(|s| s.tabline_now().contains(" 4 ")),
+        "and what it left out is not the tab the keyboard is in: {:?}",
+        s.tabline_now()
+    );
+
+    // And it is a window that moves with you, not a rule about the end of the list.
+    s.window_key("1");
+    assert!(
+        s.pump(|s| s.tabline_now().contains(" 1 ")),
+        "the bar followed the keyboard back: {:?}",
+        s.tabline_now()
+    );
+}
+
 /// Every key the prefix panel advertises is a key that is actually bound.
 ///
 /// A legend is a promise about a keyboard, and the panel is built from the live registry — so the


### PR DESCRIPTION
## What was wrong

The tab strip fitted itself left to right and cut at the end, so it spent its row on the tabs you are **not** in. Four tabs open with the keyboard in the fourth read:

```
 1 foo  2 bar  +2
```

Nothing else on screen answers "which tab is this" — so the answer was the first thing the fitting discarded.

Worst in a project you have just started, which is where it was reported from: every conversation there is titled `new`, so the number is the only thing telling the tabs apart, and the number was what went missing.

Reproduced on screen with `scripts/shot.py` before anything was touched:

```
before:   1 fix/composer-paste-truncation  +2        ← on tab 3; tab 3 is not on the bar
after:    +2  3 chore/release-notes-0-4-1
```

## What changed

**The tab you are in is what the room is spent on first**, and the rest grow outward from it — a window that moves with the keyboard rather than a prefix of the list. What is left out is counted on the side it was left out from: `+2` on the left and `+2` on the right are different sentences about where the tabs you cannot see are, and one counter at the end can only ever say the second of them.

**Three things give way, in order, and the label you are on is last:**

1. The **reservation** held for `<C-w> windows` — fourteen columns, so a pane narrow enough that holding them leaves nothing behind was a pane whose bar read `+2`: the hint about the bar having crowded out the bar. A legend that does not fit is dropped by its own fitting anyway, so taking the room back costs it nothing it could have used.
2. The **counters**, because a row saying only how many answers it is not giving has spent itself — and the number on the label already says there are at least that many tabs.
3. Only then the **label**, elided with the `…` that says so. The one exception to nothing being half-drawn, because dropping it is what this exists to prevent.

**`Tabline.Active` wears the accent**, for the reason `Pane.Active` beside it already does — the palette's own comment argues an accent beats a step up the grey ramp, and bold-on-default against dim-grey is a difference you have to compare two labels to see.

## Verification

New regression test `the_bar_always_names_the_tab_you_are_in` — four tabs, a 30-column viewport, asserts the bar both dropped something *and* still names the tab the keyboard is in, then that the window follows you back to tab 1. Checked that it genuinely fails on the old code, which produced `1 new  2 new` — neither a `+` nor a ` 4 `.

- `cargo test -p neosh --test builtin_plugins` — 197 passed / 2 failed, the two known macOS `/var` vs `/private/var` path comparisons
- `cargo test -p neosh-core`, `--test plugin_manager` — green
- ts-rs export + `git diff --exit-code plugins/api/src/generated` — clean (no proto types touched)
- `npx tsc --noEmit` in `plugins/api` — clean

Also driven under a real pty at 110, 80 and 46 columns: active-in-the-middle, active-last, and the degenerate case where the tabline window is 11 columns wide and the label has to elide to ` +2  3 fea…`.