### PR TITLE
A tab belongs to a conversation, and the bar is one conversation's tabs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,11 +136,33 @@ is `docs/releasing.md`.
   drawn, even with one tab, because a bar that appears when you make a second tab is a bar whose
   arrival moves every other row down and which nothing had ever mentioned. Numbered from one,
   because the key is `<C-w>1`. When the row is short the **legend** is what gives way, never the
-  tab names: crowded out by three key names the bar said `+1` where a conversation's title belongs,
-  on the one row whose job is telling you which conversations are open. The first hint is reserved
+  tab names: crowded out by three key names the bar said `+1` where a tab's title belongs, on the
+  one row whose job is telling you what is open. The first hint is reserved
   for, since everything else is behind it. And **which pane has the keyboard is said with its
   edges** — `Pane.Active` on the borders that belong to it, tmux's answer, because four panes of
   one conversation look identical and the caret is one cell.
+- **A tab belongs to a conversation, and the bar is one conversation's tabs.** A shell opened while
+  reading one is *that* conversation's: it was started in its directory, about its work, and a bar
+  that goes on drawing it after you have switched is a bar about the terminal rather than about what
+  you are doing — four conversations in, every one of them showed the same three tabs and two of
+  them were about none of it. `TabInfo::group` is the whole mechanism and is opaque to the editor,
+  which only ever asks whether two of them are equal: the host fills it with a `SessionId`, and a
+  plugin grouping its tabs by project would be using it exactly as intended. **A tab is filed once
+  and moves only when you switch** — `arrive_in` is the one place, guarded on the conversation
+  actually changing, because that is also what `rehome` calls when the keyboard merely crosses a
+  split, and a group re-derived from the active pane on every pass would change bars under
+  `<C-w>l`. `settle_tab_groups` is the other half and only ever fills a group that is *absent*: the
+  editor makes a terminal's first tab before anything knows which conversation it is opening in, and
+  a restored workspace puts one into a pane without ever arriving in it. Everything counted on the
+  bar is counted in the visible tabs — `<C-w>1`…`9`, `<C-w>n`, the drag, and the last-one refusal,
+  which is now a *conversation's* last tab, because closing it would land you in another
+  conversation's tabs and that is a key about where you are looking deciding what you are working
+  on. **Nothing is closed and nothing stops**: the tabs of the conversations you are not in are off
+  the strip rather than gone, so a build left running in one is still running when you come back —
+  which is why *deleting* a conversation hands its tabs to wherever each terminal landed, and
+  archiving deliberately does not. A group nothing can ever show again is a pane, its windows and
+  whatever is running in them, with no key on any keyboard that reaches it; an archived conversation
+  is one `^T` from having its tabs back.
 - **A panel you are in the middle of using has the keyboard.** `FloatConfig::modal` takes
   `KeymapScope::Global` out of the chain, and a key nothing claimed is swallowed rather than reaching
   the composer behind the float. Shadowing the keys a widget wants is the other half and not a
@@ -978,7 +1000,7 @@ table. `ui.keys.hint_delay = 0` shows it at once; a larger number keeps it out o
 |---|---|
 | `v` `s` | Split: the new pane on the right, or below. Focus follows |
 | `c` | Split to the right **on a new conversation** — the one-key version of splitting and then `^N` |
-| `q` | Close this pane. The last one is refused: `^Q` closes the terminal |
+| `q` | Close this pane. The last one of a conversation is refused: `^T` goes elsewhere, `^Q` closes the terminal |
 | `o` | Close every pane but this one |
 | `h` `j` `k` `l` | Go to the pane that way. No wrap-around — the edge is where it stops |
 | `w` | The next pane, or the next **tab** when this one has a single pane, so it always goes somewhere |
@@ -988,10 +1010,10 @@ table. `ui.keys.hint_delay = 0` shows it at once; a larger number keeps it out o
 | `x` | Swap this pane with the next, keeping their places — how the one you care about gets the wide half |
 | `=` | Give every pane an equal share |
 | `t` | A tab. **Asks what goes in it**: a new conversation, a shell, or this conversation again |
-| `T` | A tab with a **shell**, skipping the question |
+| `T` | A tab with a **shell**, skipping the question. It is this conversation's shell, and it is on this conversation's bar |
 | `S` | Split into a **shell** |
-| `X` | Close this tab and everything in it |
-| `n` `p` | The next / previous tab, wrapping |
+| `X` | Close this tab and everything in it. This conversation's last one is refused |
+| `n` `p` | The next / previous tab on this bar, wrapping |
 | `1`–`9` | That tab, counting from the left as the bar numbers them |
 | `r` | Name this tab. `↵` on an empty name gives it back to being named by what is in it |
 | `,` `.` | Move this tab along the bar |
@@ -1000,6 +1022,13 @@ table. `ui.keys.hint_delay = 0` shows it at once; a larger number keeps it out o
 A split shows what you were reading — Vim's answer for `:split`, and the only one that needs no
 dialog — and each pane then has **its own transcript, composer, draft, scroll and search**. `^T` and
 `^N` change what is in the pane you are in.
+
+**The tabs belong to the conversation you are in.** A shell you open while reading one is that
+conversation's shell, and switching with `^T` shows the tabs of where you have gone — the ones you
+left are off the bar rather than closed, so the build still running in one is still running when you
+come back to it, and it is on the bar again the moment you do. Which is also why `<C-w>X` refuses a
+conversation's last tab where it used to refuse a terminal's: closing it would land you in some other
+conversation's tabs, and a key about where you are looking should not decide what you are working on.
 
 ## A shell in a pane
 
@@ -1011,6 +1040,11 @@ move, `Esc` gives up. Every row says *what you get*: the first cut called the th
 indistinguishable from `New conversation` on the row below — and the likeliest intent is first,
 because that is where the cursor starts and `⏎` is what people press. The three verbs behind it (`tab.new`, `tab.new.chat`, `tab.new.term`) stay separate
 commands, so a script or a key can skip the question — which is what `<C-w>T` does.
+
+The first row is the one that goes somewhere: a tab on a *new* conversation is that conversation's
+first tab, so the bar it lands on is its own and the tabs you had open are the ones you came from.
+The other two stay here. That is what the row says — `a fresh one here, with tabs of its own` — rather
+than something you find out by watching the bar empty.
 
 
 `<C-w>T` opens a tab with one, `<C-w>S` splits into one. A terminal pane is one window and no

