### PR TITLE
fix(git): a branch name that arrives without its envelope is still a branch name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -417,7 +417,22 @@ is `docs/releasing.md`.
   shape of the name, which cannot tell `brisk-otter` we picked from `brisk-otter` you typed. At
   turn *start*, because the panel is drawn all through a turn — `git branch -m` is one ref write,
   so it is safe under a running agent and safe on uncommitted work. **One attempt, ever**: the mark
-  is spent before the model is asked, or a cheap model's hiccup becomes a request per message. The
+  is spent before the model is asked, or a cheap model's hiccup becomes a request per message —
+  which is exactly why **an answer that arrives without its envelope has to count as an answer**.
+  Asked for `{"branch": …}`, a model replies `fix/tab-strip-missing-in-worktree` on its own about
+  one time in ten: it did the work and skipped the wrapper, `gen.json` read that as a failed
+  request, the one attempt was already spent and the `log.info` that said so prints nowhere. Two
+  worktrees in twenty-two kept the name nobody chose, for good, with the name they should have had
+  sitting in the reply. `gen.field` is the fix and it is the host's, beside `extract_json` and for
+  the same reason — every generating plugin has this problem and none should solve it twice. **Only
+  for a value a wrong answer is recognisable in**, though: a branch name is checkable and one
+  `git branch -m` from being fixed, while a *title* is any short line and so is `(mock provider has
+  no script)` — pointed at titles this named thirteen test conversations after a driver's error
+  message. Where nothing tells an answer from a remark, the envelope is the evidence and
+  `gen.json` is the call. It is
+  also why the turn-start listener is registered **before** the plugin's own first reads: what
+  follows it is a `git status` per project, and the turn it exists for is the first one in a
+  worktree that was made seconds ago. The
   *type* is the model's — `feature/`, `fix/`, `chore/` — so `git.branch.prefix` applies only to a
   name that arrived without one, or you get `feature/fix/the-login` under a type that is now wrong.
   `git.branch.model` is unset by default and the plugin sends **no selection at all** rather than a

