### PR TITLE
The tap credential is a deploy key, and a missing one is an error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,29 +175,32 @@ jobs:
     # does nothing on a repository that has the token. Job-level `env` *can* read secrets, and
     # `env` *is* available in `if:`, so this is the one spelling that behaves.
     env:
-      HAS_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
+      HAS_TAP_KEY: ${{ secrets.HOMEBREW_TAP_KEY != '' }}
     steps:
-      # Not a failure. The token is the one credential in this release that OIDC cannot replace —
-      # trusted publishing authenticates *to a registry*, and this is a git push to another
-      # repository — so a fork, or this repository before somebody creates it, must skip rather than
-      # go red for a reason nobody has done anything wrong about.
-      - name: Say so when the tap cannot be pushed
-        if: env.HAS_TAP_TOKEN != 'true'
+      # Not a failure *on a fork*, which has no business pushing to our tap. On this repository it
+      # is one: a release that quietly leaves Homebrew on the previous version is the exact failure
+      # this job exists to remove, and "skipped" and "shipped" must not look the same here.
+      - name: The tap key has to be there
+        if: env.HAS_TAP_KEY != 'true'
         run: |
-          echo "::warning::HOMEBREW_TAP_TOKEN is not set — the tap still points at the old version."
-          echo "Create a fine-grained PAT with Contents: read and write on neoswarm/homebrew-tap,"
-          echo "then: gh secret set HOMEBREW_TAP_TOKEN"
+          echo "HOMEBREW_TAP_KEY is not set."
+          echo "It is the private half of a write-enabled deploy key on neoswarm/homebrew-tap."
+          if [ "${{ github.repository }}" = "neoswarm/neosh" ]; then
+            echo "::error::the tap cannot be updated, so this release would leave brew on the old version"
+            exit 1
+          fi
+          echo "::warning::not neoswarm/neosh — skipping the tap update"
 
       - uses: actions/checkout@v4
-        if: env.HAS_TAP_TOKEN == 'true'
+        if: env.HAS_TAP_KEY == 'true'
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Point the tap at this release
-        if: env.HAS_TAP_TOKEN == 'true'
+        if: env.HAS_TAP_KEY == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAP_KEY: ${{ secrets.HOMEBREW_TAP_KEY }}
         run: |
           set -euo pipefail
           tag="${{ github.event.inputs.tag || github.ref_name }}"
@@ -220,8 +223,25 @@ jobs:
             exit 1
           fi
 
-          git clone --depth 1 \
-            "https://x-access-token:$TAP_TOKEN@github.com/neoswarm/homebrew-tap" tap
+          # A **deploy key** rather than a personal access token, and the difference is that this
+          # one does not expire. The organisation caps fine-grained tokens at 365 days, and an
+          # expired credential here would skip rather than fail — a release going green a year from
+          # now while Homebrew silently stopped updating. A deploy key has no lifetime, is scoped to
+          # this one repository rather than to everything a person can reach, and belongs to the
+          # repository rather than to whoever happened to create it.
+          #
+          # Written to disk rather than passed through `ssh-agent`: the runner is single-use, the
+          # file is `0600` under a directory only this job has, and an agent is one more process to
+          # get wrong for no benefit at this scale.
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$TAP_KEY" > ~/.ssh/tap
+          chmod 600 ~/.ssh/tap
+          # `IdentitiesOnly` so a runner that has any other key does not offer it first and get
+          # refused; `accept-new` because github.com's host key on a fresh runner is unknown, and
+          # this is a push to a name we control rather than an arbitrary host.
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/tap -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+
+          git clone --depth 1 git@github.com:neoswarm/homebrew-tap.git tap
           ./scripts/brew-formula.sh "$tag" > tap/Formula/neosh.rb
 
           cd tap

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -239,18 +239,41 @@ a second copy of each. Creating a release **by hand** still publishes, because t
 ### The one credential OIDC cannot replace
 
 Homebrew is a git push to `neoswarm/homebrew-tap`, not an upload to a registry, so there is nothing
