### PR TITLE
A release is one tag push, and the tap is no longer the step nobody watches

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -10,6 +10,13 @@ name: publish-crates
 # a crate that already exists — which is why the first version is published by hand, once, for all
 # ten. See docs/releasing.md.
 on:
+  # A tag *is* the release. The publish jobs run from the tag push rather than from the release
+  # page so that this file keeps its name — crates.io and npm bind a trusted publisher to a
+  # workflow filename, so moving this job is what breaks authentication, not renaming the trigger.
+  push:
+    tags: ["v*"]
+  # Kept: a release created by hand in the UI still publishes, and re-running one that half failed
+  # is the documented way out of a network blip mid-way through eleven crates.
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,6 +9,13 @@ name: publish-npm
 # added to a package that already exists, which is why the first version of each package is
 # published by hand — see docs/releasing.md.
 on:
+  # A tag *is* the release. The publish jobs run from the tag push rather than from the release
+  # page so that this file keeps its name — crates.io and npm bind a trusted publisher to a
+  # workflow filename, so moving this job is what breaks authentication, not renaming the trigger.
+  push:
+    tags: ["v*"]
+  # Kept: a release created by hand in the UI still publishes, and re-running one that half failed
+  # is the documented way out of a network blip mid-way through eleven crates.
   release:
     types: [published]
   workflow_dispatch:
@@ -41,6 +48,8 @@ jobs:
           # Failures are collected and reported at the end instead.
           set -uo pipefail
           failed=""
+          retry=""
+          first=""
           # `npm/neosh` is not in this list on purpose: the launcher's optional dependencies are
           # the four binaries, so it goes up in release.yml after they do. Publishing it here would
           # put a launcher on npm before there was anything for it to launch.
@@ -54,15 +63,34 @@ jobs:
             fi
             echo "publish $name@$version"
             if ! (cd "$dir" && npm publish --access public --provenance); then
-              # A name npm has never seen is the expected case here, and it is a person's job:
-              # publish it once by hand, then add its trusted publisher. Everything else carries on.
-              echo "::warning::$name@$version was not published"
+              # Two failures wearing one face, told apart by a question this loop can answer: does
+              # npm know the package at all? A name it has never seen has no trusted publisher and
+              # cannot be published by OIDC — a person has to publish it once by hand. A name it
+              # *does* know failing is something else, and at v0.4.1 that something else was
+              # transient: `@neosh/titles` and `@neosh/usage` both failed with a 401 about web auth
+              # URLs and both went up on a plain rerun, with nothing changed. Printing the
+              # first-publish advice over that sends somebody to npmjs.com to configure a trusted
+              # publisher that is already there.
+              if npm view "$name" version >/dev/null 2>&1; then
+                echo "::warning::$name@$version was not published — npm knows this package, so this"
+                echo "is not a missing trusted publisher. Rerun the job before changing anything."
+                retry="$retry $name"
+              else
+                echo "::warning::$name@$version was not published — npm has never seen this package"
+                first="$first $name"
+              fi
               failed="$failed $name"
             fi
           done
           if [ -n "$failed" ]; then
             echo "::error::not published:$failed"
-            echo "A package npm has never seen cannot be published by OIDC. Publish it once by"
-            echo "hand, then: npm trust github <name> --file publish-npm.yml --repo neoswarm/neosh"
+            if [ -n "$retry" ]; then
+              echo "Rerun this job first —$retry already exist on npm, so their trusted publishers"
+              echo "are configured and the failure is very likely transient."
+            fi
+            if [ -n "$first" ]; then
+              echo "A package npm has never seen cannot be published by OIDC. Publish$first once by"
+              echo "hand, then: npm trust github <name> --file publish-npm.yml --repo neoswarm/neosh"
+            fi
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ name: release
 # macOS and Linux only, deliberately: the workspace talks to its terminals over a Unix socket
 # (`daemon.rs`), so there is nothing to ship for Windows yet.
 on:
+  # A tag is the release. This file keeps its name because npm binds the `@neosh/cli-*` trusted
+  # publishers to it.
+  push:
+    tags: ["v*"]
   release:
     types: [published]
   workflow_dispatch:
