### PR TITLE
Relocate a worktree from the sidebar — `m`

### DIFF
--- a/crates/neosh-core/src/editor.rs
+++ b/crates/neosh-core/src/editor.rs
@@ -890,6 +890,7 @@ impl Editor {
                 | ApiCall::GitAddWorktree { .. }
                 | ApiCall::GitRemoveWorktree { .. }
                 | ApiCall::GitClone { .. }
+                | ApiCall::GitMoveWorktree { .. }
                 | ApiCall::GenComplete { .. }
                 | ApiCall::SessionList { .. }
                 | ApiCall::ViewList
@@ -2823,6 +2824,7 @@ fn call_name(call: &ApiCall) -> &'static str {
         ApiCall::GitAddWorktree { .. } => "git.addWorktree",
         ApiCall::GitRemoveWorktree { .. } => "git.removeWorktree",
         ApiCall::GitClone { .. } => "git.clone",
+        ApiCall::GitMoveWorktree { .. } => "git.moveWorktree",
         ApiCall::GenComplete { .. } => "gen.complete",
         ApiCall::PermissionGetMode => "permission.mode",
         ApiCall::PermissionSetMode { .. } => "permission.setMode",

--- a/crates/neosh-proto/src/api.rs
+++ b/crates/neosh-proto/src/api.rs
@@ -1565,6 +1565,28 @@ pub enum ApiCall {
         /// that a picker can *show* the destination on the row before anything is written.
         path: String,
     },
+    /// Move a linked worktree to another directory — `git worktree move`.
+    ///
+    /// The git part is a rename; the reason this is an API call rather than a shell-out is
+    /// everything that is *keyed by* the directory. A worktree's path is the key of the project
+    /// facts every list draws, of the conversations in it, of the project vars holding your pin
+    /// and your fold state, and of the working directory each vendor CLI was started in. Moving
+    /// the directory without moving all of that leaves a panel row pointing at nothing and an
+    /// agent running somewhere that no longer exists — so the host does both halves, and the
+    /// second half is the one it exists for. See `Host::relocated`.
+    ///
+    /// Refused while a turn is running in the tree: renaming a directory a CLI has open and is
+    /// writing files into can land an edit in the old place with nothing to say it did.
+    GitMoveWorktree {
+        path: String,
+        /// Where it lands, in full. The leaf must not exist; the parent is created.
+        dest: String,
+        /// The repository it belongs to. `git worktree move` runs from a checkout, and the
+        /// conversation the caller is in may be standing in the one being moved — the same reason
+        /// [`Self::GitRemoveWorktree`] takes one.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cwd: Option<String>,
+    },
 
     // ---- one-shot generation -------------------------------------------
     /// Run a prompt through a model *outside* the conversation.

--- a/crates/neosh-proto/src/plugin.rs
+++ b/crates/neosh-proto/src/plugin.rs
@@ -283,6 +283,22 @@ pub enum PluginEvent {
         #[ts(type = "unknown")]
         value: Option<serde_json::Value>,
     },
+    /// A project's directory is now somewhere else — a worktree that was moved.
+    ///
+    /// Said rather than derived, because a directory is an *identity* here and not a coordinate:
+    /// project vars are keyed by it, a panel's list is a list of them, and a plugin that had to
+    /// work out "the thing at `/a` is the thing now at `/b`" from a conversation whose `cwd`
+    /// changed would be guessing at exactly the moment it must not. The host has already moved
+    /// everything it owns — the conversations, the project vars, the facts every list draws — so
+    /// what this is for is the lists somebody else keeps.
+    ///
+    /// A re-key and not a remove-and-add, which is why one event carries both ends: told
+    /// separately, a panel would drop the row and put a stranger back, losing its place in an
+    /// order you arranged by hand.
+    ProjectMoved {
+        from: String,
+        to: String,
+    },
     /// Highlight groups were defined, reset, or replaced by a theme switch.
     ///
     /// Broadcast, because the plugin that cached a colour — a panel that computed a blend, a

--- a/crates/neosh-vcs/src/lib.rs
+++ b/crates/neosh-vcs/src/lib.rs
@@ -349,7 +349,17 @@ impl Git {
         // "Inside the repository" means inside the *main* checkout — the common dir's parent —
         // not inside whichever worktree this command happened to run from.
         let Some(main) = common.parent().map(Path::to_path_buf) else { return };
-        let Ok(rel) = path.strip_prefix(&main) else { return };
+        // Both sides resolved before they are compared. `rev-parse` answers with symlinks followed
+        // — `/private/var/…` on macOS, wherever `~/Code` really lives on anybody who keeps their
+        // projects on another volume — while `path` is whatever the caller was holding, which is
+        // the unresolved one. Compared as written, `strip_prefix` fails, this returns quietly, and
+        // the result is a repository that reports itself as one giant untracked directory for ever
+        // with nothing anywhere saying why. Only the *comparison* is canonical: the line written
+        // below is still relative, so what lands in `.gitignore` is `/.worktrees/` and not
+        // somebody's home directory.
+        let real_main = tokio::fs::canonicalize(&main).await.unwrap_or_else(|_| main.clone());
+        let real_path = tokio::fs::canonicalize(path).await.unwrap_or_else(|_| path.to_path_buf());
+        let Ok(rel) = real_path.strip_prefix(&real_main) else { return };
         let rel_text = rel.to_string_lossy().replace('\\', "/");
         if rel_text.is_empty() {
             return;
@@ -385,6 +395,42 @@ impl Git {
         }
         args.push(path.display().to_string());
         self.git(args).await.map(|_| ())
+    }
+
+    /// Move a linked worktree to another directory, keeping git's own bookkeeping in step.
+    ///
+    /// `git worktree move` is the only correct way to do this: a worktree is a directory *and* two
+    /// pointers — `.git` in the tree naming its admin directory, and `gitdir` in the admin
+    /// directory naming the tree — so a `mv` leaves a checkout git reports as `prunable` and a
+    /// repository that has forgotten where half of itself went.
+    ///
+    /// The parent is created and the leaf is not: git requires the destination itself not to
+    /// exist, and refuses when its parent does not either — which for "move this into the project"
+    /// is the common case, since `.worktrees/` may never have been made. Failing on a directory
+    /// this call could have created would be a refusal with nothing behind it.
+    ///
+    /// Then [`Self::exclude_if_inside`], for the same reason [`Self::add_worktree`] runs it: a tree
+    /// that has just been moved *into* the repository reports the whole checkout as one untracked
+    /// directory until the repository's `.gitignore` says otherwise. Best-effort there and
+    /// best-effort here — the move has already happened when it runs, and failing the call over a
+    /// status-noise fix would report an operation as failed after it worked.
+    ///
+    /// Nothing is taken *out* of `.gitignore` on the way back out: the line names the worktrees'
+    /// directory rather than this tree, its siblings may still be living there, and a shared file
+    /// this edited on both directions of travel would be churn everybody has to pull.
+    pub async fn move_worktree(&self, from: &Path, to: &Path) -> Result<(), VcsError> {
+        if let Some(parent) = to.parent() {
+            if !parent.as_os_str().is_empty() {
+                tokio::fs::create_dir_all(parent).await?;
+            }
+        }
+        // The paths go through as `OsStr` rather than `display().to_string()`: a directory name is
+        // not required to be UTF-8, and a lossy conversion here would hand git a path with a
+        // replacement character in it and fail on the one checkout that has an odd byte in its name.
+        self.git([OsStr::new("worktree"), OsStr::new("move"), from.as_os_str(), to.as_os_str()])
+            .await?;
+        self.exclude_if_inside(to).await;
+        Ok(())
     }
 
     /// Everything a status line or a prompt builder needs, gathered concurrently.

--- a/crates/neosh-vcs/tests/real_repo.rs
+++ b/crates/neosh-vcs/tests/real_repo.rs
@@ -170,6 +170,60 @@ async fn branches_worktrees_and_log_round_trip() {
     assert_eq!(git.default_branch().await.as_deref(), Some("main"));
 }
 
+/// A worktree moved into the repository and back out again, with git still able to find it.
+///
+/// The reason this is a real-git test and not a parser one: `git worktree move` rewrites two
+/// pointers that nothing in this crate can see — `.git` in the tree, `gitdir` in the admin
+/// directory — and the only honest way to check they still agree is to ask git afterwards. A plain
+/// `mv` passes every assertion about paths and leaves a checkout git calls `prunable`.
+#[tokio::test]
+async fn a_worktree_moves_in_and_out_of_the_repository() {
+    if !have_git() {
+        return;
+    }
+    let repo = Repo::new("worktree-move");
+    repo.write("a.txt", "1\n");
+    repo.git(&["add", "."]);
+    repo.git(&["commit", "-m", "initial"]);
+
+    let git = Git::discover(repo.path()).await.expect("repo");
+    let inside = repo.path().join(".worktrees").join("feature-thing");
+    git.add_worktree(&inside, "feature/thing", true).await.expect("add worktree");
+
+    // In the repository, so the whole checkout would otherwise read as one untracked directory.
+    // The line is in the tracked `.gitignore`, not `.git/info/exclude`, so every clone gets it.
+    let ignored = std::fs::read_to_string(repo.path().join(".gitignore")).unwrap_or_default();
+    assert!(ignored.lines().any(|l| l.trim() == "/.worktrees/"), "got {ignored:?}");
+
+    // Out of the repository, to a sibling — and to a parent that does not exist yet, which is the
+    // case `move_worktree` creates rather than refuses.
+    let outside = repo.path().parent().expect("parent").join("neosh-vcs-worktree-move-trees/thing");
+    git.move_worktree(&inside, &outside).await.expect("move out");
+    assert!(outside.join("a.txt").is_file(), "the checkout came with it");
+    assert!(!inside.exists(), "and left nothing behind");
+
+    let trees = git.worktrees().await.expect("worktrees");
+    let moved = trees.iter().find(|t| !t.is_main).expect("the linked tree is still listed");
+    assert_eq!(
+        std::fs::canonicalize(&moved.path).ok(),
+        std::fs::canonicalize(&outside).ok(),
+        "git knows where it went",
+    );
+    assert_eq!(moved.branch.as_deref(), Some("feature/thing"), "on the branch it was made on");
+
+    // And back in. Asking git from *inside the moved tree* is the half a `mv` breaks: it works
+    // only if the tree's own `.git` file still points at an admin directory that points back.
+    let back = repo.path().join(".worktrees").join("feature-thing");
+    git.move_worktree(&outside, &back).await.expect("move back in");
+    let from_tree = Git::discover(&back).await.expect("the moved tree is still a checkout");
+    assert_eq!(
+        from_tree.status().await.expect("status").repo.branch.as_deref(),
+        Some("feature/thing"),
+    );
+
+    let _ = std::fs::remove_dir_all(outside.parent().expect("sibling dir"));
+}
+
 #[tokio::test]
 async fn diff_and_commit_go_through() {
     if !have_git() {

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -2529,8 +2529,8 @@ impl Host {
             ApiCall::ProviderSetCredential { .. } => Err(ApiError::Internal {
                 message: "credential prompts are answered by the host loop".into(),
             }),
-            // On the host loop rather than through `spawn_slow`, and it is the *only* git write
-            // that is. `git branch -m` is one ref write — the same order of cost as the
+            // On the host loop rather than through `spawn_slow`, and these two are the only git
+            // writes that are. `git branch -m` is one ref write — the same order of cost as the
             // `rev-parse` `remember_repo` already awaits here — and what follows it cannot be done
             // from a spawned task: the branch is half of what [`ProjectFacts`] cached the first
             // time this directory was seen, so a rename that did not reach the host would leave
@@ -2541,6 +2541,55 @@ impl Host {
                 let svc = self.services(plugin);
                 svc.git_rename_branch(old.clone(), new, cwd.clone()).await?;
                 self.rebranded(&old, cwd.as_deref()).await;
+                Ok(ApiOk::Unit)
+            }
+            // The other one, and here for a stronger version of the same reason: a branch name is
+            // one field the host cached, and a directory is the *key* of four maps, the
+            // conversations in it and a file on disk. See [`Self::relocated`], which is the half of
+            // this call that could not be done from a spawned task.
+            //
+            // `git worktree move` is a rename — it refuses a cross-device move rather than copying
+            // — so there is no slow case here to keep off the loop.
+            ApiCall::GitMoveWorktree { path, dest, cwd } => {
+                let from = std::path::PathBuf::from(&path);
+                let to = std::path::PathBuf::from(&dest);
+                // Refused rather than survived. A vendor CLI holds its working directory from the
+                // moment it is spawned; renaming a tree an agent is mid-turn in can land the file
+                // it is writing in the old place, with nothing on screen to say it went there. One
+                // `<Esc>` is a much better price than a silently misplaced edit, and the message
+                // says which conversation to press it in.
+                // The ids first and the store second. `sessions()` is a plain `Mutex` guard and a
+                // `std::sync::Mutex` is not reentrant, so asking `sessions_under` while already
+                // holding one is not a borrow error, it is a workspace that stops answering.
+                let under = self.sessions_under(&from);
+                let busy: Vec<String> = {
+                    let store = self.agent.sessions();
+                    under
+                        .iter()
+                        .filter_map(|id| store.get(id))
+                        .filter(|s| s.active_turn.is_some())
+                        .map(|s| {
+                            s.title.clone().unwrap_or_else(|| {
+                                s.cwd
+                                    .file_name()
+                                    .map(|n| n.to_string_lossy().into_owned())
+                                    .unwrap_or_else(|| s.id.0.clone())
+                            })
+                        })
+                        .collect()
+                };
+                if !busy.is_empty() {
+                    return Err(ApiError::InvalidArgument {
+                        message: format!(
+                            "a turn is running in this worktree — interrupt it with <Esc> and \
+                             try again ({})",
+                            busy.join(", "),
+                        ),
+                    });
+                }
+                let svc = self.services(plugin);
+                svc.git_move_worktree(path, dest, cwd).await?;
+                self.relocated(&from, &to).await;
                 Ok(ApiOk::Unit)
             }
             ApiCall::SessionRename { session, title } => {
@@ -11306,6 +11355,122 @@ impl Host {
         // Every list that draws a conversation is drawing a name that just changed, and the panel
         // redraws on this. Not the same event as switching — nothing moved — but it is the one
         // signal a thread list already listens to for "the conversations are not what you drew".
+        self.broadcast(PluginEvent::SessionChanged {
+            session: self.active_session(),
+            view: self.from.view,
+        });
+        self.refresh_status();
+    }
+
+    /// Which live conversations are in `dir` or under it.
+    ///
+    /// "Under it" as well as "in it", because a worktree is a directory somebody works *in*: a
+    /// conversation started in `<tree>/crates/neosh-tui` is as much a conversation in that tree as
+    /// one started at its root, and a move that re-pointed only the exact matches would leave the
+    /// nested ones naming a path that no longer exists.
+    ///
+    /// A path comparison rather than a string one: `starts_with` on a `Path` is by component, so
+    /// `/w/tree-2` is not read as being inside `/w/tree`.
+    fn sessions_under(&self, dir: &std::path::Path) -> Vec<neosh_proto::SessionId> {
+        self.agent
+            .sessions()
+            .iter()
+            .filter(|s| s.cwd.starts_with(dir))
+            .map(|s| s.id.clone())
+            .collect()
+    }
+
+    /// A worktree's directory moved: put right everything the host had keyed by where it was.
+    ///
+    /// [`Self::rebranded`] is the same shape one field along — a label the host cached and then
+    /// drew on every frame — and this is the harder version of it, because a directory is not a
+    /// label. It is the key of the facts every list draws, of the conversations that live there, of
+    /// the project vars holding somebody's pin, and of the working directory each vendor CLI was
+    /// started in. Four maps and a disk file, and a move that updates three of them is a workspace
+    /// pointing at a directory that is not there any more.
+    ///
+    /// In order, and each for its own reason:
+    ///
+    /// * **The conversations.** `Session::cwd` is what the agent's tools resolve against and what
+    ///   every panel groups by, and this is the only thing in the workspace that rewrites one.
+    ///   Persisted immediately: a workspace that stopped between the `git worktree move` and the
+    ///   next autosave would come back with every conversation in the tree pointing at nothing.
+    /// * **The facts and the repository handle.** Re-asked through [`Self::remember_repo`] rather
+    ///   than moved across, for the reason `rebranded` re-asks: `identity()` is the call they were
+    ///   built from, so a move that half happened is simply not reflected rather than confidently
+    ///   wrong.
+    /// * **The project vars.** The pin, the fold, the rank and the name the panel remembered. See
+    ///   [`crate::vars::Vars::rename_project`]; the listeners are told, or every cache holding an
+    ///   arrangement is now wrong and nothing said so.
+    /// * **The vendor CLIs.** One process per conversation, each started in a directory that has
+    ///   moved out from under it. Closed rather than migrated — a CLI's cwd is fixed at spawn and
+    ///   there is no message in any of these protocols for "you are somewhere else now" — so the
+    ///   next turn starts one in the right place and resumes by id. Safe precisely because the call
+    ///   refused to run while a turn was in flight.
+    ///
+    /// And `self.cwd` last, when the host was itself standing in the tree: it is what a new
+    /// conversation with no directory of its own inherits.
+    async fn relocated(&mut self, from: &std::path::Path, to: &std::path::Path) {
+        let moved = self.sessions_under(from);
+        {
+            let mut store = self.agent.sessions();
+            for id in &moved {
+                let Some(s) = store.get_mut(id) else { continue };
+                // The tail is what makes a nested conversation follow its tree: `<from>/a/b`
+                // becomes `<to>/a/b`. The tree's own root has an *empty* tail, and `join("")`
+                // appends a separator rather than doing nothing — so the root came out as
+                // `<to>/`, which is the same directory under a spelling nothing else uses. Every
+                // list keyed by the path then held both: two rows for one worktree, and a second
+                // entry in `sidebar.projects` that no amount of moving it again would clear.
+                let Ok(tail) = s.cwd.strip_prefix(from) else { continue };
+                s.cwd = if tail.as_os_str().is_empty() { to.to_path_buf() } else { to.join(tail) };
+            }
+        }
+        self.persist_sessions();
+
+        self.projects.remove(from);
+        self.repos.remove(from);
+        self.project_keys.remove(from);
+        self.remember_repo(to.to_path_buf()).await;
+        // Every directory the move carried, not only the tree's root: a conversation in a
+        // subdirectory has facts of its own under a key that has just changed.
+        for id in &moved {
+            let dir = { self.agent.sessions().get(id).map(|s| s.cwd.clone()) };
+            let Some(dir) = dir else { continue };
+            self.remember_repo(dir).await;
+        }
+
+        let old = from.display().to_string();
+        let new = to.display().to_string();
+        for (key, value) in self.vars.rename_project(&old, &new) {
+            self.broadcast(PluginEvent::VarChanged {
+                scope: neosh_proto::VarScope::Project { cwd: new.clone() },
+                key,
+                value: Some(value),
+            });
+        }
+
+        for id in &moved {
+            for d in &self.agent_drivers {
+                d.close_conversation(id);
+            }
+        }
+
+        let here = self
+            .cwd
+            .strip_prefix(from)
+            .map(|tail| if tail.as_os_str().is_empty() { to.to_path_buf() } else { to.join(tail) })
+            .ok();
+        if let Some(here) = here {
+            self.work_in(here).await;
+        }
+
+        // Said rather than left to be worked out: a panel keeping a list of directories cannot tell
+        // "the thing at `from` is the thing at `to`" from "one project went and another arrived",
+        // and the difference is whether it keeps your place in an order you arranged by hand.
+        self.broadcast(PluginEvent::ProjectMoved { from: old, to: new });
+        // The same signal `rebranded` ends on, for the same reason: every list drawing a
+        // conversation is drawing something that just changed.
         self.broadcast(PluginEvent::SessionChanged {
             session: self.active_session(),
             view: self.from.view,

--- a/crates/neosh/src/services.rs
+++ b/crates/neosh/src/services.rs
@@ -405,6 +405,18 @@ impl Services {
         Ok(ApiOk::Unit)
     }
 
+    pub async fn git_move_worktree(
+        &self,
+        path: String,
+        dest: String,
+        cwd: Option<String>,
+    ) -> ApiResult {
+        self.permit_write("worktree move")?;
+        let repo = self.repo_at(cwd).await?;
+        repo.move_worktree(&PathBuf::from(path), &PathBuf::from(dest)).await.map_err(vcs_err)?;
+        Ok(ApiOk::Unit)
+    }
+
     // ---- models ----------------------------------------------------------
 
     /// Every reachable model, paired with the instance that serves it.

--- a/crates/neosh/src/vars.rs
+++ b/crates/neosh/src/vars.rs
@@ -113,6 +113,48 @@ impl Vars {
         }
     }
 
+    /// A project's directory moved: carry everything set on it across.
+    ///
+    /// A project scope is keyed by the path, so a worktree that has been relocated would otherwise
+    /// leave its pin, its fold state and its rank behind under a directory that no longer exists —
+    /// and arrive at the far end as a project nobody has ever arranged. The keys are what the panel
+    /// calls an arrangement, and losing one because a directory moved is the thing vars exist to
+    /// prevent.
+    ///
+    /// Whatever is already at `to` wins. A destination with vars on it is a directory somebody has
+    /// worked in before, and their arrangement of it is a decision; the tree arriving has no claim
+    /// to overwrite it. The old scope goes either way — leaving it would put a ghost project back
+    /// on the panel's list the next time anything read it.
+    ///
+    /// Returns the keys that landed, so their listeners can be told: a var that changes without a
+    /// [`neosh_proto::PluginEvent::VarChanged`] is a cache somewhere that is now wrong.
+    pub fn rename_project(&mut self, from: &str, to: &str) -> Map<String, Value> {
+        self.load();
+        if from == to {
+            return Map::new();
+        }
+        let old = Self::key(&VarScope::Project { cwd: from.to_string() });
+        let new = Self::key(&VarScope::Project { cwd: to.to_string() });
+        let Some(moved) = self.scopes.remove(&old) else { return Map::new() };
+        // Nothing to carry, and nothing to create: an empty scope is removed rather than left
+        // behind here as everywhere else in this file.
+        if moved.is_empty() {
+            self.flush();
+            return Map::new();
+        }
+        let entry = self.scopes.entry(new).or_default();
+        let mut landed = Map::new();
+        for (key, value) in moved {
+            if entry.contains_key(&key) {
+                continue;
+            }
+            entry.insert(key.clone(), value.clone());
+            landed.insert(key, value);
+        }
+        self.flush();
+        landed
+    }
+
     /// The on-disk name of a scope. Prefixed by kind so a project whose path happens to look like a
     /// conversation id cannot collide with one.
     fn key(scope: &VarScope) -> String {

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -1190,6 +1190,192 @@ fn a_branch_name_without_its_json_envelope_still_names_the_branch() {
     );
 }
 
+/// Moving a worktree takes the conversations in it with it.
+///
+/// The git call is the easy half and is covered in `neosh-vcs`. What this is about is the half a
+/// `git worktree move` on its own cannot do: a worktree's path is the key of the facts every list
+/// draws, of the conversations living there, and of the project vars holding somebody's pin — so a
+/// move that only moved the directory would leave the panel pointing at nothing and the agent
+/// running somewhere that is not there. `Host::relocated` is what this asserts, one field at a
+/// time.
+#[test]
+fn moving_a_worktree_takes_its_conversations_and_its_arrangement_with_it() {
+    if !have_git() {
+        return;
+    }
+    let sb = Sandbox::new("wtmove");
+    sb.git_init();
+    let mut s = sb.start();
+    s.wait_for("PROJECTS");
+
+    // A tree inside the repository, with a conversation in it — which is what `new.inside` makes:
+    // it creates the worktree and lands you in it.
+    s.send(&command("git.worktree.new.inside"));
+    let under = sb.work().join(".worktrees");
+    assert!(
+        s.pump(|_| std::fs::read_dir(&under).is_ok_and(|d| d.count() > 0)),
+        "the worktree exists"
+    );
+    // Resolved, because the workspace's copy of this path came from git and git follows symlinks:
+    // on macOS the sandbox is under `/tmp`, which is `/private/tmp`, and a worktree named by the
+    // unresolved spelling is a worktree the panel has never heard of. The product compares paths
+    // as strings — as removing one does — so it is the test's job to name it the way git does.
+    let from = std::fs::read_dir(&under)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .next()
+        .and_then(|p| std::fs::canonicalize(p).ok())
+        .expect("one worktree");
+    let branch = head_of(&from);
+    // Waited for, not assumed: creating the tree also starts a conversation in it, and asserting
+    // before that lands is asserting about the main checkout.
+    let leaf = from.file_name().unwrap().to_string_lossy().into_owned();
+    assert!(
+        s.pump({
+            let leaf = leaf.clone();
+            move |s| s.sidebar_now().iter().any(|l| l.contains(leaf.trim_end_matches('/')))
+                || s.sidebar_now().iter().any(|l| l.contains(&branch))
+        }),
+        "the tree is a row in the panel\n{:?}",
+        s.sidebar_now()
+    );
+
+    // Out of the repository, to a sibling of it. Both paths given, so this is the scripted form
+    // and no picker is involved — the picker is a separate test, and what is under test here is
+    // what happens *after* a destination has been chosen.
+    let to = std::fs::canonicalize(&sb.root).unwrap_or_else(|_| sb.root.clone()).join("moved-tree");
+    s.send(&format!(
+        r#"{{"type":"command","name":"git.worktree.move","args":["{}","{}"]}}"#,
+        from.display(),
+        to.display(),
+    ));
+
+    assert!(
+        s.pump(|_| to.join(".git").exists() && !from.exists()),
+        "the checkout moved and left nothing behind\n{:?}",
+        s.texts()
+            .iter()
+            .filter(|t| t.contains("worktree") || t.contains("moved") || t.contains("git"))
+            .collect::<Vec<_>>()
+    );
+
+    // The conversation followed. This is the field nothing else in the workspace rewrites, and
+    // without it the agent's tools would resolve against a directory that no longer exists.
+    assert!(
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("moved-tree"))
+            || s.sidebar_now().iter().any(|l| l.contains(&head_of(&to)))),
+        "the panel is drawing the tree where it is now\n{:?}",
+        s.sidebar_now()
+    );
+
+    // And the old path is not still a row beside it. A move that reads as "one project went and
+    // another arrived" is the bug `PluginEvent::ProjectMoved` exists to prevent: the list would
+    // keep both, and the cursor would land on a directory that is not there.
+    let stale = from.display().to_string();
+    assert!(
+        !s.sidebar_now().iter().any(|l| l.contains(&stale)),
+        "and the directory it left is not still listed\n{:?}",
+        s.sidebar_now()
+    );
+
+    // The project vars came across — this is the pin, the fold and the rank. Read off disk rather
+    // than through the panel, because what is being asserted is that the *store* re-keyed rather
+    // than that one panel happened to redraw.
+    let vars = std::fs::read_to_string(sb.root.join("state/vars.json")).unwrap_or_default();
+    assert!(
+        !vars.contains(&format!("project:{}", from.display())),
+        "nothing is still filed under where it was\n{vars}"
+    );
+
+    // **Once.** Not "the new path is present and the old one is not" — that passed while the
+    // destination was on the list twice, because a conversation at the tree's own root has an
+    // empty tail and `to.join("")` appends a separator: `/…/moved-tree` and `/…/moved-tree/` are
+    // one directory under two spellings, and every list keyed by the path kept both. A duplicate
+    // is invisible to an assertion about membership and obvious in the panel, which is exactly the
+    // class of bug this file exists to hold on to.
+    let listed = |v: &str| {
+        let want = to.display().to_string();
+        serde_json::from_str::<serde_json::Value>(v)
+            .ok()
+            .and_then(|j| j["global"]["sidebar.projects"].as_array().cloned())
+            .unwrap_or_default()
+            .iter()
+            .filter(|p| p.as_str().is_some_and(|p| p.trim_end_matches('/') == want))
+            .count()
+    };
+    assert_eq!(listed(&vars), 1, "the panel's list names it exactly once\n{vars}");
+}
+
+/// `m` on a worktree row offers the same places `^N` offers when it makes one.
+///
+/// The point of the feature, and the thing that made it worth a picker rather than a path prompt:
+/// somebody who has learnt that "In this project" means `.worktrees/` when they create a tree has
+/// learnt what it means when they move one. Every row names its resolved path, and the row for
+/// where the tree already is says so rather than being quietly dropped — a menu that hides the
+/// answer you were looking for reads as the option not existing.
+#[test]
+fn moving_a_worktree_offers_the_places_a_new_one_would_go() {
+    if !have_git() {
+        return;
+    }
+    let sb = Sandbox::new("wtmovewhere");
+    sb.git_init();
+    let mut s = sb.start();
+    s.wait_for("PROJECTS");
+
+    s.send(&command("git.worktree.new.inside"));
+    let under = sb.work().join(".worktrees");
+    assert!(
+        s.pump(|_| std::fs::read_dir(&under).is_ok_and(|d| d.count() > 0)),
+        "the worktree exists"
+    );
+    // Resolved for the reason the move test resolves it: git's spelling of this path is the one
+    // the workspace is holding.
+    let tree = std::fs::read_dir(&under)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .next()
+        .and_then(|p| std::fs::canonicalize(p).ok())
+        .expect("one worktree");
+
+    // The tree named, so the first picker is skipped and the one under test is the destination.
+    s.send(&command_with("git.worktree.move", &tree.display().to_string()));
+    // The picker names its buffer after its title, which here is the branch being moved.
+    let named = |s: &Session| {
+        s.events.iter().find_map(|e| {
+            let n = e["name"].as_str()?;
+            (e["type"] == "buffer_opened" && n.starts_with("[Move ")).then(|| n.to_string())
+        })
+    };
+    // Waited on the *rows*, not on the buffer: a picker opens its buffer before it has anything in
+    // it, and reading at that moment is reading an empty float that is about to be correct.
+    let rows_now =
+        |s: &Session| named(s).map(|n| s.picker_named(&n)).unwrap_or_default();
+    assert!(s.pump(|s| !rows_now(s).is_empty()), "the destination picker opened with rows in it");
+    let rows = rows_now(&s);
+
+    assert!(
+        rows.iter().any(|l| l.contains("In this project")),
+        "the place it can be kept in the repository\n{rows:?}"
+    );
+    assert!(
+        rows.iter().any(|l| l.contains("Beside the repository")),
+        "and the place beside it\n{rows:?}"
+    );
+    assert!(
+        rows.iter().any(|l| l.contains("Somewhere else")),
+        "and the path field, for one nobody listed\n{rows:?}"
+    );
+    // Where it is now is a row, and says so. Hiding it would leave a menu of two places for a
+    // repository that has three.
+    assert!(
+        rows.iter().any(|l| l.contains("where it is now")),
+        "the row for where it already is says so\n{rows:?}"
+    );
+}
+
 /// Which branch a checkout is on, asked of git rather than of anything under test.
 fn head_of(dir: &Path) -> String {
     let out = Command::new("git")

--- a/plugins/api/src/generated/ApiCall.ts
+++ b/plugins/api/src/generated/ApiCall.ts
@@ -522,6 +522,20 @@ export type ApiCall =
     path: string;
   }
   | {
+    "call": "git_move_worktree";
+    path: string;
+    /**
+     * Where it lands, in full. The leaf must not exist; the parent is created.
+     */
+    dest: string;
+    /**
+     * The repository it belongs to. `git worktree move` runs from a checkout, and the
+     * conversation the caller is in may be standing in the one being moved — the same reason
+     * [`Self::GitRemoveWorktree`] takes one.
+     */
+    cwd?: string | null;
+  }
+  | {
     "call": "gen_complete";
     prompt: string;
     system?: string | null;

--- a/plugins/api/src/generated/PluginEvent.ts
+++ b/plugins/api/src/generated/PluginEvent.ts
@@ -63,6 +63,7 @@ export type PluginEvent =
   | { "type": "composer_changed"; text: string }
   | { "type": "event"; name: string; data?: unknown; from: string }
   | { "type": "var_changed"; scope: VarScope; key: string; value?: unknown }
+  | { "type": "project_moved"; from: string; to: string }
   | { "type": "highlight_changed"; names: Array<string> }
   | { "type": "contributions_changed"; point: string }
   | { "type": "swarm_changed" }

--- a/plugins/api/src/index.ts
+++ b/plugins/api/src/index.ts
@@ -444,6 +444,8 @@ export interface Neosh {
   readonly opt: OptionApi;
   readonly state: StateApi;
   readonly vars: VarApi;
+  /** The directories somebody works in. See {@link ProjectApi}. */
+  readonly project: ProjectApi;
   readonly ext: ExtensionApi;
   readonly event: EventApi;
   readonly swarm: SwarmApi;
@@ -1212,6 +1214,24 @@ export interface GitApi {
    */
   removeWorktree(path: string, opts?: { force?: boolean; cwd?: string }): Promise<void>;
   /**
+   * Move a worktree to `dest` — `git worktree move`, and everything that has to follow it.
+   *
+   * A worktree's path is an identity here, not a coordinate: it is the key of the project facts
+   * every list draws, of the conversations living in it, of the project vars holding a pin and a
+   * fold state, and of the working directory each vendor CLI was started in. This call moves all
+   * of them, which is why it is a call rather than a `git worktree move` you could have run
+   * yourself — the git part is the part that was never hard.
+   *
+   * `dest` is the full path it lands at. Its parent is created; the leaf must not exist.
+   *
+   * Refused while a turn is running anywhere in the tree, because a CLI holds its working
+   * directory from the moment it is spawned and would otherwise write the file it is editing into
+   * the place the tree used to be. Interrupt it and ask again.
+   *
+   * `cwd` names the repository, as everywhere.
+   */
+  moveWorktree(path: string, dest: string, opts?: { cwd?: string }): Promise<void>;
+  /**
    * Clone `url` into `path`, resolving to the path once it is there.
    *
    * The one call here with no `cwd`: everything else asks a repository a question, and this one
@@ -1551,6 +1571,27 @@ export interface VarApi {
   onChange(
     cb: (e: { scope: VarScope; key: string; value: unknown }) => void,
   ): Disposable;
+}
+
+/**
+ * The directories somebody works in, and the one thing that can happen to one.
+ *
+ * A project *is* its path everywhere else in this API — `projectScope` keys vars by it, a panel's
+ * list is a list of them, `SessionInfo.cwd` names one. Which is exactly why a path that changes
+ * needs saying out loud rather than inferring: from the outside, a worktree that moved and a
+ * project that was deleted while another was added are the same two facts in the same order.
+ */
+export interface ProjectApi {
+  /**
+   * A project's directory is now somewhere else — a worktree that was relocated.
+   *
+   * The host has already moved everything it owns by the time this arrives: the conversations, the
+   * project vars, the names and branches every list draws. What is left is whatever *you* keyed by
+   * the old path — a list of directories, a cache, a decoration target — and the point of getting
+   * both ends in one event is that you can re-key in place instead of dropping a row and gaining a
+   * stranger.
+   */
+  onMove(cb: (e: { from: string; to: string }) => void): Disposable;
 }
 
 /** Sugar for the two scopes anything with a panel spends its time in. */
@@ -1980,6 +2021,7 @@ interface Registered {
   composerListeners: Array<(e: { text: string }) => void>;
   activityListeners: Array<(e: { session: SessionId; turn: string; activity: Activity }) => void>;
   varListeners: Array<(e: { scope: VarScope; key: string; value: unknown }) => void>;
+  projectMovedListeners: Array<(e: { from: string; to: string }) => void>;
   swarmListeners: Array<() => void>;
   quotaListeners: Array<(snapshot: QuotaSnapshot) => void>;
   swarmStreamListeners: Array<
@@ -2026,6 +2068,7 @@ function reg(plugin: string): Registered {
       composerListeners: [],
       activityListeners: [],
       varListeners: [],
+      projectMovedListeners: [],
       swarmListeners: [],
       quotaListeners: [],
       swarmStreamListeners: [],
@@ -2238,6 +2281,11 @@ function build(
       },
       onChange(cb) {
         return listener(r.varListeners, cb);
+      },
+    },
+    project: {
+      onMove(cb) {
+        return listener(r.projectMovedListeners, cb);
       },
     },
     ext: {
@@ -2938,6 +2986,9 @@ function build(
           cwd: opts?.cwd ?? null,
         });
       },
+      async moveWorktree(path, dest, opts) {
+        await c({ call: "git_move_worktree", path, dest, cwd: opts?.cwd ?? null });
+      },
       async clone(url, path) {
         const v = await c({ call: "git_clone", url, path });
         return expect(v, "text").text;
@@ -3295,6 +3346,9 @@ async function dispatchEvent(
       case "var_changed":
         for (const cb of r.varListeners)
           cb({ scope: ev.scope, key: ev.key, value: ev.value });
+        break;
+      case "project_moved":
+        for (const cb of r.projectMovedListeners) cb({ from: ev.from, to: ev.to });
         break;
       case "quota":
         for (const cb of [...r.quotaListeners]) cb(ev.snapshot);

--- a/plugins/builtin/git/main.ts
+++ b/plugins/builtin/git/main.ts
@@ -48,6 +48,7 @@ import {
   spinnerFrame,
   statusPrefix,
 } from "@neosh/api/ui";
+import type { PickerItem } from "@neosh/api/ui";
 
 // ---------------------------------------------------------------------------
 // Default prompts
@@ -184,6 +185,15 @@ two-word scratch name it was created with.",
       (args: string[]) => removeWorktree(neosh, { path: arg(args, 0), cwd: arg(args, 1) }),
       "Remove a worktree — `git.worktree.remove [path] [cwd]`",
     ],
+    [
+      "git.worktree.move",
+      // Same shape one argument further: the tree, then where it goes. Both optional and both
+      // asked for when missing, so this is the palette's verb, the panel's verb and a script's
+      // verb without any of them needing a form of its own.
+      (args: string[]) =>
+        moveWorktree(neosh, { path: arg(args, 0), dest: arg(args, 1), cwd: arg(args, 2) }),
+      "Move a worktree somewhere else — `git.worktree.move [path] [dest] [cwd]`",
+    ],
     // The sidebar hands a row over as `(kind, cwd, …)`, which is not the shape the commands above
     // take from the palette. Two small verbs translate rather than every command growing a second
     // calling convention.
@@ -196,6 +206,11 @@ two-word scratch name it was created with.",
       "git.sidebar.worktree.remove",
       (args: string[]) => removeWorktree(neosh, { path: arg(args, 1), cwd: arg(args, 1) }),
       "Remove the worktree of the sidebar row under the cursor",
+    ],
+    [
+      "git.sidebar.worktree.move",
+      (args: string[]) => moveWorktree(neosh, { path: arg(args, 1), cwd: arg(args, 1) }),
+      "Move the worktree of the sidebar row under the cursor",
     ],
   ];
   for (const [name, fn, desc] of cmds) {
@@ -231,6 +246,16 @@ two-word scratch name it was created with.",
     key: "d",
     label: "remove worktree",
     command: "git.sidebar.worktree.remove",
+    on: "project",
+  });
+  // `m` for move, on the rows it can mean something on. A plain letter rather than a chord for the
+  // reason `d` and `p` are: the panel is not a text field, and the letters that read as the verb
+  // are the ones worth spending. Nothing global — a verb about the row under the cursor asked from
+  // a conversation has no row to be about, and `^K` runs `git.worktree.move` by name.
+  await neosh.ext.contribute("sidebar.action", "worktree-move", {
+    key: "m",
+    label: "move worktree",
+    command: "git.sidebar.worktree.move",
     on: "project",
   });
 
@@ -1080,15 +1105,94 @@ async function worktreePath(
   branch: string,
   inside = false,
 ): Promise<string> {
+  const layouts = await worktreeLayouts(neosh, repoRoot, branch);
+  const want = inside ? "inside" : "configured";
+  // The list is deduplicated, so the layout asked for may have been folded into an earlier one
+  // that lands in the same place — a relative `worktree.root` is both `configured` and `inside`.
+  // Falling back to the head of the list is that same answer under its other name.
+  return (layouts.find((l) => l.kind === want) ?? layouts[0]!).path;
+}
+
+/** One place a worktree can live, as both a path and a row somebody can be offered. */
+interface Layout {
+  kind: "configured" | "inside" | "beside";
+  label: string;
+  detail: string;
+  icon: string;
+  hl: string;
+  path: string;
+}
+
+/**
+ * Every default place this repository's worktrees go, in the order the "where?" question offers
+ * them.
+ *
+ * One list, read twice. {@link worktreePath} asks it where a *new* tree lands, and
+ * {@link moveWorktree} draws it as a menu for one that already exists — which is the whole reason
+ * it is a list rather than three branches of an `if`. The alternative was what this replaced: the
+ * layouts computed here and *described*, separately, in the panel's own rows, so a fourth place to
+ * put a worktree would have had to be added in two files that never reference each other.
+ *
+ * **Deduplicated by path, first one wins.** The three layouts are not always three places: a
+ * relative `worktree.root` makes `configured` and `inside` the same directory, and an empty one
+ * makes `configured` and `beside` the same. A menu offering the same destination twice under two
+ * names is a menu where picking the wrong row is impossible to notice, and the row that survives
+ * is the one whose name matches what the configuration actually says.
+ *
+ * Slashes in a branch become dashes throughout: `feat/thing` is one directory, not two, because
+ * the directory is a name and not a path.
+ */
+async function worktreeLayouts(
+  neosh: Neosh,
+  repoRoot: string,
+  branch: string,
+): Promise<Layout[]> {
   const leaf = branch.replace(/\//g, "-");
   const repoName = repoRoot.split("/").filter(Boolean).pop() ?? "repo";
   const configured = ((await neosh.opt.get<string>("worktree.root")) ?? "").trim();
-  // Asked to stay inside regardless of what is configured. A relative root still names the
-  // directory; anything else falls back to the conventional one.
-  if (inside) return `${repoRoot}/${insideDir(configured)}/${leaf}`;
-  if (configured === "") return `${parentOf(repoRoot)}/${repoName}-worktrees/${leaf}`;
-  if (configured.startsWith("/")) return `${configured}/${repoName}/${leaf}`;
-  return `${repoRoot}/${configured}/${leaf}`;
+  const dir = insideDir(configured);
+
+  const all: Layout[] = [
+    {
+      kind: "configured",
+      label: "Where worktrees go",
+      // What `worktree.root` currently says, rather than a description of what it could say: a row
+      // that names the setting is a row you have to go and read the setting to understand.
+      detail: configured === ""
+        ? "beside the repository — `worktree.root` is unset"
+        : `under ${configured}`,
+      icon: "+",
+      hl: "Diagnostic.Ok",
+      path: configured === ""
+        ? `${parentOf(repoRoot)}/${repoName}-worktrees/${leaf}`
+        : configured.startsWith("/")
+        ? `${configured}/${repoName}/${leaf}`
+        : `${repoRoot}/${configured}/${leaf}`,
+    },
+    {
+      kind: "inside",
+      label: "In this project",
+      detail: `kept in ${dir}/ — travels with the repository`,
+      icon: "⌂",
+      hl: "Accent",
+      path: `${repoRoot}/${dir}/${leaf}`,
+    },
+    {
+      kind: "beside",
+      label: "Beside the repository",
+      detail: `a sibling of ${repoName}/`,
+      icon: "⎇",
+      hl: "Sidebar.Dim",
+      path: `${parentOf(repoRoot)}/${repoName}-worktrees/${leaf}`,
+    },
+  ];
+
+  const seen = new Set<string>();
+  return all.filter((l) => {
+    if (seen.has(l.path)) return false;
+    seen.add(l.path);
+    return true;
+  });
 }
 
 /** The in-repository directory worktrees go in: a relative `worktree.root`, else `.worktrees`. */
@@ -1197,6 +1301,194 @@ async function removeWorktree(
     }
   }
   neosh.notify(`removed ${chosen.path}`);
+}
+
+/**
+ * Move a worktree somewhere else, asking where the way `^N` asks where.
+ *
+ * The question is the same question — a worktree lands in one of a few places, and those places
+ * have names — so it is asked with the same rows, out of {@link worktreeLayouts}, plus the path
+ * field for a destination nobody listed. What it is *not* is a second vocabulary: somebody who has
+ * learnt that "In this project" means `.worktrees/` when they make a tree has learnt what it means
+ * when they move one.
+ *
+ * `path` given is the sidebar's flow — `m` on the row *is* the pointing — and `dest` given as well
+ * is the scripted one, which asks nothing. Without either it is the palette's flow and both are
+ * pickers. The move runs from the main checkout for the reason removal does: git will not saw off
+ * the branch it is standing on, and the conversation this runs in may be standing in the tree.
+ *
+ * **Where it is now is a row, drawn as such and declining to be picked.** Hiding it would leave a
+ * menu of two places for a repository that has three, which reads as the third one not existing —
+ * and the question somebody presses `m` to answer is *which of these am I in*.
+ *
+ * No confirmation. A move is reversible by pressing `m` again, and a dialog charged for something
+ * you can undo is what teaches people to clear dialogs without reading them. What it is not
+ * allowed to do is happen while an agent is working in the tree, and that is the host's to refuse
+ * — it holds the conversations and knows which of them has a turn in flight.
+ */
+async function moveWorktree(
+  neosh: Neosh,
+  spec: { path?: string; dest?: string; cwd?: string } = {},
+): Promise<void> {
+  const all = await neosh.git.worktrees(spec.cwd ? { cwd: spec.cwd } : undefined).catch(() => []);
+  const main = all.find((t) => t.is_main)?.path;
+  const movable = all.filter((t) => !t.is_main);
+
+  let tree: WorktreeInfo | undefined;
+  if (spec.path) {
+    const named = all.find((t) => t.path === spec.path);
+    if (!named) {
+      neosh.notify(`no worktree at ${spec.path}`, "warn");
+      return;
+    }
+    // The repository itself. `git worktree move` refuses it, and it should: the main checkout is
+    // where the `.git` directory lives, and moving that is not this feature.
+    if (named.is_main) {
+      neosh.notify("this is the repository itself — `m` moves a worktree row", "warn");
+      return;
+    }
+    tree = named;
+  } else {
+    if (movable.length === 0) {
+      neosh.notify("nothing to move — this repository has only its main checkout");
+      return;
+    }
+    tree = await picker(
+      neosh,
+      movable.map((t) => ({
+        label: t.branch ?? t.path,
+        detail: t.path,
+        icon: "⎇",
+        hl: "Git.Branch",
+        value: t,
+      })),
+      { title: "Move worktree", width: 78 },
+    ) ?? undefined;
+  }
+  if (!tree) return;
+  const from = tree.path;
+
+  let dest = spec.dest;
+  if (!dest) {
+    const branch = tree.branch ?? basename(from);
+    const layouts = await worktreeLayouts(neosh, main ?? from, branch);
+    const rows: Array<PickerItem<Layout | { kind: "elsewhere" }>> = layouts.map((l) => ({
+      // "where it is now" goes in the *label*, not after the path. Both are one row and the row
+      // is a float's width, so something is getting clipped — and a clipped path still reads as a
+      // path while a clipped sentence is gone. The label is also what the eye lands on, which is
+      // where the one row you must not pick should say so.
+      label: l.path === from ? `${l.label} — where it is now` : l.label,
+      // The resolved path, and only that. A choice between places is only a choice if each row
+      // says where it goes — but the *path* is that sentence: `…/work/.worktrees/crisp-yarrow`
+      // already says it is in the project, and a row that then adds "kept in .worktrees/" is one
+      // that wraps onto a second line to repeat itself. The description each layout carries is
+      // still what the row is *called*, and still matches the filter.
+      detail: l.path,
+      keywords: `${l.path} ${l.detail}`,
+      icon: l.path === from ? "●" : l.icon,
+      hl: l.path === from ? "Sidebar.Dim" : l.hl,
+      value: l,
+    }));
+    rows.push({
+      label: "Somewhere else…",
+      detail: "type a path — completes as you go",
+      keywords: "path directory elsewhere custom rename",
+      icon: "/",
+      hl: "Status.Input",
+      value: { kind: "elsewhere" },
+    });
+
+    const chosen = await picker(neosh, rows, {
+      title: `Move ${tree.branch ?? basename(from)}`,
+      width: 78,
+    }).catch(() => null);
+    if (!chosen) return;
+    if (chosen.kind === "elsewhere") {
+      // Seeded with the whole path rather than its parent, so `<CR>` on an untouched field is a
+      // no-op and editing the tail renames the directory. `^W` walks back up a segment, which is
+      // how this field is also the way to move it somewhere unrelated.
+      const typed = await pathPicker(neosh, "Move worktree to", { initial: from, width: 78 });
+      if (typed === null || typed.trim() === "") return;
+      dest = typed.trim();
+    } else {
+      dest = chosen.path;
+    }
+  }
+
+  if (dest === from) {
+    neosh.notify("already there");
+    return;
+  }
+
+  neosh.progress("git.worktree.move", "moving…");
+  try {
+    await neosh.git.moveWorktree(from, dest, main ? { cwd: main } : undefined);
+  } catch (e) {
+    // A destination that exists, a tree git has locked, a turn running in it — the host and git
+    // each word their own refusal better than anything this plugin could invent from the outside.
+    neosh.notify(String(e), "error");
+    return;
+  } finally {
+    neosh.done("git.worktree.move");
+  }
+  await landed(neosh, dest);
+  neosh.notify(`moved to ${dest}`);
+}
+
+/**
+ * Light the row it landed on, once.
+ *
+ * The panel redraws on its own the moment the conversations move, so the row is *correct* without
+ * this — and a row that is merely correct is one you have to go and find, having pressed a key
+ * whose whole effect happened in a directory you cannot see. `Agent.ToolLanded` is the same
+ * argument one surface along: half of watching something happen is watching it land.
+ *
+ * A decoration rather than a redraw of our own, because this plugin does not own that panel; and
+ * withdrawn on a timer just past the flash, because a decoration left behind is a row that lights
+ * up again every time anything else redraws it.
+ */
+async function landed(neosh: Neosh, cwd: string): Promise<void> {
+  if (!(await ensureMovedGroup(neosh))) return;
+  const id = `moved:${cwd}`;
+  await neosh.ext.contribute("sidebar.decoration", id, {
+    target: { project: cwd },
+    hl: HL_MOVED,
+  }).catch(() => {});
+  neosh.timer.after(FLASH_MS + 250, () => {
+    void neosh.ext.remove("sidebar.decoration", id).catch(() => {});
+  });
+}
+
+const HL_MOVED = "Git.Moved";
+/** Long enough to be seen from the other side of the panel, short enough not to be a state. */
+const FLASH_MS = 420;
+
+/**
+ * Define the group the flash rides on, colour and all, from the palette rather than from here.
+ *
+ * A flash is a property of a *group*, and the frontend lifts a run's foreground toward white for
+ * as long as it lasts — so the group needs a real colour underneath or the row draws in `Normal`
+ * for the third of a second it is lit, which is the near-white flicker a panel full of running
+ * agents used to have. It cannot be a `link` either: a link resolves to somebody else's spec, and
+ * this needs that spec *plus* one field.
+ *
+ * So the colour is read out of `Diagnostic.Ok` — the green the "where?" question already draws the
+ * row that makes something in — and re-read whenever the theme moves. `default: true`, so a user's
+ * `init.ts` still wins. `false` when the palette cannot answer, and then there is simply no
+ * decoration: a flash is the least important thing in this operation.
+ */
+async function ensureMovedGroup(neosh: Neosh): Promise<boolean> {
+  const base = await neosh.hl.get("Diagnostic.Ok").then((h) => h.resolved).catch(() => null);
+  if (!base) return false;
+  return await neosh.hl
+    .define(HL_MOVED, { ...base, animate: { kind: "flash", ms: FLASH_MS } }, { default: true })
+    .then(() => true)
+    .catch(() => false);
+}
+
+/** The last segment of a path — a worktree's directory name, when it has no branch to be named by. */
+function basename(path: string): string {
+  return path.replace(/\/+$/, "").split("/").filter(Boolean).pop() ?? path;
 }
 
 function parentOf(path: string): string {

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -578,6 +578,17 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
       }
     }),
   );
+  // A worktree moved. The conversations in it have already followed — the host re-points them —
+  // but this list is a list of *directories*, and nothing about a conversation's `cwd` changing
+  // says whether one project moved or one went and another arrived. Which is the whole difference:
+  // the second reading loses the place you put the row in.
+  subscriptions.push(
+    neosh.project.onMove((e) => {
+      void arrangement.relocate(e.from, e.to).then((moved) => {
+        if (moved) drawAll();
+      });
+    }),
+  );
   // Rows somebody contributed came or went. Redrawing on this is what stops a plugin that loads
   // after us contributing rows nobody sees until the next unrelated refresh.
   subscriptions.push(
@@ -865,6 +876,37 @@ class Arrangement {
         void this.set(cwd, VAR_ROOT, root);
       }
     }
+  }
+
+  /**
+   * A project's directory moved — a worktree that was relocated.
+   *
+   * **In place, keeping its position.** This is not `forget` plus `note`: the list is an order
+   * somebody arranged by hand, and a project that left the bottom and came back at the top is a
+   * reorder nobody asked for. The vars themselves have already travelled — the host moves the
+   * project scope, which is where the pin and the fold live — so what is left is this list and the
+   * cache in front of it.
+   *
+   * Written back only when something actually changed, because this runs on an event anybody may
+   * raise and a `vars.set` per no-op is a disk write per no-op.
+   *
+   * A destination that is somehow already on the list collapses onto it rather than appearing
+   * twice, and takes the earlier of the two positions: two rows for one directory is a panel where
+   * the cursor lands on a project that is not the one it is pointing at.
+   */
+  async relocate(from: string, to: string): Promise<boolean> {
+    if (from === to) return false;
+    const at = this.known.indexOf(from);
+    if (at < 0) return false;
+    const already = this.known.indexOf(to);
+    this.known[at] = to;
+    // Both indices now name the destination. The later one goes, so the row keeps the earlier of
+    // the two places in the order rather than jumping to wherever the arriving tree happened to be.
+    if (already >= 0 && already !== at) this.known.splice(Math.max(at, already), 1);
+    this.cache.set(to, await this.neosh.vars.all(projectScope(to)).catch(() => ({})));
+    this.cache.delete(from);
+    await this.neosh.vars.set({ scope: "global" }, VAR_KNOWN, this.known);
+    return true;
   }
 
   /**


### PR DESCRIPTION
`m` on a worktree row in the sidebar moves it, offering the same places `^N` offers when it *creates* one, plus the path field for one nobody listed.

```
Move glad-sable
❯ + Where worktrees go                 /Users/you/.nsh/work/glad-sable
  ● In this project — where it is now  /tmp/proj/work/.worktrees/glad-sable
  ⎇ Beside the repository              /tmp/proj/work-worktrees/glad-sable
  / Somewhere else…                    type a path — completes as you go
```

Every row names its resolved path — a choice between places is only a choice if each row says where it goes — and the row for where the tree already is says so rather than being dropped, since a menu that hides the answer you were looking for reads as the option not existing. `Somewhere else…` is the shared `pathPicker`, seeded with the full current path, so editing the tail renames the directory and `^W` walks up a segment.

Those three layouts used to be computed in `worktreePath` and *described*, separately, in the sidebar's own `^N` rows. They are one list now (`worktreeLayouts`), deduplicated by path: a relative `worktree.root` makes "where worktrees go" and "in this project" the same directory, and a menu offering one place twice is one where picking the wrong row cannot be noticed.

`m` is an ordinary `sidebar.action` like `d` and `p`, so `^Z` lists it, `?` advertises it, `init.ts` can move it and `plugins.disabled = ["git"]` takes it away. No global chord — Ctrl-with-a-letter is spoken for, and `^K` runs `git.worktree.move` by name.

## The half that is not `git worktree move`

A worktree's path is the key of the project facts every list draws, of the conversations living in it, of the project vars holding a pin and a fold state, and of the working directory each vendor CLI was spawned in. `Host::relocated` moves all of them — `Session::cwd` is rewritten by something for the first time — and it is on the host loop for a stronger version of the reason `GitRenameBranch` is: what follows the git call is the host's own maps.

`PluginEvent::ProjectMoved` carries both ends, because from outside a panel, a worktree that moved and a project deleted while another arrived are the same two facts in the same order — and only one of those keeps your place in an order you arranged by hand.

Refused while a turn is running in the tree, by name: a CLI holds its working directory from the moment it is spawned, so renaming a tree an agent is mid-turn in can land the file it is writing in the old place with nothing to say it went there.

No confirmation — a move is reversible by pressing `m` again, and a dialog charged for something you can undo is what teaches people to clear dialogs without reading them. It gets a keyed `moving…` progress notice and a row that flashes once when it lands.

## Two bugs found by driving the real binary

- **`exclude_if_inside` compared git's resolved path against the caller's unresolved one**, so on any project reached through a symlink the `.gitignore` line was silently skipped and the repository reported itself as one giant untracked directory for ever. Pre-existing, and directly under this feature's headline case. Only the comparison is canonical; the line written is still relative.
- **`to.join("")` appends a separator**, so a conversation at the tree's own root landed at `<to>/` — one directory under two spellings, and every list keyed by the path kept both. Invisible to an assertion about membership, which is why the test now asserts the panel names it exactly once.

## Verification

`neosh-core`, `neosh-vcs` (new real-git test moving a tree in, out and back, asserting git still finds it and the `.gitignore` line lands), `plugin_manager`, bindings regenerate with no drift, `tsc` clean. `builtin_plugins` is 198 passed / 2 failed — 196 baseline plus the 2 new tests here, with the same two known `/var` vs `/private/var` path comparisons that fail on macOS regardless of the change.

The destination picker was read back off the wire by reconstructing its buffer, and the end-to-end move checked against `git worktree list` and `vars.json` on disk.