-to exchange an OIDC identity for. It needs a fine-grained PAT with **Contents: read and write** on
-that repository, once:
+to exchange an OIDC identity for. It is a **deploy key** — an SSH key belonging to that repository,
+with write access to it and to nothing else — kept as `HOMEBREW_TAP_KEY`.
+
+A deploy key rather than a personal access token, and the reason is expiry. The organisation caps
+fine-grained tokens at 365 days, and a credential that lapses here fails *quietly*: the job would
+skip, the release would go green, and Homebrew would stop updating with nothing on screen saying so.
+A deploy key has no lifetime at all. It is also narrower — scoped to one repository rather than to
+everything the person who made it can reach — and it belongs to the repository rather than to
+whoever happened to create it, so it does not leave with them.
+
+Setting one up again, if it is ever lost:
 
 ```sh
-gh secret set HOMEBREW_TAP_TOKEN
+ssh-keygen -t ed25519 -N "" -C "neosh release → homebrew-tap" -f /tmp/tapkey
+gh api repos/neoswarm/homebrew-tap/keys -X POST \
+  -f title="neosh release (github actions)" -f key="$(cat /tmp/tapkey.pub)" -F read_only=false
+gh secret set HOMEBREW_TAP_KEY --repo neoswarm/neosh < /tmp/tapkey
+rm -f /tmp/tapkey /tmp/tapkey.pub
 ```
 
-Without it the `homebrew` job skips with a warning rather than failing — a fork has no business
-pushing to our tap — and the tap stays where it was, which `brew upgrade` reports as "already
-installed". Note that Homebrew caches its copy of a tap: after a release, `brew update` then
-`brew upgrade neosh`, and if it still claims the old version, `git -C "$(brew --repository
-neoswarm/tap)" pull` is the thing that was stale.
+Deploy keys are disabled organisation-wide by default, which the `POST` reports as
+`Deploy keys are disabled for this repository` — a message about the repository for a setting that
+is on the organisation. An owner turns it on once:
+
+```sh
+gh api -X PATCH orgs/neoswarm -F deploy_keys_enabled_for_repositories=true
+```
+
+**Missing on `neoswarm/neosh` is an error, not a skip.** A fork has no business pushing to our tap
+and skips with a warning; here, a release that leaves Homebrew on the previous version is the exact
+failure this job exists to remove, and "skipped" must not look like "shipped".
+
+Note that Homebrew caches its own clone of a tap: after a release, `brew update` then
+`brew upgrade neosh`, and if it still claims the old version is current,
+`git -C "$(brew --repository neoswarm/tap)" pull` is the thing that was stale.
 
 **A new crate or a new bundled plugin needs its own first manual publish and its own trusted
 publisher**, exactly as in steps 3–5. Nothing else does — and this is the one part of a release that


### PR DESCRIPTION
The Homebrew job asked for a personal access token. The organisation caps fine-grained tokens at **365 days**, and there is no "no expiration" option under an org lifetime policy — so the credential this release depends on was guaranteed to lapse, and lapse *quietly*: an expired token made the step **skip**, so the release would go green and Homebrew would silently stop updating. That is the exact failure the job was added to remove, deferred twelve months.

A deploy key has no lifetime at all.

## Why a deploy key is also the narrower choice

It is not a workaround for the expiry policy that costs security elsewhere — it is smaller than the token it replaces on every axis:

| | fine-grained PAT | deploy key |
|---|---|---|
| Scope | one repo, but *a person's* credential | one repo, and nothing else exists to widen it to |
| Expiry | 365 days, org-capped | none |
| Ownership | whoever created it — leaves when they do | the repository |
| Org approval | may sit pending | not applicable |

`HOMEBREW_TAP_KEY` is the private half; the public half is a write-enabled deploy key on `neoswarm/homebrew-tap`. The job writes it to `~/.ssh/tap` at `0600` on a single-use runner and clones over SSH. `IdentitiesOnly=yes` so a runner carrying any other key does not offer that one first and get refused.

## A missing credential is now an error

The skip existed for forks, which have no business pushing to our tap — so it is kept, and gated on `github.repository`. On `neoswarm/neosh` there is no reading of a missing tap key under which carrying on is right: a release that leaves `brew upgrade` on the previous version is a broken release, and "skipped" and "shipped" must not look the same in a workflow summary.

## Already done, outside this diff

- Deploy keys were disabled organisation-wide. The API reports that as `Deploy keys are disabled for this repository` — a message about the *repository* for a setting that lives on the *organisation*, which sends you to the wrong settings page. Enabled with `gh api -X PATCH orgs/neoswarm -F deploy_keys_enabled_for_repositories=true`, and written into `docs/releasing.md` so the next person does not have to work it out.
- The keypair is generated, the public half is on the tap (`read_only=false`), and the private half is stored as `HOMEBREW_TAP_KEY`. It went from file to GitHub via stdin and was never printed.

## Verified against the real tap, before merge rather than during a release

- clone over SSH with the key — works
- `brew-formula.sh v0.4.1` into the clone — generates
- the no-change path — correctly reports the tap is already current
- **a real push** on a throwaway branch, deleted immediately afterwards — because cloning proves the key is *readable* and says nothing about whether it can write, and "can it push" is the only question that matters here

The tap's branch list is back to `main` alone.

No version bump.
