### PR TITLE
A provider you cannot use is not the first row, and GPT-6 Astra

### DIFF
--- a/crates/neosh-proto/src/provider.rs
+++ b/crates/neosh-proto/src/provider.rs
@@ -261,6 +261,21 @@ pub struct ModelInfo {
     /// numbers are already columns.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tagline: Option<String>,
+    /// Why this one cannot be chosen here, in a sentence, or nothing when it can.
+    ///
+    /// A model a driver lists but will not run — the vendor CLI on this machine is too old for it,
+    /// most often. Said rather than filtered out, for the reason a missing provider is listed
+    /// rather than dropped: nothing there and not allowed are the same empty list, and only one of
+    /// them is fixed by doing something. A model that silently vanishes from the picker is a
+    /// question with nowhere to ask it — you go looking for the release notes, or for our bug
+    /// tracker, and the answer was one `claude update` away the whole time.
+    ///
+    /// The sentence carries the fix, not just the diagnosis: "needs claude 2.1.251 — run `claude
+    /// update`" is actionable and "unsupported model" is not. Anything reading a catalogue to
+    /// *choose* — the startup default, `model.upgrade`, `model.line` — skips these; only a picker
+    /// draws them, and draws them disabled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unavailable: Option<String>,
 }
 
 impl ModelInfo {
@@ -282,6 +297,7 @@ impl ModelInfo {
             tier: None,
             legacy: false,
             tagline: None,
+            unavailable: None,
         }
     }
 }

--- a/crates/neosh-provider/src/catalog.rs
+++ b/crates/neosh-provider/src/catalog.rs
@@ -242,6 +242,9 @@ fn claude(
         tier: Some(tier),
         legacy,
         tagline: Some(tagline.into()),
+        // Nothing in a catalogue is unavailable: a catalogue says what exists. Whether *this*
+        // machine can run it is the driver's answer, and `claude-cli` is the one that has one.
+        unavailable: None,
     }
 }
 