--- a/crates/neosh-core/src/editor.rs
+++ b/crates/neosh-core/src/editor.rs
@@ -204,6 +204,39 @@ impl Tabs {
         self.tab(self.active)
     }
 
+    /// Which strip is on screen: the group of the tab you are in. See [`TabInfo::group`].
+    ///
+    /// Read off the active tab rather than kept beside it, because the two could then disagree —
+    /// and a terminal whose remembered strip does not contain the tab it is showing is one where
+    /// the bar and the screen are about different conversations.
+    fn group(&self) -> Option<&str> {
+        self.active_tab().and_then(|t| t.group.as_deref())
+    }
+
+    /// The tabs on the bar, in bar order: the ones sharing the active tab's group.
+    ///
+    /// Always at least the tab you are in, which is what every caller here relies on — an empty bar
+    /// is not a state a terminal can be in, and the numbering, the stepping and the last-tab rule
+    /// are all counted in this rather than in `tabs`.
+    fn visible(&self) -> Vec<&TabInfo> {
+        let group = self.group().map(|g| g.to_string());
+        self.at(&group).into_iter().map(|i| &self.tabs[i]).collect()
+    }
+
+    /// Where one strip's tabs sit in `tabs`, in bar order. What a move has to translate through.
+    ///
+    /// Asked with a group rather than reading the active tab's, because a move is in the middle of
+    /// taking that tab out: with the active tab lifted, "the group on screen" is momentarily
+    /// nobody's, and the second half of the move would put it back among a different conversation's.
+    fn at(&self, group: &Option<String>) -> Vec<usize> {
+        self.tabs
+            .iter()
+            .enumerate()
+            .filter(|(_, t)| t.group == *group)
+            .map(|(i, _)| i)
+            .collect()
+    }
+
     /// Remember that a pane has the keyboard.
     fn touch(&mut self, pane: PaneId) {
         self.mru.retain(|p| *p != pane);
@@ -332,6 +365,9 @@ impl Editor {
                 title: None,
                 root: PaneNode::Leaf { pane },
                 active_pane: pane,
+                // Ungrouped until something furnishes it: only the host knows which conversation a
+                // terminal opens in, and a group invented here would be one nothing else can name.
+                group: None,
             };
             self.view(view).tabs =
                 Some(Tabs { tabs: vec![first], active: tab, mru: vec![pane] });
@@ -396,15 +432,51 @@ impl Editor {
         self.peek_tabs(view).map(|t| t.active)
     }
 
-    /// How many tabs a view has. One for a view nothing has laid out yet, which is what it will
-    /// have the moment anything asks.
+    /// How many tabs are on the bar — this conversation's, not this terminal's.
+    ///
+    /// What a legend counts: `next tab` is a key worth printing when there is a second tab *you can
+    /// get to*, and one that steps to a tab of a conversation you are not in is not that. One for a
+    /// view nothing has laid out yet, which is what it will have the moment anything asks.
     pub fn tab_count_of(&self, view: ViewId) -> usize {
-        self.peek_tabs(view).map(|t| t.tabs.len()).unwrap_or(1)
+        self.peek_tabs(view).map(|t| t.visible().len()).unwrap_or(1)
     }
 
-    /// Every tab of a view, without settling one that has never been laid out.
+    /// Every tab of a view, whatever strip it is on, without settling one that has never been laid
+    /// out. Filter by [`TabInfo::group`] for the bar; see [`Editor::visible_tabs_of`].
     pub fn tabs_of(&self, view: ViewId) -> Vec<TabInfo> {
         self.peek_tabs(view).map(|t| t.tabs.clone()).unwrap_or_default()
+    }
+
+    /// The tabs on a view's bar, in bar order: the ones grouped with the tab it is showing.
+    ///
+    /// What the strip is drawn from and what `<C-w>1`…`<C-w>9` count, so that the number on a tab
+    /// is the number you type. See [`TabInfo::group`].
+    pub fn visible_tabs_of(&self, view: ViewId) -> Vec<TabInfo> {
+        self.peek_tabs(view)
+            .map(|t| t.visible().into_iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Which strip a view is showing, if its tabs have been settled.
+    pub fn tab_group_of(&self, view: ViewId) -> Option<String> {
+        self.peek_tabs(view).and_then(|t| t.group()).map(|g| g.to_string())
+    }
+
+    /// Move a tab to another strip. See [`TabInfo::group`].
+    ///
+    /// The tab keeps its panes, its windows and anything running in them: this says which
+    /// conversation's bar it is on, and nothing else. Moving the tab you are *in* is therefore not
+    /// a move at all from the screen's point of view — you go with it, and what changes is which
+    /// other tabs are beside it.
+    pub fn tab_set_group(&mut self, view: ViewId, tab: TabId, group: Option<String>) -> bool {
+        let t = self.tabs(view);
+        let Some(info) = t.tab_mut(tab) else { return false };
+        if info.group == group {
+            return false;
+        }
+        info.group = group;
+        self.publish_panes(view);
+        true
     }
 
     /// Every binding in a mode, as [`ApiCall::KeymapList`] would report them.
@@ -590,6 +662,10 @@ impl Editor {
     }
 
     /// Open a tab with one empty pane, and answer with both ids.
+    ///
+    /// On the bar you are looking at: it inherits the active tab's group, so a tab opened while
+    /// reading a conversation is that conversation's. See [`TabInfo::group`], and
+    /// [`Editor::tab_set_group`] for putting it somewhere else.
     pub fn tab_new(
         &mut self,
         view: ViewId,
@@ -604,11 +680,13 @@ impl Editor {
         self.next_tab += 1;
         self.next_pane += 1;
         let t = self.tabs(view);
+        let group = t.group().map(|g| g.to_string());
         t.tabs.push(TabInfo {
             id: tab,
             title,
             root: PaneNode::Leaf { pane },
             active_pane: pane,
+            group,
         });
         if activate {
             t.active = tab;
@@ -618,10 +696,21 @@ impl Editor {
         (tab, pane)
     }
 
-    /// Close a tab and every window in it. The view's last tab is refused.
+    /// Close a tab and every window in it. The last tab *on its bar* is refused.
+    ///
+    /// The bar rather than the terminal, because the tab you are in is the conversation you are in:
+    /// closing the only one it has would land you in some other conversation's tabs, which is a key
+    /// about where you are looking doing something to what you are working on. A terminal with one
+    /// tab is the case that used to be refused and still is — it is the same rule, counted where the
+    /// rule now lives. A tab on a bar nobody is looking at has no such problem and goes.
     pub fn tab_close(&mut self, view: ViewId, tab: TabId) -> bool {
         let t = self.tabs(view);
-        if t.tabs.len() <= 1 || t.tab(tab).is_none() {
+        let Some(going) = t.tab(tab).map(|t| t.group.clone()) else { return false };
+        let showing = t.active == tab;
+        // A floor under both rules: a terminal with no tabs has nowhere to draw and no key that
+        // would bring one back, and `active` naming a tab that is not there is a state this must
+        // not be able to turn into an empty one.
+        if t.tabs.len() <= 1 || (showing && t.visible().len() <= 1) {
             return false;
         }
         let panes = t.tab(tab).map(|t| t.root.panes()).unwrap_or_default();
@@ -633,13 +722,23 @@ impl Editor {
         let at = t.tabs.iter().position(|t| t.id == tab).unwrap_or(0);
         t.tabs.retain(|t| t.id != tab);
         t.mru.retain(|p| !panes.contains(p));
-        if t.active == tab {
-            // The tab to its left, or the first one — never "the one that is now at this index",
-            // which for the last tab is nothing at all.
-            let next = at.min(t.tabs.len().saturating_sub(1));
-            t.active = t.tabs[next].id;
-            let pane = t.tabs[next].active_pane;
-            t.touch(pane);
+        if showing {
+            // The tab to its left *on this bar*, or the first one on it — never "the one that is
+            // now at this index", which is another conversation's tab whenever one happens to sit
+            // there, and for the last tab is nothing at all. Non-empty by the refusal above.
+            let mine: Vec<usize> = t
+                .tabs
+                .iter()
+                .enumerate()
+                .filter(|(_, x)| x.group == going)
+                .map(|(i, _)| i)
+                .collect();
+            let next = mine.iter().rev().find(|i| **i < at).or_else(|| mine.first()).copied();
+            if let Some(next) = next {
+                t.active = t.tabs[next].id;
+                let pane = t.tabs[next].active_pane;
+                t.touch(pane);
+            }
         }
         self.publish_panes(view);
         true
@@ -660,28 +759,50 @@ impl Editor {
     }
 
     /// Go `delta` tabs along the bar, wrapping.
+    ///
+    /// Along *this conversation's* tabs. Wrapping over all of them would step out of the
+    /// conversation you are in — the one thing a key called "next tab" should never do — and would
+    /// wrap after a number that is not the number the bar is showing.
     pub fn tab_step(&mut self, view: ViewId, delta: i32) -> Option<TabId> {
         let t = self.tabs(view);
-        let n = t.tabs.len() as i32;
+        let bar: Vec<TabId> = t.visible().into_iter().map(|x| x.id).collect();
+        let n = bar.len() as i32;
         if n == 0 {
             return None;
         }
-        let at = t.tabs.iter().position(|x| x.id == t.active)? as i32;
-        let to = (at + delta).rem_euclid(n) as usize;
-        let id = t.tabs[to].id;
+        let at = bar.iter().position(|id| *id == t.active)? as i32;
+        let id = bar[(at + delta).rem_euclid(n) as usize];
         self.tab_select(view, id).then_some(id)
     }
 
     /// Move a tab along the bar, clamped at the ends.
+    ///
+    /// `to` is a position on the bar, so it is the number printed on the strip: the tabs of other
+    /// conversations sit between these in `tabs` and are not places you can drag one to. Which is
+    /// why this is an insert rather than a swap — a drag past a hidden tab has to land where the
+    /// bar says it landed, and the tab it displaces has to end up on the side it came from.
     pub fn tab_move(&mut self, view: ViewId, tab: TabId, to: u32) -> bool {
         let t = self.tabs(view);
-        let Some(from) = t.tabs.iter().position(|x| x.id == tab) else { return false };
-        let to = (to as usize).min(t.tabs.len().saturating_sub(1));
+        let Some(group) = t.tab(tab).map(|x| x.group.clone()) else { return false };
+        let bar = t.at(&group);
+        let Some(from) = bar.iter().position(|i| t.tabs[*i].id == tab) else { return false };
+        let to = (to as usize).min(bar.len().saturating_sub(1));
         if from == to {
             return false;
         }
-        let info = t.tabs.remove(from);
-        t.tabs.insert(to, info);
+        let info = t.tabs.remove(bar[from]);
+        // Recomputed after the removal: every index past the hole moved, and an insert against the
+        // stale ones puts the tab one place off whenever a hidden tab lies between the two.
+        let rest = t.at(&group);
+        let at = match rest.get(to) {
+            // Immediately before whichever tab is to hold that place, which for a move rightwards
+            // is the one currently after the hole — so the result reads as the drag you did.
+            Some(i) => *i,
+            // Past the end of the bar: after its last tab, not after every tab there is. A hidden
+            // tab beyond it belongs to a conversation this move has nothing to do with.
+            None => rest.last().map(|i| i + 1).unwrap_or(t.tabs.len()),
+        };
+        t.tabs.insert(at, info);
         self.publish_panes(view);
         true
     }
@@ -2203,15 +2324,27 @@ impl Editor {
                 self.pane_equalize(named.unwrap_or(view));
                 Ok(ApiOk::Unit)
             }
-            ApiCall::TabNew { view: named, title, activate } => {
-                let (tab, _) = self.tab_new(named.unwrap_or(view), title, activate);
+            ApiCall::TabNew { view: named, title, activate, group } => {
+                let at = named.unwrap_or(view);
+                let (tab, _) = self.tab_new(at, title, activate);
+                // After it exists, so that the common case — no group named — is the inheritance
+                // `tab_new` already did, and a named one is a tab that moves before anything has
+                // had a chance to draw it anywhere else.
+                if group.is_some() {
+                    self.tab_set_group(at, tab, group);
+                }
                 Ok(ApiOk::Tab { tab })
+            }
+            ApiCall::TabGroup { tab, group } => {
+                let at = self.view_of_tab(tab).ok_or_else(|| no_tab(tab))?;
+                self.tab_set_group(at, tab, group);
+                Ok(ApiOk::Unit)
             }
             ApiCall::TabClose { tab } => {
                 let at = self.view_of_tab(tab).ok_or_else(|| no_tab(tab))?;
                 if !self.tab_close(at, tab) {
                     return Err(ApiError::InvalidArgument {
-                        message: "a terminal's last tab cannot be closed".into(),
+                        message: "the last tab of a conversation cannot be closed".into(),
                     });
                 }
                 Ok(ApiOk::Unit)

--- a/crates/neosh-core/tests/tab_groups.rs
+++ b/crates/neosh-core/tests/tab_groups.rs
@@ -1,0 +1,140 @@
+//! A tab belongs to a conversation, and the bar is one conversation's tabs.
+//!
+//! The invariant worth protecting is that *everything counted on the bar is counted in the visible
+//! tabs*. A shell opened while reading one conversation is that conversation's, so switching has to
+//! take it off the strip — and the moment it is off the strip, every key that walks the bar has a
+//! second answer available to it and the wrong one is silent: `<C-w>n` steps into a conversation you
+//! were not in, `<C-w>2` lands on somebody else's tab, and closing the last tab you can see puts you
+//! somewhere you never asked to be.
+//!
+//! What the editor knows about a group is only that two of them can be equal. These use plain
+//! strings for that reason: the host fills them with a `SessionId`, and nothing here should care.
+
+use neosh_core::Editor;
+use neosh_proto::{TabId, ViewId};
+
+const V: ViewId = ViewId::LOCAL;
+
+/// A terminal with its first tab filed under `a`, the way `settle_tab_groups` does.
+fn setup() -> (Editor, TabId) {
+    let mut e = Editor::new();
+    // Settling the view is what any first question about its layout does, and it is what makes the
+    // first tab exist at all — the editor has no idea which conversation a terminal opens in.
+    e.active_pane(V);
+    let first = e.active_tab_of(V).expect("a settled view has a tab");
+    e.tab_set_group(V, first, Some("a".into()));
+    (e, first)
+}
+
+fn bar(e: &Editor) -> Vec<TabId> {
+    e.visible_tabs_of(V).iter().map(|t| t.id).collect()
+}
+
+#[test]
+fn a_new_tab_joins_the_bar_it_was_opened_on() {
+    let (mut e, first) = setup();
+    let (second, _) = e.tab_new(V, None, true);
+    assert_eq!(bar(&e), vec![first, second], "a tab opened here is this conversation's");
+    assert_eq!(e.tabs_of(V)[1].group.as_deref(), Some("a"));
+}
+
+#[test]
+fn switching_conversation_takes_the_other_tabs_off_the_bar() {
+    let (mut e, first) = setup();
+    let (shell, _) = e.tab_new(V, Some("shell".into()), false);
+    assert_eq!(bar(&e), vec![first, shell]);
+
+    // What `arrive_in` does: the tab you switched in is now about the conversation in it.
+    e.tab_set_group(V, first, Some("b".into()));
+    assert_eq!(bar(&e), vec![first], "the shell belongs to the conversation you left");
+
+    // And going back brings it with you. Nothing was closed.
+    e.tab_set_group(V, first, Some("a".into()));
+    assert_eq!(bar(&e), vec![first, shell], "coming back finds it still there");
+}
+
+#[test]
+fn stepping_stays_on_this_conversations_tabs() {
+    let (mut e, first) = setup();
+    let (mine, _) = e.tab_new(V, None, false);
+    let (theirs, _) = e.tab_new(V, None, false);
+    e.tab_set_group(V, theirs, Some("b".into()));
+
+    assert_eq!(e.tab_step(V, 1), Some(mine));
+    // Wrapping is over the bar, so the second step comes back round rather than landing in `b`.
+    assert_eq!(e.tab_step(V, 1), Some(first));
+    assert_eq!(e.tab_step(V, -1), Some(mine));
+}
+
+#[test]
+fn the_bar_counts_its_own_tabs() {
+    let (mut e, _) = setup();
+    let (_, _) = e.tab_new(V, None, false);
+    let (theirs, _) = e.tab_new(V, None, false);
+    e.tab_set_group(V, theirs, Some("b".into()));
+    assert_eq!(e.tab_count_of(V), 2, "two on this bar, three in the terminal");
+    assert_eq!(e.tabs_of(V).len(), 3);
+}
+
+#[test]
+fn a_conversations_last_tab_is_refused_even_with_tabs_open_elsewhere() {
+    let (mut e, first) = setup();
+    let (theirs, _) = e.tab_new(V, None, false);
+    e.tab_set_group(V, theirs, Some("b".into()));
+
+    assert!(!e.tab_close(V, first), "closing it would land you in another conversation's tabs");
+    assert_eq!(bar(&e), vec![first]);
+    // A tab on a bar nobody is looking at has no such problem.
+    assert!(e.tab_close(V, theirs));
+}
+
+#[test]
+fn closing_hands_the_keyboard_to_a_tab_on_the_same_bar() {
+    let (mut e, first) = setup();
+    // Interleaved on purpose: `b`'s tab sits between two of `a`'s, which is exactly the case an
+    // index into the whole list gets wrong.
+    let (theirs, _) = e.tab_new(V, None, false);
+    e.tab_set_group(V, theirs, Some("b".into()));
+    let (mine, _) = e.tab_new(V, None, true);
+
+    assert!(e.tab_close(V, mine));
+    assert_eq!(e.active_tab_of(V), Some(first), "back to the tab on the left of this bar");
+    assert_eq!(bar(&e), vec![first]);
+}
+
+#[test]
+fn a_drag_lands_where_the_bar_says_it_landed() {
+    let (mut e, first) = setup();
+    let (theirs, _) = e.tab_new(V, None, false);
+    e.tab_set_group(V, theirs, Some("b".into()));
+    let (second, _) = e.tab_new(V, None, false);
+    let (third, _) = e.tab_new(V, None, false);
+    assert_eq!(bar(&e), vec![first, second, third]);
+
+    // One place right, over a hidden tab: a swap in the underlying list would jump it two.
+    assert!(e.tab_move(V, first, 1));
+    assert_eq!(bar(&e), vec![second, first, third]);
+
+    assert!(e.tab_move(V, first, 2));
+    assert_eq!(bar(&e), vec![second, third, first]);
+
+    assert!(e.tab_move(V, first, 0));
+    assert_eq!(bar(&e), vec![first, second, third]);
+
+    // And the other conversation's tab is where it was through all of it.
+    assert!(e.tabs_of(V).iter().any(|t| t.id == theirs));
+}
+
+#[test]
+fn an_unfiled_tab_is_its_own_bar() {
+    // What every tab was before groups existed, and what the editor's first tab is until the host
+    // settles it: `None` is a group like any other rather than "on every bar".
+    let mut e = Editor::new();
+    e.active_pane(V);
+    let first = e.active_tab_of(V).expect("a settled view has a tab");
+    let (second, _) = e.tab_new(V, None, false);
+    assert_eq!(bar(&e), vec![first, second]);
+
+    e.tab_set_group(V, second, Some("a".into()));
+    assert_eq!(bar(&e), vec![first], "filing one takes it off the unfiled bar");
+}

--- a/crates/neosh-proto/src/api.rs
+++ b/crates/neosh-proto/src/api.rs
@@ -564,8 +564,27 @@ pub enum ApiCall {
         /// work somewhere is not, for the same reason `SessionNew { activate: false }` exists.
         #[serde(default)]
         activate: bool,
+        /// Which strip to open it on. See [`TabInfo::group`].
+        ///
+        /// `None` inherits the tab you are on, which is what a new tab almost always wants: opened
+        /// while reading a conversation, it is that conversation's. Saying one is for a caller
+        /// putting a tab somewhere *else* — and a group nothing is currently showing is a tab that
+        /// is made and is off the bar, which is a legitimate thing to want and a surprising thing
+        /// to do by accident.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        group: Option<String>,
     },
-    /// Close a tab and every pane in it. The view's last tab is refused.
+    /// Move a tab to another strip, or to nobody's with `None`. See [`TabInfo::group`].
+    ///
+    /// What the host calls when you switch conversation: the tab you did it in is now about the
+    /// conversation in it, so it leaves the old strip and joins the new one. A tab that is on
+    /// screen when this moves it stays on screen — you are in it — and what changes is which
+    /// *other* tabs are beside it.
+    TabGroup {
+        tab: TabId,
+        group: Option<String>,
+    },
+    /// Close a tab and every pane in it. A conversation's last tab is refused.
     TabClose {
         tab: TabId,
     },
@@ -573,11 +592,13 @@ pub enum ApiCall {
     TabSelect {
         tab: TabId,
     },
-    /// Go to the tab `delta` along, wrapping.
+    /// Go to the tab `delta` along the bar, wrapping.
     ///
     /// Wrapping where [`ApiCall::PaneFocusDir`] does not, because a tab bar is a list you can see
     /// all of: coming round from the last to the first is visible in the same glance as the key
-    /// that did it, and a pane you wrapped to may be off in a corner of a nested split.
+    /// that did it, and a pane you wrapped to may be off in a corner of a nested split. Along *the
+    /// bar*, which is this conversation's tabs — stepping into another conversation's would be a
+    /// key that changes what you are working on, from a key about where you are looking.
     TabStep {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         view: Option<ViewId>,
@@ -585,6 +606,10 @@ pub enum ApiCall {
     },
     /// Move a tab along the bar. Clamped at the ends rather than wrapping — this is a drag, and a
     /// drag that teleports is a drag you did not mean.
+    ///
+    /// `to` counts the tabs on the bar, which is the tabs of one conversation: it is the number
+    /// printed on the strip and the one `<C-w>1` takes, rather than a position in a list that
+    /// includes tabs nothing is drawing. Moving a tab to another conversation is [`ApiCall::TabGroup`].
     TabMove {
         tab: TabId,
         to: u32,
@@ -595,6 +620,11 @@ pub enum ApiCall {
         title: Option<String>,
     },
     /// Every tab of a view, its panes, and which of each is active.
+    ///
+    /// *Every* one, including the tabs of the conversations this terminal is not in — with
+    /// [`TabInfo::group`] on each, which is what tells them apart. The whole truth and the key to
+    /// filter it by: a caller drawing a bar wants the active tab's group, and one asking "what is
+    /// open in this terminal" wants all of them, and both are answers this can give.
     TabList {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         view: Option<ViewId>,

--- a/crates/neosh-proto/src/ui.rs
+++ b/crates/neosh-proto/src/ui.rs
@@ -211,6 +211,21 @@ pub struct TabInfo {
     /// Per tab rather than per view, so that leaving a tab and coming back puts you where you were
     /// rather than in whichever pane happens to be first.
     pub active_pane: PaneId,
+    /// Which strip this tab is on — the conversation it belongs to.
+    ///
+    /// **A tab belongs to a conversation, and the bar shows one conversation's tabs.** A shell
+    /// opened while reading one is *that* conversation's shell: it was started in its directory,
+    /// about its work, and a bar that goes on showing it after you have switched is a bar about
+    /// the terminal rather than about what you are doing. The tabs of the conversations you are
+    /// not in are not closed, and nothing in them stops — they are off the strip until you go
+    /// back, which is what makes leaving a build running and returning to it work.
+    ///
+    /// Opaque here and in the editor, which only ever asks whether two of them are equal: the host
+    /// fills it with a [`crate::SessionId`], and a plugin that grouped its tabs by project would be
+    /// using it exactly as intended. `None` is a group of its own — where a tab nobody has filed
+    /// sits, and what every tab was before this existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group: Option<String>,
 }
 
 /// What a float is positioned relative to.

--- a/crates/neosh-tui/tests/rendering.rs
+++ b/crates/neosh-tui/tests/rendering.rs
@@ -1520,7 +1520,7 @@ fn paned(root: PaneNode) -> Mirror {
     });
     let active = TabId(1);
     m.apply(UiEvent::PanesChanged {
-        tabs: vec![TabInfo { id: active, title: None, root, active_pane: PaneId(1) }],
+        tabs: vec![TabInfo { id: active, title: None, root, active_pane: PaneId(1), group: None }],
         active,
     });
     m
@@ -1683,6 +1683,7 @@ fn a_window_that_names_no_pane_lands_in_the_active_one() {
             title: None,
             root: split(SplitDir::Row, vec![leaf(1), leaf(2)]),
             active_pane: PaneId(2),
+            group: None,
         }],
         active: TabId(1),
     });

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -105,8 +105,14 @@ pub const KIND_TAB_CHOICE: &str = "neosh.tab_choice";
 /// split already covers — it is offered because a *tab* of it is a whole screen where a split is
 /// half of one, and it is last because that is a thing you want occasionally rather than by
 /// default.
+///
+/// **And the first row says where it puts you.** A tab belongs to the conversation in it — see
+/// [`neosh_proto::TabInfo::group`] — so a tab on a *new* conversation is that conversation's first
+/// tab, and the bar it lands on is that conversation's rather than this one's. The two rows below
+/// it stay on this bar, which is the difference worth printing: without it the row is a key whose
+/// visible effect is the tabs you had open disappearing.
 const TAB_CHOICES: &[(&str, &str)] = &[
-    ("New conversation", "a fresh one, here in this directory"),
+    ("New conversation", "a fresh one here, with tabs of its own"),
     ("Terminal", "a shell, here in this directory"),
     ("This conversation again", "a second place to read it, with its own scroll"),
 ];
@@ -2484,6 +2490,13 @@ impl Host {
                 // in `vars.json` per conversation ever deleted, and a future id collision inherits
                 // somebody's stale colour.
                 self.vars.forget_session(&session);
+                // And its bar comes with you. A deleted conversation is a group nothing can ever
+                // show again, so a shell you had open in a second tab of it would keep running
+                // where no key could reach it — a process with no way back, which is the one thing
+                // hiding a tab must never turn into. Deleting is the irreversible one; archiving
+                // deliberately does not do this, because going back to the conversation is what
+                // brings its tabs back with it.
+                self.adopt_tabs_of(&session);
                 if closing_active {
                     // Where you landed is a conversation of its own, and it may be in another
                     // directory: the banner names one, the file tools are pointed at one, and
@@ -3051,14 +3064,45 @@ impl Host {
     /// The conversation being left is named rather than worked out by the store, because the store
     /// has no idea how many terminals there are: leaving a placeholder is what drops it, and a
     /// placeholder somebody else is still sitting in is not one anybody left.
+    ///
+    /// **And the tab comes with you.** A tab belongs to the conversation in it — see
+    /// [`neosh_proto::TabInfo::group`] — so switching is what moves this tab onto the new
+    /// conversation's bar, beside whatever was already open there and away from the shell you left
+    /// running in the old one. Guarded on the conversation actually changing, because this is also
+    /// the call [`Self::rehome`] makes when the keyboard merely moves *between* panes: a tab split
+    /// across two conversations would otherwise change which bar it is on every time you crossed
+    /// the boundary, and the strip would flicker between two conversations under `<C-w>l`.
     fn arrive_in(
         &mut self,
         session: &neosh_proto::SessionId,
     ) -> Result<(), neosh_agent::StoreError> {
         let leaving = self.abandoning(session);
+        let switching = self.v().session != *session;
         self.agent.sessions().enter(session, leaving.as_ref())?;
         self.vm().session = session.clone();
+        if switching {
+            self.file_tab(session.clone());
+        }
         Ok(())
+    }
+
+    /// Put the tab this pane is in on a conversation's bar.
+    ///
+    /// The tab *containing the acting pane*, which is not always the one the terminal is showing:
+    /// an orchestrator steering another view, or a call that named a pane, is arriving somewhere
+    /// that may be a tab along. Filing the tab on screen instead would leave the pane that actually
+    /// moved on a bar about a conversation it is no longer in.
+    fn file_tab(&mut self, group: neosh_proto::SessionId) {
+        let view = self.view_now();
+        let Some(pane) = self.acting_pane.or_else(|| self.editor.active_pane_of(view)) else {
+            return;
+        };
+        let Some(tab) =
+            self.editor.tabs_of(view).iter().find(|t| t.root.contains(pane)).map(|t| t.id)
+        else {
+            return;
+        };
+        self.editor.tab_set_group(view, tab, Some(group.0));
     }
 
     /// The conversation this pane is leaving, if nothing else is showing it.
@@ -3903,9 +3947,69 @@ impl Host {
                 }
             }
 
+            self.settle_tab_groups(view);
             self.rehome(view);
         }
         self.refresh_tabline();
+    }
+
+    /// Hand a gone conversation's tabs to the conversation each terminal landed in.
+    ///
+    /// Every view, not only the one that asked: the same conversation can have had a tab open in
+    /// two terminals, and a tab left on a group nothing will ever show again is a pane, its
+    /// windows, and whatever is running in it, all unreachable. Where they land is that terminal's
+    /// own bar, which by the time this runs is the conversation it stepped out into.
+    fn adopt_tabs_of(&mut self, gone: &neosh_proto::SessionId) {
+        let views: Vec<neosh_proto::ViewId> = self.views.keys().copied().collect();
+        for view in views {
+            let Some(here) = self.editor.tab_group_of(view) else { continue };
+            if here == gone.0 {
+                // The terminal is still standing in the conversation that has gone — nothing has
+                // moved it, so its tabs are all together and all on screen. Moving them somewhere
+                // would be inventing a destination this does not have.
+                continue;
+            }
+            let orphans: Vec<neosh_proto::TabId> = self
+                .editor
+                .tabs_of(view)
+                .iter()
+                .filter(|t| t.group.as_deref() == Some(gone.0.as_str()))
+                .map(|t| t.id)
+                .collect();
+            for tab in orphans {
+                self.editor.tab_set_group(view, tab, Some(here.clone()));
+            }
+        }
+    }
+
+    /// File any tab nobody has filed yet under the conversation in it.
+    ///
+    /// The editor makes the first tab of a terminal before anything knows which conversation that
+    /// terminal is opening in, and a workspace restored from disk puts a conversation into a pane
+    /// without ever *arriving* in it — so both leave a tab on the group `None` is. Left there, the
+    /// first shell you opened would inherit `None` and go on being drawn beside every conversation,
+    /// which is the whole of what this change is about.
+    ///
+    /// Only ever a tab with no group at all: it is a settling, not a reconciliation. Re-deriving
+    /// every tab's group from its active pane on each pass would make a tab split across two
+    /// conversations change bars whenever the keyboard crossed the split — see [`Self::arrive_in`],
+    /// which is the other and only place a tab moves.
+    fn settle_tab_groups(&mut self, view: neosh_proto::ViewId) {
+        let unfiled: Vec<(neosh_proto::TabId, neosh_proto::PaneId)> = self
+            .editor
+            .tabs_of(view)
+            .iter()
+            .filter(|t| t.group.is_none())
+            .map(|t| (t.id, t.active_pane))
+            .collect();
+        for (tab, pane) in unfiled {
+            let Some(session) =
+                self.views.get(&view).and_then(|v| v.panes.get(&pane)).map(|p| p.session.clone())
+            else {
+                continue;
+            };
+            self.editor.tab_set_group(view, tab, Some(session.0));
+        }
     }
 
     /// Start a shell in a pane, and claim the surface it draws on.
@@ -5043,7 +5147,10 @@ impl Host {
         // viewports at all is never.
         let known = width > 0;
 
-        let (tabs, active) = (self.editor.tab_list(view).0, self.editor.active_tab_of(view));
+        // This conversation's tabs, not this terminal's. A tab belongs to the conversation in it —
+        // see [`neosh_proto::TabInfo::group`] — so the shell you left running in another one is not
+        // on this bar, and the numbers here are the numbers `<C-w>1` takes.
+        let (tabs, active) = (self.editor.visible_tabs_of(view), self.editor.active_tab_of(view));
         // Text and its colours, built together and written as one line plus range marks — the way
         // the status strip does it, and for the same reason: virtual text on an empty line cannot
         // be selected, searched or read back, and this is a row people will want to screenshot.
@@ -11168,7 +11275,12 @@ impl Host {
             landed
         };
         if let Some(id) = landed {
-            self.vm().session = id;
+            self.vm().session = id.clone();
+            // The tab is filed with it. This is an arrival that does not come through `arrive_in` —
+            // the pane is simply told which conversation it holds — and a first tab left on the
+            // placeholder's group is a bar that the first `^T` strands: the tab moves to where you
+            // went, and a shell opened before that stays behind on a group nothing will ever show.
+            self.file_tab(id);
             let _ = self.agent.sessions().remove(&placeholder);
         }
         // Every restored conversation may live in a different checkout — that is what makes a
@@ -12254,7 +12366,10 @@ impl Host {
                     .or_else(|| args.first().and_then(|a| a.parse::<u32>().ok()));
                 if let Some(n) = n.filter(|n| *n >= 1) {
                     let view = self.view_now();
-                    let tabs = self.editor.tab_list(view).0;
+                    // Counted on the bar, which is what the bar numbered: a conversation's tabs are
+                    // `1`…`n` on screen, and indexing the whole list would take `<C-w>2` to whatever
+                    // tab of whatever other conversation happens to sit second in memory.
+                    let tabs = self.editor.visible_tabs_of(view);
                     match tabs.get(n as usize - 1) {
                         Some(t) => {
                             let id = t.id;
@@ -12476,9 +12591,13 @@ impl Host {
         let view = self.view_now();
         let Some(tab) = self.editor.active_tab_of(view) else { return };
         if !self.editor.tab_close(view, tab) {
+            // Of *this conversation*, which is the honest sentence now that a bar is one
+            // conversation's: there may well be tabs open elsewhere, and closing this one would
+            // have landed you in them — which is a key about where you are looking deciding what
+            // you are working on. `^T` goes to another conversation and `^Q` closes the terminal.
             self.editor_message(
                 MessageLevel::Warn,
-                "this is the last tab — ^Q closes the terminal, and the turns keep running",
+                "this conversation's last tab — ^T goes elsewhere, ^Q closes the terminal",
             );
             return;
         }
@@ -12890,7 +13009,9 @@ impl Host {
     fn shift_tab(&mut self, delta: i32) {
         let view = self.view_now();
         let Some(tab) = self.editor.active_tab_of(view) else { return };
-        let tabs = self.editor.tab_list(view).0;
+        // Positions on the bar, which is what a drag is in: `to` is a place among this
+        // conversation's tabs, and one place along has to be one place along on screen.
+        let tabs = self.editor.visible_tabs_of(view);
         let Some(at) = tabs.iter().position(|t| t.id == tab) else { return };
         let to = (at as i32 + delta).clamp(0, tabs.len().saturating_sub(1) as i32) as u32;
         self.editor.tab_move(view, tab, to);

--- a/plugins/api/src/generated/ApiCall.ts
+++ b/plugins/api/src/generated/ApiCall.ts
@@ -141,7 +141,18 @@ export type ApiCall =
      * work somewhere is not, for the same reason `SessionNew { activate: false }` exists.
      */
     activate: boolean;
+    /**
+     * Which strip to open it on. See [`TabInfo::group`].
+     *
+     * `None` inherits the tab you are on, which is what a new tab almost always wants: opened
+     * while reading a conversation, it is that conversation's. Saying one is for a caller
+     * putting a tab somewhere *else* — and a group nothing is currently showing is a tab that
+     * is made and is off the bar, which is a legitimate thing to want and a surprising thing
+     * to do by accident.
+     */
+    group?: string | null;
   }
+  | { "call": "tab_group"; tab: TabId; group: string | null }
   | { "call": "tab_close"; tab: TabId }
   | { "call": "tab_select"; tab: TabId }
   | { "call": "tab_step"; view?: ViewId | null; delta: number }

--- a/plugins/api/src/generated/TabInfo.ts
+++ b/plugins/api/src/generated/TabInfo.ts
@@ -24,4 +24,20 @@ export type TabInfo = {
    * rather than in whichever pane happens to be first.
    */
   active_pane: PaneId;
+  /**
+   * Which strip this tab is on — the conversation it belongs to.
+   *
+   * **A tab belongs to a conversation, and the bar shows one conversation's tabs.** A shell
+   * opened while reading one is *that* conversation's shell: it was started in its directory,
+   * about its work, and a bar that goes on showing it after you have switched is a bar about
+   * the terminal rather than about what you are doing. The tabs of the conversations you are
+   * not in are not closed, and nothing in them stops — they are off the strip until you go
+   * back, which is what makes leaving a build running and returning to it work.
+   *
+   * Opaque here and in the editor, which only ever asks whether two of them are equal: the host
+   * fills it with a [`crate::SessionId`], and a plugin that grouped its tabs by project would be
+   * using it exactly as intended. `None` is a group of its own — where a tab nobody has filed
+   * sits, and what every tab was before this existed.
+   */
+  group?: string | null;
 };

--- a/plugins/api/src/index.ts
+++ b/plugins/api/src/index.ts
@@ -662,21 +662,63 @@ export interface PaneApi {
   equalize(view?: ViewId): Promise<void>;
 }
 
-/** The tabs of one terminal. Each is a title and a tree of panes. */
+/**
+ * The tabs of one terminal. Each is a title, a tree of panes, and the conversation it belongs to.
+ *
+ * **A tab belongs to a conversation, and the bar shows one conversation's tabs** — that is
+ * {@link TabInfo.group}, and it is why a shell opened while reading one conversation is not still
+ * on the bar after you have switched to another. The tabs of the conversations you are not in are
+ * not closed and nothing in them stops; they are off the strip until you go back.
+ *
+ * Which splits these calls in two. {@link TabApi.list} answers with *every* tab of a terminal,
+ * whatever bar it is on, because "what is open here" is a real question — and {@link TabApi.step},
+ * {@link TabApi.move} and the numbers on the strip all count the tabs of one conversation, because
+ * a key about where you are looking must not change what you are working on.
+ */
 export interface TabApi {
-  /** Every tab of a terminal, its panes, and which one is on screen. */
+  /**
+   * Every tab of a terminal, its panes, and which one is on screen.
+   *
+   * All of them, including the ones on other conversations' bars: filter by {@link TabInfo.group}
+   * for what is drawn, which is the tabs sharing the active tab's group.
+   */
   list(view?: ViewId): Promise<{ tabs: TabInfo[]; active: TabId }>;
   /**
    * Open a tab with one empty pane. `activate` goes to it — `false` is for putting work somewhere
    * without moving the screen out from under whoever is reading it.
+   *
+   * On the bar you are looking at unless `group` says otherwise: a tab opened while reading a
+   * conversation is that conversation's, which is what a new tab almost always wants.
    */
-  create(opts?: { title?: string; activate?: boolean; view?: ViewId }): Promise<TabId>;
-  /** Close a tab and every pane in it. Rejects on a terminal's last tab. */
+  create(opts?: {
+    title?: string;
+    activate?: boolean;
+    view?: ViewId;
+    group?: string;
+  }): Promise<TabId>;
+  /**
+   * Move a tab to another conversation's bar, or to nobody's with `null`. See
+   * {@link TabInfo.group}.
+   *
+   * It keeps its panes, its windows and anything running in them — this says which bar it is on
+   * and nothing else, so moving the tab you are *in* changes which other tabs are beside it.
+   */
+  group(tab: TabId, group: string | null): Promise<void>;
+  /** Close a tab and every pane in it. Rejects on a conversation's last tab. */
   close(tab: TabId): Promise<void>;
   select(tab: TabId): Promise<void>;
-  /** Go `delta` tabs along, wrapping — a tab bar is a list you can see all of. */
+  /**
+   * Go `delta` tabs along, wrapping — a tab bar is a list you can see all of. Along *this
+   * conversation's* tabs: stepping into another one's would be a key that changes what you are
+   * working on.
+   */
   step(delta: number, view?: ViewId): Promise<void>;
-  /** Move a tab along the bar, clamped at the ends. This is a drag; a drag that teleports is a bug. */
+  /**
+   * Move a tab along the bar, clamped at the ends. This is a drag; a drag that teleports is a bug.
+   *
+   * `to` counts the tabs on the bar, which is the number printed on the strip — the tabs of other
+   * conversations sit between these and are not places a drag can land.
+   */
   move(tab: TabId, to: number): Promise<void>;
   /** Name a tab, or pass `null` to give it back its derived name. */
   rename(tab: TabId, title: string | null): Promise<void>;
@@ -2648,9 +2690,13 @@ function build(
             view: opts?.view,
             title: opts?.title,
             activate: opts?.activate ?? true,
+            group: opts?.group,
           }),
           "tab",
         ).tab;
+      },
+      async group(tab, group) {
+        await c({ call: "tab_group", tab, group });
       },
       async close(tab) {
         await c({ call: "tab_close", tab });


### PR DESCRIPTION
A shell opened while reading one conversation is *that* conversation's: it was started in its directory, about its work. Tabs were per terminal, so it stayed on the bar however far you switched away — four conversations in, every one of them drew the same three tabs and two of them were about none of it.

### The mechanism

`TabInfo::group` is the whole of it, and it is opaque to the editor, which only ever asks whether two of them are equal: the host fills it with a `SessionId`, and a plugin grouping its tabs by project would be using it exactly as intended. `None` is a group of its own, which is what every tab was before this existed.

**A tab is filed once and moves only when you switch.** `arrive_in` is the one place, guarded on the conversation actually changing — that is also the call `rehome` makes when the keyboard merely crosses a split, and a group re-derived from the active pane on every pass would change bars under `<C-w>l`. `settle_tab_groups` is the other half and only ever fills a group that is *absent*: the editor makes a terminal's first tab before anything knows which conversation it opens in, and a restored workspace puts one into a pane without ever arriving in it.

**Everything counted on the bar is counted in the visible tabs** — `<C-w>1`…`9`, `<C-w>n`, the drag (an insert that translates through the hidden tabs rather than a swap), and the last-one refusal, which is now a *conversation's* last tab because closing it would land you in another conversation's.

**Nothing is closed and nothing stops.** The tabs of the conversations you are not in are off the strip rather than gone, so a build left running in one is still running when you come back. Which is why *deleting* a conversation hands its tabs to wherever each terminal landed and archiving does not — a group nothing can ever show again is a pane, its windows and whatever is running in them, with no key on any keyboard that reaches it.

`ApiCall::TabGroup` and `group` on `TabNew` put the same mechanism in a plugin's hands, with `tab.group()` and `tab.create({ group })` in `@neosh/api`.

### On screen

Driven against the real binary with `scripts/shot.py`:

| | bar |
|---|---|
| shell tab open | `1 new  2 zsh` |
| switch to another conversation | `1 new` |
| switch back | `1 new  2 zsh  3 new` |

The third row is the rule working as designed: the tab you switch *in* comes with you, so returning to a conversation shows its own tabs plus the one you arrived on.

`<C-w>t` → "New conversation" therefore opens that conversation's *first* tab and the tabs you came from leave the bar. The panel row says so — `a fresh one here, with tabs of its own` — rather than letting you find out by watching the bar empty.

### Verification

- `cargo test -p neosh-core` — all green, including 8 new tests in `tests/tab_groups.rs`
- `cargo test -p neosh --test builtin_plugins` — 209 passed, 2 failed: `a_turn_runs_in_the_project_the_conversation_belongs_to` and `switching_conversations_moves_the_working_directory_too`, the known `/var` vs `/private/var` path compares that fail on this machine regardless of the change
- `TS_RS_EXPORT_DIR=… cargo test -p neosh-proto export_bindings` — 192 tests, generated files regenerated and committed
- `./scripts/check.sh web` — all checks passed