@@ -148,3 +152,87 @@ jobs:
             exit 0
           fi
           (cd npm/neosh && npm publish --access public --provenance)
+
+  # The step docs/releasing.md called "the one with nothing watching it", now watched.
+  #
+  # `brew upgrade` cannot see a release the tap does not point at, so until this existed a green
+  # release still left every Homebrew user on the previous version — silently, because nothing in
+  # the release reports on a second repository. It ran by hand or not at all, and "not at all" looks
+  # exactly like "shipped".
+  #
+  # `needs: build` because the formula is *written from the release*: `brew-formula.sh` reads the
+  # four `.sha256` files off it, so running before the tarballs are attached produces a formula with
+  # nothing in it.
+  homebrew:
+    name: Homebrew formula
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    # Mapped to `env` rather than tested directly. The `secrets` context is not available in a step's
+    # `if:` — it evaluates to empty there, so `if: secrets.X` is always false and the job silently
+    # does nothing on a repository that has the token. Job-level `env` *can* read secrets, and
+    # `env` *is* available in `if:`, so this is the one spelling that behaves.
+    env:
+      HAS_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
+    steps:
+      # Not a failure. The token is the one credential in this release that OIDC cannot replace —
+      # trusted publishing authenticates *to a registry*, and this is a git push to another
+      # repository — so a fork, or this repository before somebody creates it, must skip rather than
+      # go red for a reason nobody has done anything wrong about.
+      - name: Say so when the tap cannot be pushed
+        if: env.HAS_TAP_TOKEN != 'true'
+        run: |
+          echo "::warning::HOMEBREW_TAP_TOKEN is not set — the tap still points at the old version."
+          echo "Create a fine-grained PAT with Contents: read and write on neoswarm/homebrew-tap,"
+          echo "then: gh secret set HOMEBREW_TAP_TOKEN"
+
+      - uses: actions/checkout@v4
+        if: env.HAS_TAP_TOKEN == 'true'
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Point the tap at this release
+        if: env.HAS_TAP_TOKEN == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ github.event.inputs.tag || github.ref_name }}"
+
+          # The assets are attached by four independent matrix jobs, and `needs:` waits for the jobs
+          # rather than for the release to have settled. Wait for the eight files themselves.
+          n=0
+          for _ in $(seq 30); do
+            # `|| echo 0` because a five-minute poll against an API is a five-minute window for one
+            # request to fail, and `set -e` on an empty command substitution would end the release
+            # over a blip the next iteration would have sailed through.
+            n=$(gh release view "$tag" --json assets \
+                  --jq '[.assets[] | select(.name | endswith(".sha256"))] | length' 2>/dev/null || echo 0)
+            [ "$n" -eq 4 ] && break
+            echo "waiting for checksums — $n of 4"
+            sleep 10
+          done
+          if [ "$n" -ne 4 ]; then
+            echo "::error::only $n of 4 checksums on $tag; not writing a formula from a partial release"
+            exit 1
+          fi
+
+          git clone --depth 1 \
+            "https://x-access-token:$TAP_TOKEN@github.com/neoswarm/homebrew-tap" tap
+          ./scripts/brew-formula.sh "$tag" > tap/Formula/neosh.rb
+
+          cd tap
+          # Nothing to say is a success. Re-running a release over a tap that is already correct
+          # must not fail on an empty commit.
+          if git diff --quiet; then
+            echo "the tap already points at $tag"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -qam "neosh ${tag#v}"
+          git push
+          echo "tap now points at $tag"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,80 @@
+name: tag
+
+# A release is one `git push --follow-tags`, and nothing after it.
+#
+# What this file does is small on purpose: it checks the tag against the version in the manifest,
+# and it creates the GitHub release page. Everything that *publishes* — the four binaries, the
+# eleven crates, the sixteen npm packages, the Homebrew formula — is triggered by the same tag push
+# in its own file, in parallel with this one.
+#
+# **The publishing jobs are not moved into here, and that is deliberate.** crates.io and npm bind a
+# trusted publisher to a repository *and a workflow filename*: `publish-crates.yml` and
+# `publish-npm.yml` are written down on both registries. Consolidating them into one file would
+# change `job_workflow_ref`, every OIDC exchange would stop matching, and the failure would arrive
+# at the worst possible moment — mid-release, on a tag that already exists, with half the crates up.
+# So each keeps its name and gains a trigger.
+#
+# The release page is created with `GITHUB_TOKEN`, which by GitHub's own loop-prevention rule does
+# *not* fire the `release: published` event for other workflows. That is the property this design
+# needs rather than a limitation to work around: the publish workflows are already running from the
+# tag, and a release event would start a second copy of each.
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: create the release page
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The generated notes need history to diff against the previous tag.
+          fetch-depth: 0
+
+      # The one thing worth failing a release over, and the cheapest to check.
+      #
+      # `[workspace.package] version` is what ends up on crates.io and in every npm package, and the
+      # tag is what Homebrew and the binary tarballs are named after. Nothing downstream compares
+      # them, so `git tag v0.4.2` on a commit that still says `0.4.1` publishes nothing new — every
+      # registry skips the version it already has — and leaves a release page full of binaries
+      # labelled with a version the code inside them does not carry.
+      - name: The tag and the manifest agree
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME#v}"
+          manifest=$(cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.name=="neosh") | .version')
+          if [ "$tag" != "$manifest" ]; then
+            echo "::error::tag v$tag does not match [workspace.package] version $manifest"
+            echo "Bump the version, commit, and re-tag. Both halves of the root manifest:"
+            echo "  [workspace.package] version, and the ten pins in [workspace.dependencies]."
+            exit 1
+          fi
+          echo "v$tag matches the manifest"
+
+      # A file if you wrote one, generated notes if you did not. Writing them is the one part of a
+      # release a person is better at than a script, and not writing them must not be a reason to
+      # stop — `--generate-notes` lists the commits, which is worse than prose and much better than
+      # an empty page.
+      - name: Publish the release page
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="$GITHUB_REF_NAME"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "release $tag already exists — leaving it alone"
+            exit 0
+          fi
+          notes="docs/release-notes/$tag.md"
+          if [ -f "$notes" ]; then
+            gh release create "$tag" --verify-tag --title "$tag" --notes-file "$notes"
+          else
+            echo "::notice::no $notes — generating notes from the commit log"
+            gh release create "$tag" --verify-tag --title "$tag" --generate-notes
+          fi

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -178,23 +178,27 @@ checksum somebody typed is a formula that installs whatever is at that URL now.
 # 1. Bump the version — in both halves of the root manifest.
 $EDITOR Cargo.toml                       # [workspace.package] version
                                          # AND the ten internal pins in [workspace.dependencies]