@@ -268,6 +271,14 @@ fn cache_read_multiple(id: &str) -> f64 {
 /// The effort/thinking split is load-bearing: `budget_tokens` is rejected outright on the 5 and
 /// 4.7+ generations, and `effort` gained `xhigh` there, so a single flattened option set would
 /// produce 400s on half the catalog.
+///
+/// # Newest first
+///
+/// One rule, and it decides two things at once: what a picker draws at the top, and — through
+/// [`crate::ProviderRegistry::default_selection`], which takes the first live entry — what a fresh
+/// install with nothing configured lands on. Read as capability order instead, this list put Opus
+/// above the 5.1 that supersedes it, and the newest model in the catalogue was the second row of a
+/// list whose whole job is saying what is current.
 pub fn anthropic_models() -> Vec<ModelInfo> {
     use ModelTier::{Balanced, Fast, Frontier};
     const OPUS: &str = "Most capable for complex work";
@@ -277,10 +288,10 @@ pub fn anthropic_models() -> Vec<ModelInfo> {
     // agentic work, and it is the one row whose price says so.
     const FABLE: &str = "Deepest reasoning and long-running work";
     vec![
-        claude("claude-opus-5", "Claude Opus 5", "opus", Frontier, OPUS, 1_000_000, 128_000, (5.0, 25.0), Some(EFFORT_5), true, false),
         claude("claude-fable-5-1", "Claude Fable 5.1", "fable", Frontier, FABLE, 1_000_000, 128_000, (10.0, 50.0), Some(EFFORT_5), false, false),
-        claude("claude-fable-5", "Claude Fable 5", "fable", Frontier, FABLE, 1_000_000, 128_000, (10.0, 50.0), Some(EFFORT_5), false, true),
+        claude("claude-opus-5", "Claude Opus 5", "opus", Frontier, OPUS, 1_000_000, 128_000, (5.0, 25.0), Some(EFFORT_5), true, false),
         claude("claude-sonnet-5", "Claude Sonnet 5", "sonnet", Balanced, SONNET, 1_000_000, 128_000, (2.0, 10.0), Some(EFFORT_5), false, false),
+        claude("claude-fable-5", "Claude Fable 5", "fable", Frontier, FABLE, 1_000_000, 128_000, (10.0, 50.0), Some(EFFORT_5), false, true),
         claude("claude-opus-4-8", "Claude Opus 4.8", "opus", Frontier, OPUS, 1_000_000, 128_000, (5.0, 25.0), Some(EFFORT_5), true, true),
         claude("claude-opus-4-7", "Claude Opus 4.7", "opus", Frontier, OPUS, 1_000_000, 128_000, (5.0, 25.0), Some(EFFORT_5), false, true),
         claude("claude-opus-4-6", "Claude Opus 4.6", "opus", Frontier, OPUS, 1_000_000, 128_000, (5.0, 25.0), Some(EFFORT_46), false, true),
@@ -351,17 +362,23 @@ type ClaudeCliEntry = (
 /// version's own option set, and hides every model that is not the newest in its line. Pinning
 /// slugs and letting `model.line opus` do the resolving separates the two jobs: the catalogue says
 /// what exists, and the ladder says which one is current.
+///
+/// # Newest first
+///
+/// As in [`anthropic_models`], and for the same two reasons. Note that "too new for the `claude`
+/// on this machine" is not a reason to move one down the list or take it out of it — see
+/// [`crate::drivers::claude_cli`], which answers that by *saying so on the row*.
 pub fn claude_cli_models() -> Vec<ModelInfo> {
     use ModelTier::{Balanced, Fast, Frontier};
     const OPUS: &str = "Most capable for complex work";
     const SONNET: &str = "Best for everyday tasks";
     const FABLE: &str = "Deepest reasoning and long-running work";
     const ENTRIES: &[ClaudeCliEntry] = &[
-        ("claude-opus-5", "Claude Opus 5", "opus", Frontier, OPUS, 1_000_000, Some(EFFORT_5), true, Some(true), false),
         ("claude-fable-5-1", "Claude Fable 5.1", "fable", Frontier, FABLE, 1_000_000, Some(EFFORT_5), false, Some(true), false),
-        ("claude-fable-5", "Claude Fable 5", "fable", Frontier, FABLE, 1_000_000, Some(EFFORT_5), false, Some(true), true),
+        ("claude-opus-5", "Claude Opus 5", "opus", Frontier, OPUS, 1_000_000, Some(EFFORT_5), true, Some(true), false),
         ("claude-sonnet-5", "Claude Sonnet 5", "sonnet", Balanced, SONNET, 1_000_000, Some(EFFORT_5), false, Some(false), false),
         ("claude-haiku-4-5", "Claude Haiku 4.5", "haiku", Fast, "Fastest, for quick answers", 200_000, None, false, None, false),
+        ("claude-fable-5", "Claude Fable 5", "fable", Frontier, FABLE, 1_000_000, Some(EFFORT_5), false, Some(true), true),
         ("claude-opus-4-8", "Claude Opus 4.8", "opus", Frontier, OPUS, 1_000_000, Some(EFFORT_5), true, None, true),
         ("claude-opus-4-7", "Claude Opus 4.7", "opus", Frontier, OPUS, 1_000_000, Some(EFFORT_5), false, None, true),
         ("claude-opus-4-6", "Claude Opus 4.6", "opus", Frontier, OPUS, 1_000_000, Some(EFFORT_46), false, None, true),
@@ -475,6 +492,14 @@ pub fn verbosity_levels() -> ProviderOptionDescriptor {
 /// from the id, because the failure mode of guessing is a 400 on send rather than a knob that reads
 /// slightly wrong — the same reason the Anthropic catalogue is written down at all.
 fn openai_knobs(id: &str) -> Vec<ProviderOptionDescriptor> {
+    // GPT-6 is the generation that *dropped* a rung as well as gaining one: the docs say
+    // `reasoning.effort supports low, medium, high, xhigh, and max`, and `minimal` — which every
+    // GPT-5 takes — is not among them. It also documents no `verbosity`, so it is not offered:
+    // this file exists to keep a knob nobody advertised off the wire, and inheriting the GPT-5 set
+    // by prefix is exactly how a model gains two parameters it will 400 on.
+    if id.starts_with("gpt-6") {
+        return vec![effort(&["low", "medium", "high", "xhigh", "max"], "medium")];
+    }
     let levels: &[&str] = if id.starts_with("gpt-5.6") {
         &["minimal", "low", "medium", "high", "xhigh"]
     } else if id.starts_with("gpt-5") {
@@ -549,6 +574,9 @@ fn seed_models(instance: &str) -> Vec<ModelInfo> {
     };
     seeded(match instance {
         "openai" => &[
+            // Newest first, as everywhere. Its own family rather than a version of `sol`: Astra is
+            // a generation up and both are current, so `model.line sol` has to keep meaning Sol.
+            ("gpt-6-astra", "GPT-6 Astra", "astra", Frontier, "Frontier reasoning and computer use", false),
             ("gpt-5.6-sol", "GPT-5.6 Sol", "sol", Frontier, "Frontier agentic coding", false),
             ("gpt-5.6-terra", "GPT-5.6 Terra", "terra", Balanced, "Balanced, for everyday work", false),
             ("gpt-5.6-luna", "GPT-5.6 Luna", "luna", Fast, "Fast and affordable", false),
@@ -622,6 +650,12 @@ pub fn merge(discovered: Vec<ModelInfo>, seeds: &[ModelInfo]) -> Vec<ModelInfo> 
                     out.capabilities.option_descriptors = m.capabilities.option_descriptors.clone();
                     out.capabilities.thinking = m.capabilities.thinking;
                 }
+                // Taken whole rather than `or`-ed with the seed's: whether this machine can run it
+                // is the driver's answer and only the driver's, and a seed is a catalogue — it has
+                // never heard of the `claude` you have installed. `or` would also make the reason
+                // sticky, so a model that started working after `claude update` would keep telling
+                // you to run it.
+                out.unavailable = m.unavailable.clone();
                 described.push(out);
             }
             None => rest.push(m),
@@ -954,6 +988,26 @@ mod tests {
         assert_eq!(merged[1].id.0, "something-new", "and a model we had not heard of survives");
     }
 
+    /// A field the merge does not carry is a field that comes back wrong, and this one is the
+    /// difference between a row that says "run `claude update`" and a row that looks ordinary and
+    /// fails the turn. The seed cannot supply it — a catalogue has never heard of the CLI you have
+    /// installed — so the driver's answer is taken whole, including its absence.
+    #[test]
+    fn why_a_model_cannot_be_run_survives_the_merge() {
+        let seeds = seed_models("openai");
+        let known = seeds[0].id.clone();
+        let mut said = ModelInfo::undescribed(known.0.as_str(), known.0.as_str());
+        said.unavailable = Some("needs a newer CLI".into());
+        let merged = merge(vec![said], &seeds);
+        assert_eq!(merged[0].unavailable.as_deref(), Some("needs a newer CLI"));
+        assert_eq!(merged[0].display_name, seeds[0].display_name, "and it is still described");
+
+        // And it goes away again when the driver stops saying it, or `claude update` would fix the
+        // model and leave the sentence behind.
+        let quiet = ModelInfo::undescribed(known.0.as_str(), known.0.as_str());
+        assert_eq!(merge(vec![quiet], &seeds)[0].unavailable, None);
+    }
+
     #[test]
     fn a_seeded_model_the_endpoint_does_not_serve_is_not_offered() {
         // The endpoint is the authority on what your account can reach. Keeping a seed it did not
@@ -1026,6 +1080,48 @@ mod tests {
             "a fresh install must land on a plan, not on something that needs a key"
         );
         assert!(!all[0].models.is_empty(), "needs models so default_selection can resolve");
+    }
+
+    /// The first row of these lists is two things at once: what `^P` opens on, and what a fresh
+    /// install talks to. Both want the same answer — the newest thing the vendor serves — and the
+    /// list read as a capability ladder instead, which put Opus 5 above the Fable 5.1 that
+    /// supersedes it and made the newest model in the catalogue the second row of a list whose
+    /// whole job is saying what is current.
+    #[test]
+    fn the_newest_model_is_the_first_row() {
+        for (who, models) in [("anthropic", anthropic_models()), ("claude-cli", claude_cli_models())]
+        {
+            let first = models.first().expect("a catalogue with models in it");
+            assert_eq!(first.id.as_ref(), "claude-fable-5-1", "{who} leads with the newest");
+            assert!(!first.legacy, "{who}: a superseded model is never the top row");
+        }
+    }
+
+    /// A live model buried under superseded ones is a live model that
+    /// [`crate::ProviderRegistry::default_selection`] walks past a handful of dead ids to reach,
+    /// and — with the fold in the picker keyed on `legacy` rather than on position — a list whose
+    /// order stops meaning anything at the point the first old one appears.
+    #[test]
+    fn nothing_current_is_listed_below_something_superseded_it_replaced() {
+        for (who, models) in [("anthropic", anthropic_models()), ("claude-cli", claude_cli_models())]
+        {
+            let mut seen_legacy: Option<String> = None;
+            for m in &models {
+                if m.legacy {
+                    seen_legacy.get_or_insert_with(|| m.id.to_string());
+                } else if let Some(older) = &seen_legacy {
+                    // Only within a line: Haiku 4.5 is current and genuinely older than every 5.
+                    let same_line = models
+                        .iter()
+                        .any(|o| o.legacy && o.family == m.family && o.id.as_ref() == older.as_str());
+                    assert!(
+                        !same_line,
+                        "{who}: {} is current and sits below {older}, which it replaced",
+                        m.id
+                    );
+                }
+            }
+        }
     }
 
     #[test]
@@ -1151,6 +1247,40 @@ mod tests {
             panic!("expected an effort select");
         };
         assert!(!options.iter().any(|o| o.id == "xhigh"), "4.6 predates xhigh");
+    }
+
+    /// GPT-6 is the first generation here to *lose* a rung as well as gain one, so it cannot inherit
+    /// the GPT-5 set by prefix — and the two knobs it would inherit are two parameters the endpoint
+    /// documents no support for, which is a 400 after the question has been typed rather than a
+    /// dial that reads slightly wrong. `reasoning.effort supports low, medium, high, xhigh, and
+    /// max`, and nothing on the page mentions `verbosity`.
+    #[test]
+    fn gpt_6_takes_max_and_neither_minimal_nor_verbosity() {
+        let astra = seed_models("openai")
+            .into_iter()
+            .find(|m| m.id.0 == "gpt-6-astra")
+            .expect("Astra is seeded so it is visible before a key is present");
+
+        let ids: Vec<&str> =
+            astra.capabilities.option_descriptors.iter().map(|d| d.id()).collect();
+        assert_eq!(ids, vec!["effort"], "the only knob it advertises");
+
+        let ProviderOptionDescriptor::Select { options, .. } =
+            &astra.capabilities.option_descriptors[0]
+        else {
+            panic!("expected an effort select");
+        };
+        let levels: Vec<&str> = options.iter().map(|o| o.id.as_str()).collect();
+        assert_eq!(levels, vec!["low", "medium", "high", "xhigh", "max"]);
+        assert!(astra.capabilities.thinking, "an effort ladder is a model that reasons");
+
+        // The generation below it keeps both, so this is a difference and not a rewrite.
+        let sol = seed_models("openai")
+            .into_iter()
+            .find(|m| m.id.0 == "gpt-5.6-sol")
+            .expect("Sol is still current");
+        let sol_ids: Vec<&str> = sol.capabilities.option_descriptors.iter().map(|d| d.id()).collect();
+        assert_eq!(sol_ids, vec!["effort", "verbosity"]);
     }
 
     #[test]

--- a/crates/neosh-provider/src/drivers/claude_cli.rs
+++ b/crates/neosh-provider/src/drivers/claude_cli.rs
@@ -107,15 +107,21 @@ pub fn control_mode(mode: PermissionMode) -> &'static str {
 /// The oldest `claude` that will accept a given model.
 ///
 /// A CLI that has not heard of a model does not degrade — it exits with "unknown model" after you
-/// have typed your question. So the picker is filtered rather than the failure explained, and
-/// anything not listed here has been around long enough that no installed version lacks it.
+/// have typed your question. So the model is marked rather than the failure explained afterwards,
+/// and anything not listed here has been around long enough that no installed version lacks it.
 ///
-/// Sourced from the release each model shipped in. Wrong in the safe direction if it drifts: a
-/// too-high floor hides a model until the next upgrade, a too-low one is the behaviour we have
-/// today.
+/// Sourced from the release each model shipped in — and where the CLI itself will say, from the CLI:
+/// the 400 it answers with reads *"Claude Code 2.1.222 does not support this model; version 2.1.251
+/// or newer is required"*, which is the number, the fix and the sentence to put on the row, all
+/// from the one place that cannot be wrong about it.
+///
+/// Wrong in the safe direction if it drifts: a too-high floor tells somebody to update a CLI that
+/// would have run the model, a too-low one is a failed turn. `claude-fable-5-1` was written down as
+/// 2.1.255 and is 2.1.251 — four releases in which the picker's answer was "update" and the CLI's
+/// was "yes".
 const MIN_VERSION: &[(&str, (u32, u32, u32))] = &[
     ("claude-opus-5", (2, 1, 219)),
-    ("claude-fable-5-1", (2, 1, 255)),
+    ("claude-fable-5-1", (2, 1, 251)),
     ("claude-fable-5", (2, 1, 170)),
     // 197, not 219. Read off the vendor's own table rather than assumed equal to Opus 5's, which
     // is what it was — and a floor twenty-two releases too high is a model missing from the picker
@@ -442,14 +448,27 @@ fn parse_version(out: &str) -> Option<(u32, u32, u32)> {
     Some((major, minor, patch))
 }
 
-/// Whether an installed version can serve a model.
+/// Why an installed version cannot serve a model, or nothing when it can.
 ///
-/// Unknown version means yes: see [`ClaudeCliProvider::version`].
-fn serves(model: &str, installed: Option<(u32, u32, u32)>) -> bool {
-    let Some(need) = MIN_VERSION.iter().find(|(id, _)| *id == model).map(|(_, v)| *v) else {
-        return true;
-    };
-    installed.is_none_or(|have| have >= need)
+/// Unknown version means it can: see [`ClaudeCliProvider::version`].
+///
+/// The sentence carries the fix. "unsupported" is a diagnosis and `claude update` is an action, and
+/// the one thing somebody reading a greyed-out row wants is the second. The version is on the end
+/// because *which* update is the next question — a `claude` installed by Homebrew does not update
+/// itself when the one the CLI ships with says it does.
+///
+/// Twenty-seven columns, and that is not an accident: this is read in the detail column of the
+/// model picker, which is twenty-eight wide on the row it is drawn on and cannot be landed on to
+/// wrap. A sentence one column too long is a row that says `run claude update (2.1.25` — the fix
+/// cut off mid-number, which is worse than not having said it. The version installed is not in
+/// here for the same reason and loses nothing: you are reading this *because* yours is older.
+fn too_old_for(model: &str, installed: Option<(u32, u32, u32)>) -> Option<String> {
+    let need = MIN_VERSION.iter().find(|(id, _)| *id == model).map(|(_, v)| *v)?;
+    let have = installed?;
+    (have < need).then(|| {
+        let (a, b, c) = need;
+        format!("run claude update ({a}.{b}.{c})")
+    })
 }
 
 /// The model string `--model` should be given.
@@ -487,16 +506,33 @@ impl Provider for ClaudeCliProvider {
         DriverKind::from("claude-cli")
     }
 
-    /// The catalogue, minus anything this install is too old to accept.
+    /// The catalogue, with anything this install is too old to accept marked as such.
+    ///
+    /// Marked, not removed. Filtered out, the newest model in the catalogue was simply absent from
+    /// the picker on every CLI older than its floor — no row, no reason, and nothing anywhere on
+    /// screen to say it had ever been there. What that looks like from the keyboard is the feature
+    /// not existing, which sends somebody to the release notes for an answer that was one `claude
+    /// update` away.
     ///
     /// Not a network call and not cached upstream by accident: `--version` is asked once per
-    /// process, and the filtering is a comparison over nine entries.
+    /// process, and the comparison is over nine entries.
     async fn list_models(&self, _instance: &InstanceConfig) -> Result<Vec<ModelInfo>, ProviderError> {
         let installed = self.version();
         Ok(catalog::claude_cli_models()
             .into_iter()
-            .filter(|m| serves(m.id.as_ref(), installed))
+            .map(|mut m| {
+                m.unavailable = too_old_for(m.id.as_ref(), installed);
+                m
+            })
             .collect())
+    }
+
+    fn unavailable(
+        &self,
+        _instance: &InstanceConfig,
+        model: &neosh_proto::ModelId,
+    ) -> Option<String> {
+        too_old_for(model.as_ref(), self.version())
     }
 
     fn delegates_agent_loop(&self) -> bool {
@@ -1702,41 +1738,80 @@ mod tests {
     }
 
     /// The ordering that matters is patch-level: the releases these models shipped in differ only
-    /// there, so a comparison that stopped at minor would offer every one of them to every install.
+    /// there, so a comparison that stopped at minor would clear every one of them on every install.
     #[test]
-    fn an_older_cli_is_not_offered_a_model_it_will_reject() {
-        assert!(!serves("claude-opus-5", Some((2, 1, 218))));
-        assert!(serves("claude-opus-5", Some((2, 1, 219))));
-        assert!(serves("claude-opus-5", Some((2, 2, 0))));
+    fn an_older_cli_is_told_what_it_would_reject() {
+        assert!(too_old_for("claude-opus-5", Some((2, 1, 218))).is_some());
+        assert!(too_old_for("claude-opus-5", Some((2, 1, 219))).is_none());
+        assert!(too_old_for("claude-opus-5", Some((2, 2, 0))).is_none());
         // Nothing recorded means it has always been there.
-        assert!(serves("claude-haiku-4-5", Some((1, 0, 0))));
+        assert!(too_old_for("claude-haiku-4-5", Some((1, 0, 0))).is_none());
     }
 
-    /// A CLI that will not say what it is gets the benefit of the doubt: hiding everything recent
-    /// from somebody whose install works is worse than offering one model too many.
+    /// The row has to say what to *do*. A greyed-out model whose only explanation is that it is
+    /// unsupported sends somebody to the release notes; one that names the command and the version
+    /// is answered where it is read — and it has to be answered *there*, because the row cannot be
+    /// landed on and so is never wrapped.
+    #[test]
+    fn the_reason_carries_the_fix_and_fits_the_column_it_is_read_in() {
+        let why = too_old_for("claude-fable-5-1", Some((2, 1, 222))).expect("too old");
+        assert!(why.contains("claude update"), "{why} says how to get there");
+        assert!(why.contains("2.1.251"), "{why} says which version would do");
+        assert!(why.chars().count() <= 28, "{why} is {} columns, and 28 is the room", why.len());
+    }
+
+    /// A CLI that will not say what it is gets the benefit of the doubt: greying out everything
+    /// recent for somebody whose install works is worse than offering one model too many.
     #[test]
     fn an_unknown_version_is_offered_everything() {
-        assert!(serves("claude-opus-5", None));
+        assert!(too_old_for("claude-opus-5", None).is_none());
     }
 
-    /// Every floor here is a number read off the vendor's release notes, and the failure it causes
-    /// is silent in both directions: too high and the model is missing from `^P` with nothing
-    /// saying why, too low and picking it fails the turn after you have typed the question. Pinned
-    /// per model rather than as one "is it recent" check, because they genuinely differ — Sonnet 5
-    /// landed twenty-two releases before Opus 5 and was hidden for all of them by a floor copied
-    /// from its neighbour.
+    /// Every floor here is a number read off the vendor's release notes — or, where it has said so,
+    /// off the CLI's own 400. The failure is silent in both directions: too high and a model that
+    /// would have run reads as one needing an update, too low and picking it fails the turn after
+    /// you have typed the question. Pinned per model rather than as one "is it recent" check,
+    /// because they genuinely differ — Sonnet 5 landed twenty-two releases before Opus 5 and was
+    /// hidden for all of them by a floor copied from its neighbour.
     #[test]
     fn each_model_carries_the_release_it_actually_shipped_in() {
         for (model, floor, before) in [
-            ("claude-fable-5-1", (2, 1, 255), (2, 1, 254)),
+            // 251, not 255. `claude --model claude-fable-5-1` on 2.1.222 answers *"version 2.1.251
+            // or newer is required"* — the vendor's own number, and four releases below what was
+            // written down here.
+            ("claude-fable-5-1", (2, 1, 251), (2, 1, 250)),
             ("claude-fable-5", (2, 1, 170), (2, 1, 169)),
             ("claude-sonnet-5", (2, 1, 197), (2, 1, 196)),
             ("claude-opus-5", (2, 1, 219), (2, 1, 218)),
             ("claude-opus-4-8", (2, 1, 154), (2, 1, 153)),
         ] {
-            assert!(serves(model, Some(floor)), "{model} is offered on the release that added it");
-            assert!(!serves(model, Some(before)), "{model} is hidden on the one before");
+            let at = too_old_for(model, Some(floor));
+            assert!(at.is_none(), "{model} is offered on the release that added it");
+            let under = too_old_for(model, Some(before));
+            assert!(under.is_some(), "{model} says so on the one before");
         }
+    }
+
+    /// The catalogue is the catalogue whatever is installed. A model too new for this `claude` is
+    /// still a row — with a sentence on it — because the alternative is a model that is simply
+    /// absent, which reads as neosh never having heard of it.
+    #[tokio::test]
+    async fn a_model_too_new_for_this_cli_is_listed_and_says_why() {
+        let provider = ClaudeCliProvider::default();
+        *provider.version.lock().expect("version lock") = Some(Some((2, 1, 222)));
+        let inst = crate::catalog::builtin_instances()
+            .into_iter()
+            .find(|i| i.id.as_ref() == "claude-cli")
+            .expect("claude-cli is a builtin");
+        let models = provider.list_models(&inst).await.expect("the catalogue needs no network");
+
+        let fable = models
+            .iter()
+            .find(|m| m.id.as_ref() == "claude-fable-5-1")
+            .expect("still listed on a CLI that cannot run it");
+        assert!(fable.unavailable.is_some(), "and says why");
+        let opus = models.iter().find(|m| m.id.as_ref() == "claude-opus-5").expect("listed");
+        assert!(opus.unavailable.is_none(), "2.1.222 runs Opus 5, so nothing is said about it");
     }
 
     #[test]

--- a/crates/neosh-provider/src/lib.rs
+++ b/crates/neosh-provider/src/lib.rs
@@ -84,6 +84,21 @@ pub trait Provider: Send + Sync {
         Ok(instance.models.clone())
     }
 
+    /// Why this driver will not run a model *on this machine*, in a sentence, or nothing.
+    ///
+    /// The vendor CLI being too old for a model the catalogue lists is the whole of it today. Two
+    /// callers, and they are the reason this is separate from [`Self::list_models`]: that one is
+    /// async and answers a picker, and the other is
+    /// [`ProviderRegistry::default_selection`](crate::ProviderRegistry::default_selection), which
+    /// is synchronous and has to pick something a first message will not bounce off. One question
+    /// asked twice from two places is how the picker and the default come to disagree.
+    ///
+    /// Cheap by contract: no network, no process launch per call. `claude --version` is asked once
+    /// per process and remembered, which is what makes that true here.
+    fn unavailable(&self, _instance: &InstanceConfig, _model: &neosh_proto::ModelId) -> Option<String> {
+        None
+    }
+
     /// Start a turn. Dropping the returned stream, or cancelling the token, must terminate any
     /// in-flight request and reap any child process.
     fn stream(

--- a/crates/neosh-provider/src/registry.rs
+++ b/crates/neosh-provider/src/registry.rs
@@ -123,9 +123,28 @@ impl ProviderRegistry {
     ///
     /// Falls back to any usable instance so that `--list-models` and an explicit `--model` still
     /// behave when nothing is configured; the status line then shows what was picked.
+    ///
+    /// Within an instance it is the first model the driver will actually *run*, rather than the
+    /// first row. The catalogues are newest-first, so the first row is exactly the one most likely
+    /// to be ahead of the vendor CLI installed on this machine: `models.first()` alone is a fresh
+    /// install landing on a model whose first message comes back "version 2.1.251 or newer is
+    /// required" — which is the one turn where nobody yet suspects the model. Asked of the driver
+    /// rather than read off [`ModelInfo::unavailable`](neosh_proto::ModelInfo::unavailable),
+    /// because the field is set by `list_models` and what is being read here is the static
+    /// catalogue.
+    ///
+    /// Falls all the way back to the first row: a selection that will not run still says its name
+    /// in the footer, and an install with nothing selected has nowhere to start from.
     pub fn default_selection(&self) -> Option<ModelSelection> {
         let inst = self.ready_instances().next().or_else(|| self.usable_instances().next())?;
-        let model = inst.models.first()?;
+        let drv = self.drivers.get(&inst.driver);
+        let model = inst
+            .models
+            .iter()
+            .find(|m| {
+                !m.legacy && drv.is_none_or(|d| d.unavailable(inst, &m.id).is_none())
+            })
+            .or_else(|| inst.models.first())?;
         Some(ModelSelection {
             instance: inst.id.clone(),
             model: model.id.clone(),
@@ -191,4 +210,87 @@ mod tests {
         assert!(r.default_selection().is_some());
     }
 
+    /// The catalogues are newest-first, so the top row is the one a vendor CLI is most likely to be
+    /// behind. A fresh install taking it regardless spends its very first message finding out — the
+    /// one turn where nobody yet suspects the model, and where the error names a version rather
+    /// than anything the person did.
+    #[test]
+    fn a_first_run_skips_a_model_the_driver_says_it_cannot_run() {
+        struct Fussy;
+        #[async_trait::async_trait]
+        impl Provider for Fussy {
+            fn driver(&self) -> DriverKind {
+                DriverKind::from("fussy")
+            }
+            fn unavailable(&self, _i: &InstanceConfig, model: &ModelId) -> Option<String> {
+                (model.as_ref() == "too-new").then(|| "needs a newer CLI".to_string())
+            }
+            fn stream(
+                &self,
+                _i: &InstanceConfig,
+                _r: neosh_proto::TurnRequest,
+                _c: tokio_util::sync::CancellationToken,
+            ) -> crate::ProviderStream {
+                unreachable!("nothing here starts a turn")
+            }
+        }
+
+        let mut r = ProviderRegistry::new();
+        r.register_driver(std::sync::Arc::new(Fussy));
+        r.add_instance(InstanceConfig {
+            id: InstanceId::from("only"),
+            driver: DriverKind::from("fussy"),
+            display_name: "only".into(),
+            base_url: None,
+            brand: None,
+            auth: AuthRef::Inherited,
+            models: vec![
+                ModelInfo::undescribed(ModelId::from("too-new"), "Too New"),
+                ModelInfo::undescribed(ModelId::from("runs-here"), "Runs Here"),
+            ],
+            extra_headers: vec![],
+        });
+
+        let chosen = r.default_selection().expect("something is selectable");
+        assert_eq!(chosen.model, ModelId::from("runs-here"));
+    }
+
+    /// And when *every* model is refused it still picks one. A selection that will not run at least
+    /// puts a name in the footer and a row under the cursor in `^P`; nothing selected is a workspace
+    /// with nowhere to start and no explanation of why.
+    #[test]
+    fn a_run_where_nothing_can_be_served_still_selects_something() {
+        struct Nothing;
+        #[async_trait::async_trait]
+        impl Provider for Nothing {
+            fn driver(&self) -> DriverKind {
+                DriverKind::from("nothing")
+            }
+            fn unavailable(&self, _i: &InstanceConfig, _m: &ModelId) -> Option<String> {
+                Some("needs a newer CLI".into())
+            }
+            fn stream(
+                &self,
+                _i: &InstanceConfig,
+                _r: neosh_proto::TurnRequest,
+                _c: tokio_util::sync::CancellationToken,
+            ) -> crate::ProviderStream {
+                unreachable!("nothing here starts a turn")
+            }
+        }
+
+        let mut r = ProviderRegistry::new();
+        r.register_driver(std::sync::Arc::new(Nothing));
+        r.add_instance(InstanceConfig {
+            id: InstanceId::from("only"),
+            driver: DriverKind::from("nothing"),
+            display_name: "only".into(),
+            base_url: None,
+            brand: None,
+            auth: AuthRef::Inherited,
+            models: vec![ModelInfo::undescribed(ModelId::from("m"), "m")],
+            extra_headers: vec![],
+        });
+        assert_eq!(r.default_selection().map(|s| s.model), Some(ModelId::from("m")));
+    }
 }

--- a/crates/neosh/src/main.rs
+++ b/crates/neosh/src/main.rs
@@ -1017,7 +1017,14 @@ async fn list_models(agent: &Agent) -> anyhow::Result<()> {
             }
         }
         for m in models {
-            say!("    {}/{}", inst.id, m.id);
+            // A model the driver has said it will not run is listed with the reason on the end,
+            // for the reason the picker draws it greyed rather than dropping it: `--list-models`
+            // is what somebody runs to find out why `--model` did not take, and a list that is
+            // silently missing the id they typed answers that with nothing.
+            match &m.unavailable {
+                Some(why) => say!("    {}/{}  ({why})", inst.id, m.id),
+                None => say!("    {}/{}", inst.id, m.id),
+            }
         }
     }
     Ok(())

--- a/plugins/api/src/generated/ModelInfo.ts
+++ b/plugins/api/src/generated/ModelInfo.ts
@@ -27,4 +27,20 @@ export type ModelInfo = {
    * numbers are already columns.
    */
   tagline?: string | null;
+  /**
+   * Why this one cannot be chosen here, in a sentence, or nothing when it can.
+   *
+   * A model a driver lists but will not run — the vendor CLI on this machine is too old for it,
+   * most often. Said rather than filtered out, for the reason a missing provider is listed
+   * rather than dropped: nothing there and not allowed are the same empty list, and only one of
+   * them is fixed by doing something. A model that silently vanishes from the picker is a
+   * question with nowhere to ask it — you go looking for the release notes, or for our bug
+   * tracker, and the answer was one `claude update` away the whole time.
+   *
+   * The sentence carries the fix, not just the diagnosis: "needs claude 2.1.251 — run `claude
+   * update`" is actionable and "unsupported model" is not. Anything reading a catalogue to
+   * *choose* — the startup default, `model.upgrade`, `model.line` — skips these; only a picker
+   * draws them, and draws them disabled.
+   */
+  unavailable?: string | null;
 };

--- a/plugins/api/src/ui.ts
+++ b/plugins/api/src/ui.ts
@@ -2528,8 +2528,21 @@ export async function railPicker<G, T>(
     all = got;
     rebuild();
     cursor = Math.max(0, Math.min(opts.itemAt?.(all) ?? 0, Math.max(0, rows.length - 1)));
-    // Land on something selectable rather than on a section header.
-    if (rows[cursor]?.kind !== "item") cursor = rows.findIndex((r) => r.kind === "item");
+    // Land on something you can actually press `↵` on: not a section header, and not a row the
+    // caller disabled. `movePane` has always stepped over disabled rows, so the only way to be
+    // standing on one was to open here — and the first row of a list is where a picker opens by
+    // default. A pane whose top row is "this needs a newer CLI" then greeted every `↵` with
+    // nothing happening, which reads as the picker being broken rather than the row being refused.
+    const landable = (at: number) => {
+      const row = rows[at];
+      return row?.kind === "item" && !row.item.disabled;
+    };
+    if (!landable(cursor)) {
+      const next = rows.findIndex((_, at) => landable(at));
+      // Every row refused is still a list worth opening — you came to read why. Falling back to
+      // the first item rather than to nothing keeps the detail line of *something* on screen.
+      cursor = next >= 0 ? next : rows.findIndex((r) => r.kind === "item");
+    }
     if (cursor < 0) cursor = 0;
     paneTop = 0;
   };
@@ -2607,7 +2620,11 @@ export async function railPicker<G, T>(
       ? takeWords(detail, Math.max(0, room))
       : [clipToWidth(detail, Math.max(0, room)), ""];
     const label = padToWidth(labelHead, labelWidth);
-    const badgeCell = badgeWidth === 0 ? "" : padToWidth(clipToWidth(badge, badgeWidth), badgeWidth);
+    // One column narrower than the cell it sits in, so there is always a space before the detail.
+    // Clipped to the full width, a badge that happens to fill it runs straight into the sentence
+    // after it and the two read as one word.
+    const badgeCell =
+      badgeWidth === 0 ? "" : padToWidth(clipToWidth(badge, badgeWidth - 1), badgeWidth);
     const text = `${head}${label}${badgeCell}${detailHead}`;
 
     const labelAt = byteLength(head);

--- a/plugins/builtin/model/main.ts
+++ b/plugins/builtin/model/main.ts
@@ -299,7 +299,7 @@ async function pickModel(neosh: Neosh): Promise<void> {
   const order: AccountKind[] = ["plan", "api_key", "local"];
   const rail: RailItem<CredentialInfo>[] = [];
   for (const account of order) {
-    for (const c of creds.filter((x) => x.account === account)) {
+    for (const c of creds.filter((x) => x.account === account).sort(byUsefulness)) {
       rail.push({
         mark: { text: markFor(c, glyphs), hl: c.brand?.hl ?? "Comment" },
         label: c.display_name,
@@ -363,9 +363,21 @@ async function pickModel(neosh: Neosh): Promise<void> {
       }));
       return blocked.concat(named).concat(entries.map((e) => ({
         label: e.model.display_name,
-        badge: e.model.tier ? { text: tierLabel(e.model.tier), hl: tierHl(e.model.tier) } : undefined,
-        detail: describeModel(e, showPricing),
-        disabled: !c.driver_available,
+        // What is wrong with it outranks what rung it is on: a model this machine cannot run is
+        // not going to be chosen for its tier. "too new" rather than "unavailable" because it is
+        // what is actually true — the model is ahead of the CLI installed here — and because it
+        // fits the column the rungs are read down, which the longer word does not.
+        badge: e.model.unavailable
+          ? { text: "too new", hl: "Diagnostic.Warn" }
+          : e.model.tier
+          ? { text: tierLabel(e.model.tier), hl: tierHl(e.model.tier) }
+          : undefined,
+        // The reason, in place of the tagline and the price — which are about a model you could
+        // choose, and this is not one. Stays in the main list rather than moving to "superseded":
+        // it is not last year's model, it is next month's, and burying the newest thing in the
+        // catalogue under a fold is the opposite of what the fold is for.
+        detail: e.model.unavailable ?? describeModel(e, showPricing),
+        disabled: !c.driver_available || Boolean(e.model.unavailable),
         keywords: `${e.model.id} ${e.model.family ?? ""}`,
         // Last year's models are reachable and out of the way. You go looking for one to
         // reproduce something, which is exactly when hiding it outright would be worst.
@@ -470,9 +482,19 @@ async function step(neosh: Neosh, delta: number): Promise<void> {
     neosh.notify(delta > 0 ? "already the most capable one here" : "already the quickest one here");
     return;
   }
-  const next = best(entries.filter((e) => e.model.tier === want));
+  const rung = entries.filter((e) => e.model.tier === want);
+  const next = best(rung);
   if (!next) {
-    neosh.notify(`${current.instance} has nothing on the ${tierLabel(want)} rung`, "warn");
+    // "Nothing on that rung" and "the thing on that rung needs a newer CLI" are the same empty
+    // answer and different problems, and only the second one is fixed by doing something. Said
+    // with the reason the row in `^P` carries, so the key and the picker agree.
+    const why = rung.find((e) => e.model.unavailable)?.model.unavailable;
+    neosh.notify(
+      why
+        ? `${tierLabel(want)} on ${current.instance} is out of reach — ${why}`
+        : `${current.instance} has nothing on the ${tierLabel(want)} rung`,
+      "warn",
+    );
     return;
   }
   await use(neosh, next, current);
@@ -514,10 +536,16 @@ async function useLine(neosh: Neosh, line: string | undefined): Promise<void> {
  *
  * Order within a rung is the catalogue's, which lists newest first — so "current" needs no version
  * parsing, which is the thing that goes wrong the moment a vendor renames something.
+ *
+ * Anything the driver has said it will not run is out before any of that. `model.upgrade` and
+ * `model.line` are the two callers, and both of them exist to be pressed without reading a list:
+ * a rung that answers with a model whose next message comes back "run `claude update`" is a key
+ * that reports success and breaks the conversation.
  */
 function best(entries: ModelEntry[]): ModelEntry | undefined {
-  const live = entries.filter((e) => !e.model.legacy);
-  const pool = live.length > 0 ? live : entries;
+  const runnable = entries.filter((e) => !e.model.unavailable);
+  const live = runnable.filter((e) => !e.model.legacy);
+  const pool = live.length > 0 ? live : runnable;
   const rank = (e: ModelEntry) =>
     e.model.tier === "frontier" ? 2 : e.model.tier === "balanced" ? 1 : 0;
   return pool.reduce<ModelEntry | undefined>(
@@ -543,6 +571,39 @@ async function use(
   });
   await refreshFooter();
   neosh.notify(`model: ${chosen.instance}/${chosen.model.display_name}`);
+}
+
+/**
+ * How much use a provider is to you right now, as a number to sort a group by.
+ *
+ * Three ranks, and the order they put a rail in is the order the column is read in: what works,
+ * then what you could make work, then what nothing here can fix.
+ *
+ *  * **2 — it answers.** Signed in, its driver is here, a model on it can be chosen today.
+ *  * **1 — one action away.** A CLI to install, a key to paste. `^S` is pointed at these.
+ *  * **0 — nothing to do.** A plan the vendor withdrew, or a driver no plugin provides.
+ *
+ * Why it is sorted at all: instances arrive alphabetically by id, so `antigravity` — whose `agy`
+ * is not installed on most machines — was the first row under PLANS, above the Claude and Codex
+ * logins that actually work, and the rail opened on a provider with nothing to offer. Alphabetical
+ * is a fine tie-break and a poor first key: which of these you can use is not a fact about how
+ * they are spelled.
+ *
+ * Stable within a rank, so that tie-break survives — `Array.prototype.sort` has been required to
+ * be stable since ES2019.
+ */
+function byUsefulness(a: CredentialInfo, b: CredentialInfo): number {
+  return usefulness(b) - usefulness(a);
+}
+
+function usefulness(c: CredentialInfo): number {
+  // A vendor that stopped serving the plan. Not `1`: `^S` on it has nothing to collect, and the
+  // only thing to do about it is read the row — which is why it sits under the ones you can act on.
+  if (c.source.kind === "plan_retired") return 0;
+  // No driver and no way to get one: nothing provides it, so there is nothing to install either.
+  // A missing *CLI* is not this — that is `plan_missing`, and it is one `brew install` away.
+  if (!c.driver_available) return c.source.kind === "plan_missing" ? 1 : 0;
+  return c.source.kind === "missing" ? 1 : 2;
 }
 
 function headingFor(account: AccountKind): string {
@@ -741,11 +802,12 @@ async function pickProvider(neosh: Neosh): Promise<void> {
   // Unavailable drivers are listed rather than hidden. The `claude` CLI not being installed is the
   // single most likely reason a subscription does not show up, and a provider that has silently
   // vanished from the list is a question with nowhere to ask it.
+  // The same order the `^P` rail is in, and by the same comparison — two lists of one set of
+  // providers that disagree about which of them is worth looking at first is a worse answer than
+  // either of them alone.
   const order = ["plan", "api_key", "local"] as const;
   const sorted = order.flatMap((account) =>
-    rows
-      .filter((c) => c.account === account)
-      .sort((a, b) => Number(b.driver_available) - Number(a.driver_available)),
+    rows.filter((c) => c.account === account).sort(byUsefulness),
   );
   const chosen = await picker(
     neosh,


### PR DESCRIPTION
Four things, all in the model picker and the catalogue behind it.

## The rail opened on a provider with nothing to offer

Instances arrive alphabetically by id, and the rail kept that order inside each account group — so `antigravity`, whose `agy` most machines do not have, was the first row under **PLANS**, above the Claude and Codex logins that actually answer.

Sorted by what a provider is worth to you instead: what answers, then what is one `brew install` or one pasted key away, then what nothing here can fix (a withdrawn plan, a driver nothing provides). Alphabetical is a fine tie-break and a poor first key — which of these you can use is not a fact about how they are spelled. `provider.auth` sorts the same way, because two lists of one set of providers that disagree about which is worth looking at first is worse than either alone.

```
PLANS                        PLANS
 ◇ Antigravity  !             ✳ Claude       ✓
 ✳ Claude       ✓    -->      ⬢ Codex        ✓
 ⬢ Codex        ✓             ◇ Antigravity  !
 ◩ Cursor       !             ◩ Cursor       !
 ◆ Gemini       ⨯             ✕ Grok         !
 ✕ Grok         !             ◆ Gemini       ⨯
```

## A model your CLI is too old for now says so

Fable 5.1 was *filtered out* below its version floor — the same empty answer as a model that does not exist, and a different problem. It was simply absent from `^P` on every `claude` in that range, with nothing on screen to say it had ever been there, which from the keyboard reads as the feature not existing.

`ModelInfo::unavailable` carries the sentence. The row stays in the main list — it is not last year's model, it is next month's — draws dim with a `too new` badge, and puts the fix where the tagline goes:

```
   Claude Fable 5.1      too new   run claude update (2.1.251)
 ❯ Claude Opus 5         Frontier  Most capable for complex work
```

The floor was wrong too: **2.1.255**, where the CLI's own 400 says **2.1.251** — four releases in which the picker's answer was "update" and the CLI's was "yes". Same reason on `--list-models`, and `model.upgrade` / `model.line` skip these rather than switching you to something that fails on send.

## Newest first

Both Claude catalogues now lead with the newest model rather than the most capable. The two agreed until Fable 5.1 superseded Opus 5, and then the newest thing in the catalogue was the second row of a list whose whole job is saying what is current.

`default_selection` reads the first model the **driver** will run rather than `models.first()` — otherwise a fresh install on an older CLI spends its very first message finding out, which is the one turn where nobody yet suspects the model.

## GPT-6 Astra

From OpenAI's own docs rather than the coverage. Sole variant, `gpt-6-astra`, its own family so `model.line sol` keeps meaning Sol.

GPT-6 is the first generation here to **lose** a rung as well as gain one — `reasoning.effort` takes `low, medium, high, xhigh, max`, `minimal` is gone, and no `verbosity` is documented. Inheriting the GPT-5 set by prefix would have been two parameters the endpoint 400s on, so it gets its own branch:

```
╭ GPT-6 Astra ──────────────────────────────────────────╮
│❯ Effort  ‹ Low  Medium  High  X-high  Max ›           │
╰───────────────────────────────────────────────────────╯
```

Deliberately **not** seeded on `codex-cli`: 0.153.1 added it *"without changing the default model or showing it in the model picker"*, so discovery will not return it and a seed would be offered on a CLI that does not serve it. Chat Completions is supported, so the existing `openai-compat` path is unchanged.

## Found on the way

- `catalog::merge` rebuilt each row from the seed and dropped the driver's answer, so the reason never reached the picker at all — a value that is only forwarded is a value that comes back wrong.
- `railPicker` opened its cursor on the first row even when that row was disabled, so `↵` did nothing on open, which reads as the picker being broken rather than the row being refused.
- A badge clipped to the full width of its cell ran straight into the detail beside it (`unavailablneeds claude…`). Clipped one column narrower now, so the column always has a gap.

## Known gap, not fixed here

The `Seed` tuple carries no context window or pricing, so Astra shows no `$10/$50` and its 1,050,000-token window does not reach the context meter. That is true of every OpenAI model today — `/v1/models` returns neither — and fixing it means reshaping `Seed` across twelve provider lists. Worth its own change.

## Verification

- `neosh-provider` 232 + 10 integration, `neosh-core` 187, `plugin_manager` 5 — all green
- `builtin_plugins` 197 passed / 2 failed: `a_turn_runs_in_the_project…` and `switching_conversations_moves_the_working_directory_too`, the documented macOS `/var` vs `/private/var` string comparisons that fail on a clean tree too
- `workspace` 26 passed / 1: `each_terminal_fits_a_card_to_its_own_width`, the documented pid-length artefact
- TS bindings regenerated with no drift, `tsc --noEmit` clean, clippy unchanged at 14 warnings
- Every screen above is a real `scripts/shot.py` capture of the built binary, re-checked after rebasing onto #83