### PR TITLE
fix(git): one import of PickerItem, not two

### DIFF
--- a/plugins/builtin/git/main.ts
+++ b/plugins/builtin/git/main.ts
@@ -48,7 +48,6 @@ import {
   spinnerFrame,
   statusPrefix,
 } from "@neosh/api/ui";
-import type { PickerItem } from "@neosh/api/ui";
 
 // ---------------------------------------------------------------------------
 // Default prompts


### PR DESCRIPTION
Main is red. #84 and #85 both reached for `PickerItem` in `plugins/builtin/git/main.ts` — the clone picker put `type PickerItem` inside the `@neosh/api/ui` import block, the worktree-move picker added a separate `import type` line — and my conflict resolution took both, which is a duplicate identifier rather than a merge.

```
git/main.ts(46,8): error TS2300: Duplicate identifier 'PickerItem'.
git/main.ts(51,15): error TS2300: Duplicate identifier 'PickerItem'.
```

One line deleted. `./scripts/check.sh web` passes on it.

**What let it through:** `cargo check --workspace` is clean, and so is `npx tsc --noEmit` run inside `plugins/api` — that checks the API package against the generated types, not the bundled plugins against the *published* API. The step that catches this is `check.sh web`, and it is the one to run after touching anything under `plugins/`. It also ran green on #84's own branch and only failed once the two changes were in the same tree, which is exactly the shape a rebase conflict produces.