-$EDITOR npm/neosh/package.json          # version AND the four optionalDependencies
+$EDITOR npm/neosh/package.json           # version AND the four optionalDependencies
 $EDITOR plugins/api/package.json plugins/builtin/*/package.json
 cargo update -w                          # so Cargo.lock agrees before anything is committed
 
 # 2. Prove it.
 ./scripts/check.sh
 
-# 3. Tag it. Annotated — `--follow-tags` silently skips a lightweight tag, so
-#    `git tag v0.3.0` alone pushes the commit and leaves the tag behind.
-git commit -am "release: v0.3.0" && git tag -a v0.3.0 -m v0.3.0 && git push --follow-tags
-
-# 4. Publish the GitHub release, wait for it to build, then point Homebrew at it.
-gh release create v0.3.0 --verify-tag --notes-file notes.md
-gh run watch
-scripts/brew-formula.sh v0.3.0 > ../homebrew-tap/Formula/neosh.rb
-(cd ../homebrew-tap && git commit -am "neosh 0.3.0" && git push)
+# 3. Push a tag. That is the whole release.
+git commit -am "release: v0.4.2" && git tag -a v0.4.2 -m v0.4.2 && git push --follow-tags
 ```
+
+There is no step 4. The tag push runs `tag.yml`, which checks the tag against the manifest and
+creates the release page, and it runs `release.yml`, `publish-crates.yml` and `publish-npm.yml`
+straight from the tag — four binaries onto the release, eleven crates onto crates.io, sixteen
+packages onto npm, and then the Homebrew formula, which waits for the checksums it is written from.
+
+Write `docs/release-notes/v0.4.2.md` first if you want prose on the release page; without one the
+notes are generated from the commit log, because not having written them is not a reason to stop.
+
+**Annotated tags.** `--follow-tags` silently skips a lightweight one, so `git tag v0.4.2` alone
+pushes the commit and leaves the tag behind — and here that means nothing publishes at all.
 
 **Both halves of the root manifest**, and this is the one that bites. Every internal dependency in
 `[workspace.dependencies]` carries a `version` beside its `path` — it has to, or `cargo package`
@@ -206,8 +210,11 @@ error: failed to select a version for the requirement `neosh-proto = "^0.2.0"`
 candidate versions found which didn't match: 0.3.0
 ```
 
-It fails loudly and on the first command, which is the good case. It is in step 1 rather than in a
-troubleshooting section because reading it after `check.sh` has already died is reading it too late.
+It fails loudly and on the first command, which is the good case. `tag.yml` also refuses a tag whose
+number does not match the manifest, because the failure that used to be possible was silent: every
+registry skips the version it already has, so `git tag v0.4.2` on a commit that still says `0.4.1`
+published nothing and left a release page full of binaries labelled with a version the code inside
+them did not carry.
 
 **Which number.** `0.x` is breaking at the *minor*, and Cargo means it: a new variant on a public
 `enum` or a new field on a public `struct` breaks an exhaustive `match` or a struct literal
@@ -215,16 +222,35 @@ downstream, and both are ordinary things to add. `0.2.0` → `0.3.0` was exactly
 gained `Waiting`, `SwarmEvent` gained `Unapproved`, `allow::Peer` gained `alias`. Ship those as a
 patch and the version number has stopped telling anybody anything.
 
-Then publish the GitHub release for that tag. Publishing it is the trigger: `release.yml` builds
-the four binaries and attaches them, `publish-crates.yml` pushes the eleven crates,
-`release.yml` pushes the four platform packages and then the `neosh` launcher, and
-`publish-npm.yml` pushes the plugin packages, skipping anything the registry already has — so it is
-safe to re-run a half-failed release.
+### Why the publishing is spread across three files rather than one
 
-Then regenerate the Homebrew formula, as in step 9 — a release nobody points Homebrew at is a
-release `brew upgrade` cannot see. It is the one step of a release with nothing watching it:
-the registries are pushed by workflows that fail loudly, and the tap is a second repository
-that a green release says nothing about.
+Because crates.io and npm bind a trusted publisher to a repository **and a workflow filename**.
+`publish-crates.yml` and `publish-npm.yml` are written down on both registries, so consolidating
+them into a single release workflow would change `job_workflow_ref`, every OIDC exchange would stop
+matching, and it would fail mid-release on a tag that already exists with half the crates up. Each
+file keeps its name and gained a trigger.
+
+The release page is created with `GITHUB_TOKEN`, which by GitHub's loop-prevention rule does not
+fire `release: published` for other workflows — which is the property this needs rather than a
+limitation: the publish workflows are already running from the tag, and a release event would start
+a second copy of each. Creating a release **by hand** still publishes, because the
+`release: published` trigger is kept.
+
+### The one credential OIDC cannot replace
+
+Homebrew is a git push to `neoswarm/homebrew-tap`, not an upload to a registry, so there is nothing
+to exchange an OIDC identity for. It needs a fine-grained PAT with **Contents: read and write** on
+that repository, once:
+
+```sh
+gh secret set HOMEBREW_TAP_TOKEN
+```
+
+Without it the `homebrew` job skips with a warning rather than failing — a fork has no business
+pushing to our tap — and the tap stays where it was, which `brew upgrade` reports as "already
+installed". Note that Homebrew caches its copy of a tap: after a release, `brew update` then
+`brew upgrade neosh`, and if it still claims the old version, `git -C "$(brew --repository
+neoswarm/tap)" pull` is the thing that was stale.
 
 **A new crate or a new bundled plugin needs its own first manual publish and its own trusted
 publisher**, exactly as in steps 3–5. Nothing else does — and this is the one part of a release that


### PR DESCRIPTION
Cutting v0.4.1 was: push a tag, `gh release create`, watch three workflows, clone a second repository, run `brew-formula.sh` into it, commit, push. Six manual steps of which one was interesting — and the last one has **nothing watching it**, so a green release still left every Homebrew user on the previous version, silently, because nothing in this repository reports on the tap. That is exactly how it went today.

Now `git push --follow-tags` is the whole release.

```sh
$EDITOR Cargo.toml …            # bump
./scripts/check.sh              # prove it
git commit -am "release: v0.4.2" && git tag -a v0.4.2 -m v0.4.2 && git push --follow-tags
```

There is no step 4.

## `tag.yml`, and why it is small

It checks the tag against `[workspace.package] version`, and creates the release page. That is all.

The check earns its place because the failure it prevents is **silent**: every registry skips a version it already has, so `git tag v0.4.2` on a commit that still says `0.4.1` publishes nothing at all and leaves a release page full of binaries labelled with a version the code inside them does not carry. Nothing downstream compares the two.

Notes come from `docs/release-notes/<tag>.md` if you wrote one, and from the commit log if you did not — not having written prose is not a reason to stop a release.

## The publishing stayed exactly where it was

This is the part that looks like it should have been consolidated and must not be.

crates.io and npm bind a trusted publisher to a repository **and a workflow filename**. `publish-crates.yml` and `publish-npm.yml` are written down on both registries. Moving those jobs into one release workflow changes `job_workflow_ref`, every OIDC exchange stops matching, and the failure lands mid-release on a tag that already exists with half the crates up. So each file keeps its name and gains a `push: tags` trigger.

`release: published` is kept alongside, so creating a release by hand still publishes. There is no double-fire: the page is created with `GITHUB_TOKEN`, and by GitHub's loop-prevention rule that does not raise `release: published` for other workflows — which is the property this design wants rather than a limitation to route around.

## Homebrew, now watched

A job in `release.yml` with `needs: build`, because the formula is written *from* the release — `brew-formula.sh` reads the four `.sha256` files off it. `needs:` waits for the jobs rather than for the assets to have settled, so it polls for the four checksums and refuses to write a formula from a partial release.

It is **the one credential OIDC cannot replace**: a git push to another repository is not an upload to a registry. So it takes `HOMEBREW_TAP_TOKEN` and *skips with a warning* when there is none — a fork has no business pushing to our tap, and going red for that is a lie about what went wrong.

**One thing to do once, and then never again:**

```sh
gh secret set HOMEBREW_TAP_TOKEN     # fine-grained PAT, Contents: read+write on neoswarm/homebrew-tap
```

Until that exists the job skips loudly and the tap stays where it is.

The token is tested through job-level `env` rather than `if: secrets.X`, because the `secrets` context is **not available in a step's `if:`** — it evaluates to empty there, so the direct spelling is always false and the job would silently do nothing on a repository that has the token configured. Job-level `env` can read secrets and `env` is available in `if:`; that is the one spelling that behaves.

## `publish-npm.yml` stops blaming a cause it can rule out

It printed "a package npm has never seen cannot be published by OIDC — publish it once by hand" for *every* failure. At v0.4.1 `@neosh/titles` and `@neosh/usage` failed with a transient 401 about web auth URLs, and both went up on a plain rerun with nothing changed — but that message sent me to npmjs.com to configure a trusted publisher that was already there.

The loop now asks npm whether it knows the package, and says "rerun this first" when it does.

## Verification

All five workflow files parse (`js-yaml`), and the wait loop's two shell subtleties were tested rather than reasoned about: `[ "$n" -eq 4 ] && break` is safe under `set -euo pipefail` inside a `for`, and the `gh` call is guarded with `|| echo 0` so one failed request in a five-minute poll cannot end a release.

Not verifiable before merge: workflow triggers only take effect once they are on the default branch, so the tag path proves itself on the next release. Everything it replaced is still present — `workflow_dispatch` on all three, and `release: published` — so the manual route remains available if it misbehaves.

No version bump: this ships with the next release, whenever that is.