--- a/crates/neosh-proto/src/api.rs
+++ b/crates/neosh-proto/src/api.rs
@@ -1545,6 +1545,29 @@ pub enum ApiCall {
         /// Ask for JSON and parse it host-side, tolerating the code fences models wrap it in.
         #[serde(default)]
         json: bool,
+        /// The one key the answer is *about*, when the whole answer is one value.
+        ///
+        /// A prompt that says "return `{"branch": …}`" is answered with the object most of the
+        /// time and with a bare `fix/composer-paste` the rest of it — the model did the work and
+        /// skipped the envelope, and a caller that only accepts the envelope throws a correct
+        /// answer away. Measured on this workspace's own history it was two runs in twenty-two:
+        /// twice a branch was never named, silently, and both times the name was sitting in the
+        /// reply.
+        ///
+        /// So: extraction first, exactly as before, and this is what a *bare* answer means. Named
+        /// rather than inferred, because only the caller knows which key one value belongs under
+        /// — and absent, nothing changes, which is what every existing caller wants.
+        ///
+        /// Only for a one-value answer. A commit message is a subject *and* a body, and guessing
+        /// which half a bare paragraph is would be inventing the other one.
+        ///
+        /// And only for a value a *wrong* answer is recognisable in. A branch name is checkable
+        /// and one `git branch -m` from being fixed; a thread title is any short line, which is
+        /// also what a refusal and a driver's own error message look like — there the envelope is
+        /// the only evidence the question was answered rather than commented on, and it is worth
+        /// the one reply in ten that arrives without it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        field: Option<String>,
         /// Defaults to `gen.model` if set, else the session's own selection.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         selection: Option<ModelSelection>,

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -13693,8 +13693,8 @@ async fn run_slow(svc: Services, call: ApiCall) -> ApiResult {
         ApiCall::GitRemoveWorktree { path, force, cwd } => {
             svc.git_remove_worktree(path, force, cwd).await
         }
-        ApiCall::GenComplete { prompt, system, json, selection } => {
-            svc.gen_complete(prompt, system, json, selection).await
+        ApiCall::GenComplete { prompt, system, json, field, selection } => {
+            svc.gen_complete(prompt, system, json, field, selection).await
         }
         // Off the host loop for the same reason as git: discovery is a network round trip per
         // configured provider, and doing it inline freezes typing for as long as it takes.

--- a/crates/neosh/src/services.rs
+++ b/crates/neosh/src/services.rs
@@ -473,6 +473,7 @@ impl Services {
         prompt: String,
         system: Option<String>,
         json: bool,
+        field: Option<String>,
         selection: Option<ModelSelection>,
     ) -> ApiResult {
         // Precedence: what the caller asked for, then `gen.model`, then the session's own model.
@@ -491,9 +492,17 @@ impl Services {
         }
         match extract_json(&text) {
             Some(value) => Ok(ApiOk::Json { value }),
-            None => Err(ApiError::Internal {
-                message: format!("expected JSON, got: {}", truncate(&text, 200)),
-            }),
+            // The envelope is missing and the caller said what a bare answer would be. See
+            // [`ApiCall::GenComplete::field`]: the model answered the question and skipped the
+            // wrapper, which is a shape to accept rather than a failure to report.
+            None => match field.and_then(|key| bare_value(&text).map(|v| (key, v))) {
+                Some((key, value)) => {
+                    Ok(ApiOk::Json { value: serde_json::json!({ key: value }) })
+                }
+                None => Err(ApiError::Internal {
+                    message: format!("expected JSON, got: {}", truncate(&text, 200)),
+                }),
+            },
         }
     }
 }
@@ -587,6 +596,41 @@ pub fn extract_json(text: &str) -> Option<serde_json::Value> {
     None
 }
 
+/// The answer itself, when the model gave the value and left the envelope off.
+///
+/// Only ever consulted after [`extract_json`] has failed, and only when the caller named the key a
+/// bare answer belongs under. What it accepts is deliberately narrow: **the whole reply, trimmed,
+/// is one short line.** `fix/tab-strip-missing-in-worktree` is that; a paragraph explaining why the
+/// model would rather not is not, and neither is an answer with a preamble above it — which stays a
+/// failure exactly as it was, because "the last line of some prose" is a guess and this is not.
+///
+/// A fence and the quotes some models wrap a lone string in come off first: ```` ```fix/thing``` ````
+/// and `"fix/thing"` are the same answer written three ways.
+///
+/// This is a check on the *shape* of a reply, not on the truth of it — which is what decides who
+/// may ask for it. A branch name is checkable by the caller and a wrong one is one `git branch -m`
+/// away; a *title* is any short line, and so is `(mock provider has no script)`, so the envelope is
+/// the only evidence a title was answered rather than commented on. The rule that falls out:
+/// `field` is for a value you would recognise as wrong on sight.
+fn bare_value(text: &str) -> Option<String> {
+    let mut body = text.trim();
+    // ```lang\n…\n``` — and ```…``` on one line, which is what a fenced single value looks like.
+    if let Some(rest) = body.strip_prefix("```")
+        && let Some(rest) = rest.strip_suffix("```")
+    {
+        body = match rest.split_once('\n') {
+            Some((first, tail)) if !first.contains(char::is_whitespace) => tail,
+            _ => rest,
+        }
+        .trim();
+    }
+    let body = body.trim_matches(['"', '\'', '`', ' ']).trim();
+    let one_line = !body.is_empty() && !body.contains('\n');
+    // Room for any name a prompt would ask for, and far short of anything with a second sentence
+    // in it.
+    (one_line && body.chars().count() <= 200).then(|| body.to_string())
+}
+
 fn truncate(s: &str, n: usize) -> String {
     // Byte slicing a model's output would panic on a multi-byte boundary, which is a spectacular
     // way to crash while reporting a different error.
@@ -651,6 +695,40 @@ mod tests {
     fn prose_with_no_json_is_none() {
         assert!(extract_json("I'm sorry, I can't do that.").is_none());
         assert!(extract_json("").is_none());
+    }
+
+    /// The whole reason [`bare_value`] exists, taken from two real answers.
+    ///
+    /// Asked for `{"branch": …}`, `claude` returned `feature/project-picker-locations` — the name
+    /// it had been asked for, without the envelope. Read as JSON that is a failed request, and the
+    /// worktree kept the name nobody chose for good.
+    #[test]
+    fn an_answer_without_its_envelope_is_still_the_answer() {
+        assert_eq!(bare_value("feature/project-picker-locations").as_deref(), Some("feature/project-picker-locations"));
+        assert_eq!(bare_value("\n  fix/tab-strip-missing-in-worktree \n").as_deref(), Some("fix/tab-strip-missing-in-worktree"));
+        // The wrappings a lone string arrives in.
+        assert_eq!(bare_value("\"fix/login\"").as_deref(), Some("fix/login"));
+        assert_eq!(bare_value("`fix/login`").as_deref(), Some("fix/login"));
+        assert_eq!(bare_value("```\nfix/login\n```").as_deref(), Some("fix/login"));
+        assert_eq!(bare_value("```text\nfix/login\n```").as_deref(), Some("fix/login"));
+        // A title is a value too, and it has spaces in it.
+        assert_eq!(
+            bare_value("Make popups scrollable with keys").as_deref(),
+            Some("Make popups scrollable with keys")
+        );
+    }
+
+    /// What it will not guess at.
+    ///
+    /// A reply with more than one line in it may be an answer with a preamble above it or a
+    /// refusal with a reason under it, and nothing here can tell which — so it stays the failure
+    /// it already was rather than becoming a branch named after the first sentence of an apology.
+    #[test]
+    fn bare_prose_is_not_a_value() {
+        assert!(bare_value("Here you go:\nfix/login").is_none());
+        assert!(bare_value("").is_none());
+        assert!(bare_value("   \n  ").is_none());
+        assert!(bare_value(&"x".repeat(201)).is_none());
     }
 
     #[test]

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -1128,6 +1128,66 @@ fn a_scratch_worktree_is_named_by_the_first_message_and_the_sidebar_follows() {
     );
 }
 
+/// And named when the model answers with the name and nothing else.
+///
+/// The prompt asks for `{"branch": …}` and gets the object most of the time. The rest of the time
+/// — two runs in twenty-two, measured on a real workspace's own history — it gets
+/// `fix/the-login-redirect` on its own: the name it asked for, without the envelope. That was read
+/// as a failed request and swallowed by a `log.info` nothing prints, so the worktree kept the name
+/// nobody chose, for good, with the name it should have had sitting in the reply.
+///
+/// Deliberately end to end rather than a unit test of the parse: what broke was a *shape* crossing
+/// four layers — driver, host, the API's `gen.field`, and the plugin that acts on it — and every
+/// one of them could have thrown the answer away on its own.
+#[test]
+fn a_branch_name_without_its_json_envelope_still_names_the_branch() {
+    if !have_git() {
+        return;
+    }
+    let sb = Sandbox::new("branchbare");
+    sb.git_init();
+
+    let mut s = sb.start_with(
+        &Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/branch_name_bare.jsonl"),
+    );
+    s.wait_for("PROJECTS");
+
+    s.send(&command("git.worktree.new.inside"));
+    let under = sb.work().join(".worktrees");
+    assert!(
+        s.pump(|_| std::fs::read_dir(&under).is_ok_and(|d| d.count() > 0)),
+        "the worktree exists, on a name nobody chose"
+    );
+    let tree = std::fs::read_dir(&under)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .next()
+        .expect("one worktree");
+
+    let scratch = head_of(&tree);
+    assert!(scratch.contains('-'), "a two-word scratch name, not {scratch:?}");
+
+    // Waited for, for the reason the test above says: typing before the new conversation lands
+    // types into the one in the main checkout, where there is no scratch branch to rename.
+    let named_scratch = scratch.clone();
+    assert!(
+        s.pump(move |s| s.sidebar_now().iter().any(|l| l.contains(&named_scratch))),
+        "the worktree is a row in the panel\n{:?}",
+        s.sidebar_now()
+    );
+
+    s.type_text("the login page bounces");
+    s.special("enter");
+
+    assert!(
+        s.pump(|_| head_of(&tree) == "fix/the-login-redirect"),
+        "a bare answer is the answer — the branch is on {:?}\n{}",
+        head_of(&tree),
+        s.transcript()
+    );
+}
+
 /// Which branch a checkout is on, asked of git rather than of anything under test.
 fn head_of(dir: &Path) -> String {
     let out = Command::new("git")

--- a/crates/neosh/tests/fixtures/branch_name_bare.jsonl
+++ b/crates/neosh/tests/fixtures/branch_name_bare.jsonl
@@ -1,0 +1,27 @@
+{"type": "message_start", "model": "mock", "usage": {}}
+{"type": "block_start", "index": 0, "block": {"kind": "text"}}
+{"type": "text_delta", "index": 0, "text": "fix/the-login-redirect"}
+{"type": "block_stop", "index": 0}
+{"type": "message_delta", "stop_reason": {"kind": "end_turn"}, "usage": {}}
+{"type": "message_stop"}
+
+{"type": "message_start", "model": "mock", "usage": {}}
+{"type": "block_start", "index": 0, "block": {"kind": "text"}}
+{"type": "text_delta", "index": 0, "text": "fix/the-login-redirect"}
+{"type": "block_stop", "index": 0}
+{"type": "message_delta", "stop_reason": {"kind": "end_turn"}, "usage": {}}
+{"type": "message_stop"}
+
+{"type": "message_start", "model": "mock", "usage": {}}
+{"type": "block_start", "index": 0, "block": {"kind": "text"}}
+{"type": "text_delta", "index": 0, "text": "fix/the-login-redirect"}
+{"type": "block_stop", "index": 0}
+{"type": "message_delta", "stop_reason": {"kind": "end_turn"}, "usage": {}}
+{"type": "message_stop"}
+
+{"type": "message_start", "model": "mock", "usage": {}}
+{"type": "block_start", "index": 0, "block": {"kind": "text"}}
+{"type": "text_delta", "index": 0, "text": "fix/the-login-redirect"}
+{"type": "block_stop", "index": 0}
+{"type": "message_delta", "stop_reason": {"kind": "end_turn"}, "usage": {}}
+{"type": "message_stop"}

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -334,14 +334,24 @@ git through a registered tool, gated like every tool.
 ## Generation
 
 ```ts
-const { branch } = await neosh.gen.json<{ branch: string }>(
+const branch = await neosh.gen.field(
   'Return JSON with one key: branch.\n\nUser message:\n' + text,
+  'branch',
 );
 ```
 
 Nothing here enters session history, so asking for a commit message does not change what the agent
 believes it was asked to do. `gen.json` tolerates what models actually return — code fences, a
 "Sure!" preamble.
+
+`gen.field` is that plus the one thing `gen.json` cannot do: when the answer is a single value, a
+model asked for `{"branch": …}` sometimes replies `fix/composer-paste` and nothing else. It did the
+work and left the envelope off, and `gen.json` rejects it. Name the key and both are the same
+answer. For one value only — a commit message is a subject *and* a body, and there is no telling
+which half a lone paragraph is — and only for a value you would know was wrong on sight. A branch
+name is that. A thread title is any short line, and so is a refusal or a driver's own error
+message; where nothing tells an answer from a remark, the envelope is the evidence and `gen.json`
+is the call.
 
 Make your prompts options rather than constants, in two layers: `<thing>.instructions` appended to
 your default, `<thing>.prompt` replacing it. That is what the bundled `git` plugin does, and it is

--- a/plugins/api/src/generated/ApiCall.ts
+++ b/plugins/api/src/generated/ApiCall.ts
@@ -516,6 +516,30 @@ export type ApiCall =
      */
     json: boolean;
     /**
+     * The one key the answer is *about*, when the whole answer is one value.
+     *
+     * A prompt that says "return `{"branch": …}`" is answered with the object most of the
+     * time and with a bare `fix/composer-paste` the rest of it — the model did the work and
+     * skipped the envelope, and a caller that only accepts the envelope throws a correct
+     * answer away. Measured on this workspace's own history it was two runs in twenty-two:
+     * twice a branch was never named, silently, and both times the name was sitting in the
+     * reply.
+     *
+     * So: extraction first, exactly as before, and this is what a *bare* answer means. Named
+     * rather than inferred, because only the caller knows which key one value belongs under
+     * — and absent, nothing changes, which is what every existing caller wants.
+     *
+     * Only for a one-value answer. A commit message is a subject *and* a body, and guessing
+     * which half a bare paragraph is would be inventing the other one.
+     *
+     * And only for a value a *wrong* answer is recognisable in. A branch name is checkable
+     * and one `git branch -m` from being fixed; a thread title is any short line, which is
+     * also what a refusal and a driver's own error message look like — there the envelope is
+     * the only evidence the question was answered rather than commented on, and it is worth
+     * the one reply in ten that arrives without it.
+     */
+    field?: string | null;
+    /**
      * Defaults to `gen.model` if set, else the session's own selection.
      */
     selection?: ModelSelection | null;

--- a/plugins/api/src/index.ts
+++ b/plugins/api/src/index.ts
@@ -1190,6 +1190,32 @@ export interface GenApi {
    * do not each reimplement that. Rejects if there is no JSON in the response at all.
    */
   json<T = unknown>(prompt: string, opts?: { system?: string; selection?: ModelSelection }): Promise<T>;
+  /**
+   * One value, asked for as JSON and accepted however it comes back.
+   *
+   * The shape almost every generating plugin actually wants: a branch name, a thread title, a PR
+   * subject — one string, asked for as `{"branch": …}` because that is how you pin a model down,
+   * and answered as a bare `fix/composer-paste` often enough to matter. Both are the same answer,
+   * and {@link GenApi.json} rejects the second one — which is a correct name thrown away, with
+   * nothing on screen to say so.
+   *
+   * So the key is passed down and a bare reply is read as its value. Everything
+   * {@link GenApi.json} tolerates is tolerated first and unchanged; this is only what happens when
+   * there is no JSON at all. Rejects on an empty answer, or on prose it will not guess at.
+   *
+   * For one value only. A commit message is a subject and a body, and there is no answering the
+   * question of which one a lone paragraph is — that stays {@link GenApi.json}.
+   *
+   * And only for a value you would know was wrong on sight. A branch name is that, and a wrong one
+   * is one rename away; a thread title is any short line, and so is a refusal or a driver's own
+   * error message — where nothing distinguishes an answer from a remark, the envelope is the
+   * evidence, and {@link GenApi.json} is the call.
+   */
+  field(
+    prompt: string,
+    key: string,
+    opts?: { system?: string; selection?: ModelSelection },
+  ): Promise<string>;
 }
 
 /**
@@ -2850,6 +2876,23 @@ function build(
           selection: opts?.selection ?? null,
         });
         return expect(v, "json").value as never;
+      },
+      async field(prompt, key, opts) {
+        const v = await c({
+          call: "gen_complete",
+          prompt,
+          system: opts?.system ?? null,
+          json: true,
+          field: key,
+          selection: opts?.selection ?? null,
+        });
+        const value = (expect(v, "json").value as Record<string, unknown>)?.[key];
+        // A key that came back as something other than a non-empty string is an answer to a
+        // different question, and the caller is about to name a branch after it.
+        if (typeof value !== "string" || value.trim() === "") {
+          throw new Error(`the model returned no ${key}`);
+        }
+        return value.trim();
       },
     },
     view: {

--- a/plugins/builtin/git/main.ts
+++ b/plugins/builtin/git/main.ts
@@ -244,6 +244,16 @@ two-word scratch name it was created with.",
       }).catch(() => {});
     }
   };
+  // The first thing asked in a scratch worktree is what its branch should have been called.
+  //
+  // Before the reads below for the same reason they register their own listeners first, and with
+  // more at stake: what follows is a `git status` per project in the sidebar, run one after
+  // another, and a workspace with a dozen of them on a slow disk spends seconds here. A turn
+  // started in that window is the *first* turn in a new worktree — the one turn this exists for —
+  // and a turn that starts before the listener does is a turn nobody hears.
+  subscriptions.push(
+    neosh.agent.onTurnStart((e) => void nameScratchBranch(neosh, e.session as SessionId)),
+  );
   // Listeners before the first read: the sidebar writes `sidebar.projects` from its first draw,
   // which can land while this plugin is still awaiting its own `git status`, and a change that
   // arrives before the listener exists is a change nobody hears.
@@ -291,10 +301,6 @@ two-word scratch name it was created with.",
   await footer();
   subscriptions.push(neosh.agent.onTurnEnd(() => void footer()));
   subscriptions.push(neosh.session.onChange(() => void footer()));
-  // The first thing asked in a scratch worktree is what its branch should have been called.
-  subscriptions.push(
-    neosh.agent.onTurnStart((e) => void nameScratchBranch(neosh, e.session as SessionId)),
-  );
   // The working tree changes whenever anything writes a file, including the agent.
   subscriptions.push(neosh.timer.every(5000, () => void footer()));
 }
@@ -451,16 +457,20 @@ async function newBranch(neosh: Neosh): Promise<void> {
  * Throws rather than returning a fallback. There is no useful default branch name, and the two
  * callers want opposite things when this fails — one tells you, the other says nothing — which is
  * a decision for them and not for this.
+ *
+ * `gen.field` rather than `gen.json`, because a model asked for `{"branch": …}` answers with a
+ * bare `fix/tab-strip-missing-in-worktree` about one time in ten — the name it was asked for,
+ * without the envelope. Read as JSON that was a failed request and a worktree left on
+ * `warm-juniper` for good, with the name it should have had sitting in the reply and nothing
+ * anywhere saying so.
  */
 async function nameBranch(neosh: Neosh, description: string, cwd?: string): Promise<string> {
-  const answer = await neosh.gen.json<{ branch?: string }>(
+  const branch = await neosh.gen.field(
     `${await promptFor(neosh, "branch", BRANCH_PROMPT)}\n\nUser message:\n${description}`,
+    "branch",
     await branchModel(neosh),
   );
-  if (typeof answer.branch !== "string" || answer.branch.trim() === "") {
-    throw new Error("the model returned no branch name");
-  }
-  const name = slug(answer.branch);
+  const name = slug(branch);
   const prefix = (await neosh.opt.get<string>("git.branch.prefix")) ?? "";
   // Skipped when the model already chose a type. The built-in prompt asks for `fix/`, `feature/`
   // and the rest, so a `git.branch.prefix` applied unconditionally on top of it would read

--- a/plugins/builtin/titles/main.ts
+++ b/plugins/builtin/titles/main.ts
@@ -117,6 +117,14 @@ async function retitle(neosh: Neosh, attempted: Set<SessionId>, forced: boolean)
   const prompt = `${extra ? `${base}\n\nAdditional instructions:\n${extra}` : base}\n\nConversation:\n${transcript}`;
 
   try {
+    // `json` rather than `gen.field`, and the difference is what a wrong answer costs. A branch
+    // name is checkable — `fix/…`, one line, no spaces — so a bare reply can be read as the name
+    // it plainly is. A title is *any* short line, which is also what a refusal, a stack trace's
+    // first row and a driver's own error message look like: `(mock provider has no script)` is a
+    // sentence, and nothing here can tell it from a title. The envelope is the only evidence that
+    // the model answered the question rather than said something, so here it is worth the one
+    // reply in ten that arrives without it — an untitled conversation says what it is in the
+    // sidebar, and `r` names it.
     const answer = await neosh.gen.json<{ title?: string }>(prompt);
     const title = (answer.title ?? "").trim().replace(/^["']|["']$/g, "");
     if (title === "") return;

--- a/website/src/pages/docs/plugin-api.md
+++ b/website/src/pages/docs/plugin-api.md
@@ -99,12 +99,13 @@ const status = await neosh.git.status();       // rejects with not_found outside
 await neosh.git.diff({ kind: "staged" }, { stat: true });
 await neosh.git.commit("fix: the thing");      // needs vcs_write; reads need nothing
 
-const { branch } = await neosh.gen.json<{ branch: string }>(
+const branch = await neosh.gen.field(
   "Return JSON with one key: branch.\n\nUser message:\n" + text,
+  "branch",
 );
 ```
 
-`gen` runs one-shot generation outside any conversation: nothing enters session history, so asking for a commit message does not change what the agent believes it was asked to do. `gen.json` tolerates what models actually return, fences and preambles included. Make your prompts options rather than constants, in the two layers the git plugin uses: `*.instructions` appended, `*.prompt` replacing.
+`gen` runs one-shot generation outside any conversation: nothing enters session history, so asking for a commit message does not change what the agent believes it was asked to do. `gen.json` tolerates what models actually return, fences and preambles included. `gen.field` tolerates the one thing it cannot: an answer that is a single value often arrives *as* that value — `fix/composer-paste`, with the object the prompt asked for left off — and naming the key makes both the same answer. Use it for a value you would know was wrong on sight, which a branch name is; a thread title is any short line, and so is a refusal, so there the envelope is the evidence the question was answered at all. Make your prompts options rather than constants, in the two layers the git plugin uses: `*.instructions` appended, `*.prompt` replacing.
 
 ## Sessions and views
 


### PR DESCRIPTION
A scratch worktree is named by the first thing asked in it, and sometimes it was not. This is why.

## What was wrong

The evidence is in the vendor CLI's own one-shot transcripts. Of **22** branch-naming runs on one workspace, 20 answered `{"branch": …}` and **2 answered the bare name**:

| worktree | what the model returned |
|---|---|
| `warm-juniper` | `feature/project-picker-locations` |
| `lively-lantern` | `fix/tab-strip-missing-in-worktree` |

Those are exactly the two worktrees still sitting on the name nobody chose. The model did the work and skipped the envelope; `gen.json` read that as a failed request. The one attempt was already spent before the model was asked, and the `log.info` that said so prints nowhere at the default level — so the branch was never named, never retried, and nothing on screen said why, with the name it should have had sitting in the reply.

## The fix

- **`ApiCall::GenComplete` gains `field`**, and `bare_value` sits beside `extract_json` in the host — every generating plugin has this problem and none should solve it twice. Extraction runs first and unchanged; this is only what a *bare* reply means, and only when the caller named the key it belongs under.
- Deliberately narrow: the whole trimmed answer must be **one line under 200 characters**, fences and wrapping quotes off. An answer with a preamble above it stays the failure it was, because "the last line of some prose" is a guess and this is not.
- **`neosh.gen.field(prompt, key)`** in `@neosh/api`; `git`'s `nameBranch` uses it.
- **The turn-start listener registers before the git plugin's own first reads.** What follows it is a `git status` per project in the sidebar, run one after another — seconds on a slow disk — and the turn it exists for is the first one in a worktree made moments ago.

## Only for a value a wrong answer is recognisable in

The other half, learned the hard way. Pointed at thread titles this named thirteen test conversations `(mock provider has no script)` — a driver's own error, and a short line like any other. A branch name is checkable and one `git branch -m` from being fixed; a title is not, and stays on `gen.json`. The rule is written into the API docs, `docs/plugins.md` and `AGENTS.md`.

## Tests

`a_branch_name_without_its_json_envelope_still_names_the_branch` drives the real binary with a bare-answer fixture, end to end rather than as a unit test of the parse — what broke was a shape crossing four layers, and each could have dropped the answer on its own. Plus unit tests for what `bare_value` accepts and refuses.

Locally: `builtin_plugins` 197/2 and `workspace` 26/1, both the documented macOS path-length failures; `plugin_manager` 5/5; `neosh-core` green; `tsc` clean; bindings regenerate with no drift.