### PR TITLE
fix(turns): what the agent said between turns is not yours to write over

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -762,7 +762,23 @@ is `docs/releasing.md`.
   a turn opened to hold an answer has no question above it. **A turn still ends on its own
   `result`** — `init` opens one and `result` closes one for their turns as much as ours, so a prompt
   queued behind one has two endings to wait for, and ending on the first is how a message that had
-  not been read yet came back as `{"type":"thinking","text":""}`.
+  not been read yet came back as `{"type":"thinking","text":""}`. **And the report has to outlive
+  the turn it interrupted, because it is raised by that turn ending.** The driver notices an
+  unasked turn precisely because *nothing is reading the pipe* — which is the moment the last turn
+  let go of it, strictly before that turn's `TurnEnded` reaches the host loop. So `hear_out` was
+  always called with the finished turn still in `turns`, declined on "a turn is already running",
+  and nothing ever mentioned it again: a driver reports a *new* `init`, and that one had been and
+  gone. What the agent said then sat in the pipe until the next message was sent, where
+  `drain_between_turns` drops it by design. From the keyboard that is the whole bug in one
+  sentence: a turn ends, you type, something is instantly running, and what the agent said in
+  between is gone under your message — or, when its turn was still going, streamed in *below* the
+  message as though it were the answer to it. `Host::unheard` holds the report and the ending that
+  was in the way spends it, **before** the leftover steering starts its turn: what the agent had
+  already begun saying came first, so it is heard first, and the message you typed meanwhile is
+  steered into that listening turn and asked at the end of it. The listening turn also says what it
+  is (`Reporting back`, not one of `VERBS`) and stops saying it the moment steering hands it a
+  question — a spinner claiming to be working on something you never asked is what made your own
+  message look like the thing that started it.
 - **A vendor CLI outlives the turn, so an abandoned turn has to be *drained*.** `Live::lines` is
   per conversation. A turn that is walked away from — `<Esc>`, a switch — leaves the CLI mid-answer
   with the rest of it in the pipe, and the next turn reads it as its own: someone else's reply, and

--- a/crates/neosh-provider/src/drivers/claude_cli.rs
+++ b/crates/neosh-provider/src/drivers/claude_cli.rs
@@ -2172,6 +2172,107 @@ done
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// And the report is raised *before* the turn it interrupted has ended.
+    ///
+    /// Which is the whole reason the workspace cannot act on it where it arrives. A turn's last act
+    /// is to ask how full the context is, and everything the CLI says while that answer is
+    /// outstanding is held for whatever comes next — so an unasked `init` landing there is never
+    /// read by the turn, the note stays up, and it is the turn *letting go of the pipe* that
+    /// reports it. That happens inside the stream's own task, ahead of the channel closing, which
+    /// is ahead of the ending the host is waiting for. Asserted with no polling loop on purpose:
+    /// `collect` cannot return until the stream is closed, so a count that is already 1 here is the
+    /// ordering itself, and a host that reads "is a turn running" at that moment always reads yes.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_turn_begun_while_the_last_one_was_winding_down_is_still_reported() {
+        use futures::StreamExt;
+        use std::os::unix::fs::PermissionsExt;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        #[derive(Debug, Default)]
+        struct Heard(AtomicUsize);
+        impl super::super::Unasked for Heard {
+            fn began(&self, _conversation: &SessionId) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+            fn background(&self, _conversation: &SessionId, _tasks: Vec<neosh_proto::BackgroundTask>) {}
+        }
+
+        let dir = std::env::temp_dir().join(format!("neosh-winding-down-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("dirs");
+        let script = dir.join("fake-claude");
+        // The turn is answered, and then — in the gap between it asking for one last number and
+        // being given it — the CLI opens a turn of its own. The rest of that turn arrives a moment
+        // later, so the listening turn has something to wait for rather than a pipe already empty.
+        std::fs::write(
+            &script,
+            r#"#!/bin/sh
+spoke=
+while IFS= read -r line; do
+  case "$line" in
+    *control_request*)
+      id=`printf '%s' "$line" | sed 's/.*"request_id":"\([^"]*\)".*/\1/'`
+      if [ -z "$spoke" ]; then
+        spoke=1
+        printf '{"type":"system","subtype":"init","session_id":"s","slash_commands":[]}\n'
+      fi
+      printf '{"type":"control_response","response":{"subtype":"success","request_id":"%s","response":{"totalTokens":10,"maxTokens":100}}}\n' "$id"
+      if [ "$spoke" = 1 ]; then
+        spoke=2
+        sleep 1
+        printf '{"type":"result","subtype":"success","is_error":false,"session_id":"s","result":"the background command finished"}\n'
+      fi
+      continue
+      ;;
+  esac
+  printf '{"type":"system","subtype":"init","session_id":"s","slash_commands":[]}\n'
+  printf '{"type":"result","subtype":"success","is_error":false,"session_id":"s","result":"answer"}\n'
+done
+"#,
+        )
+        .expect("script");
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+        let p = ClaudeCliProvider::new(script.display().to_string());
+        let heard = Arc::new(Heard::default());
+        crate::drivers::AgentDriver::set_unasked(&p, heard.clone());
+        let conversation = SessionId::from("test");
+        let said = |evs: Vec<ProviderEvent>| {
+            evs.into_iter()
+                .filter_map(|e| match e {
+                    ProviderEvent::TextDelta { text, .. } => Some(text),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join(" / ")
+        };
+
+        let first: Vec<_> =
+            p.stream(&inst(), req("claude-opus-5"), CancellationToken::new()).collect().await;
+        assert_eq!(said(first), "answer");
+        assert_eq!(
+            heard.0.load(Ordering::SeqCst),
+            1,
+            "the report is raised by the ending turn letting go, which is before its own ending"
+        );
+
+        // And what it was raised about is still there to be heard: held past the turn that could
+        // not use it, and read by the one opened for it.
+        crate::drivers::AgentDriver::listen_only(&p, &conversation);
+        let mut listening = req("claude-opus-5");
+        listening.messages.clear();
+        let heard_out: Vec<_> =
+            p.stream(&inst(), listening, CancellationToken::new()).collect().await;
+        assert_eq!(
+            said(heard_out),
+            "the background command finished",
+            "what the agent said between the turns is drawn, not drained away under the next one"
+        );
+
+        p.shutdown(&conversation);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// An empty directory means "wherever the host is", which is what a driver with no opinion did
     /// before the field existed — so a provider plugin written against the old shape still works.
     #[test]

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -992,6 +992,23 @@ pub struct Host {
     /// [`neosh_provider::drivers::Unasked`].
     unasked_rx: Option<tokio::sync::mpsc::UnboundedReceiver<Unheard>>,
     unasked_tx: tokio::sync::mpsc::UnboundedSender<Unheard>,
+    /// Conversations that reported one of those while the turn it interrupted was still winding
+    /// down, and which therefore still have to be heard out.
+    ///
+    /// The report cannot simply be acted on where it arrives. A driver notices an unasked turn
+    /// because *nothing is reading its pipe*, and the moment nothing is reading is the moment the
+    /// last turn let go — which is strictly **before** that turn's `TurnEnded` reaches this loop.
+    /// So [`Host::hear_out`] is always called with the finished turn still in [`Self::turns`], sees
+    /// a turn running, and declines; and because the driver only ever reports a *new* `init`,
+    /// nothing would ever mention it again. What the agent said next then sat in the pipe until the
+    /// next message was sent, where [`drain_between_turns`](neosh_provider) drops it by design —
+    /// the answer to a question that was never put. Which is what it looked like from the keyboard:
+    /// a turn ends, you type, something is instantly running, and whatever the agent said in
+    /// between is gone under your message.
+    ///
+    /// Held here instead and spent by the ending that was in the way, so the report survives the
+    /// gap rather than falling into it.
+    unheard: std::collections::HashSet<neosh_proto::SessionId>,
     /// Set by a turn ending, cleared by the poll that follows it. See [`crate::quota::AFTER_TURN`].
     quota_due: bool,
     /// Conversations that were blocked on an answer as of the last `question.asking`.
@@ -1277,6 +1294,21 @@ const VERBS: &[&str] = &[
     "Mulling", "Deliberating", "Reckoning", "Chewing", "Turning it over",
 ];
 
+/// What a turn opened to *hear* the agent out is doing. See [`Host::hear_out`].
+///
+/// Not one of [`VERBS`], and that is the point: those all describe the agent answering something
+/// you asked, and nobody asked this. It is also how the line is recognised when the turn stops
+/// being a report and starts being an answer — see the `Steered` arm.
+const REPORTING: &str = "Reporting back";
+
+/// One of [`VERBS`], per turn.
+///
+/// Not random: the turn id would be ideal but is not known yet, and a clock read is the one varying
+/// thing already to hand.
+fn a_verb() -> &'static str {
+    VERBS.get(now_secs().unsigned_abs() as usize % VERBS.len()).copied().unwrap_or("Working")
+}
+
 /// A key being typed in, and who is waiting to hear how it went.
 /// A search being typed in the transcript.
 ///
@@ -1443,6 +1475,7 @@ impl Host {
             quota_rx: Some(quota_rx),
             unasked_rx: Some(unasked_rx),
             unasked_tx,
+            unheard: std::collections::HashSet::new(),
             quota_due: false,
             asking: Vec::new(),
             permitting: Vec::new(),
@@ -2464,6 +2497,9 @@ impl Host {
                     t.cancel.cancel();
                 }
                 self.rounds.remove(&session);
+                // Nothing left to hear out: the transcript this would have been drawn into is about
+                // to be deleted, and the CLI holding it is closed a few lines below.
+                self.unheard.remove(&session);
                 self.driver_commands.remove(&session);
                 // A vendor CLI held open for this conversation has nothing left to answer. Left
                 // alone it would sit there for the rest of the program, holding a conversation
@@ -3367,14 +3403,9 @@ impl Host {
         let token = CancellationToken::new();
         self.turns
             .insert(session.clone(), Running { cancel: token.clone(), cancelling: false });
-        // Not random: the turn id would be ideal but is not known yet, and a clock read is the one
-        // varying thing already to hand. Per turn, so it does not change under you mid-answer.
-        let verb = VERBS
-            .get(now_secs().unsigned_abs() as usize % VERBS.len())
-            .copied()
-            .unwrap_or("Working");
         self.rounds.insert(session.clone(), Round {
-            verb,
+            // Per turn, so it does not change under you mid-answer.
+            verb: a_verb(),
             started: std::time::Instant::now(),
             note: None,
             note_is_wait: false,
@@ -9619,6 +9650,18 @@ impl Host {
                 // poll at zero reliably returns the figure from *before* the turn — which draws as
                 // a turn that cost nothing at all.
                 self.quota_due = true;
+                // The ending this conversation was waiting for. A turn nobody asked for that began
+                // while this one was winding down could not be opened then — see [`Self::unheard`]
+                // — and the gap it fell into ends exactly here.
+                //
+                // Before the leftover below, and that ordering is the whole of it: what the agent
+                // has already started saying came first, so it is heard first, and the message you
+                // typed in the meantime is steered into that listening turn and asked at the end of
+                // it. The other way round, your turn would drain what the agent said and drop it —
+                // your message written over the thing it was answering.
+                if self.unheard.remove(&session) {
+                    self.hear_out(session.clone());
+                }
                 if !leftover.is_empty() {
                     self.start_turn_in(session, Prompt {
                         text: leftover
@@ -9651,6 +9694,13 @@ impl Host {
                 self.persist_session(&session);
             }
             AgentEvent::Steered { session, prompt, .. } => {
+                // A turn opened to hear the agent out has just been handed a question, so it is not
+                // a report any more. Left alone, the line went on saying `Reporting back` over the
+                // answer to the thing you had typed — which is the same lie as the one that label
+                // exists to stop, told the other way round.
+                if let Some(r) = self.rounds.get_mut(&session).filter(|r| r.verb == REPORTING) {
+                    r.verb = a_verb();
+                }
                 // Drawn now rather than when it was typed: until the model has been told, a
                 // transcript showing the question is a transcript that is lying about what was
                 // asked. Off screen it needs no drawing at all — it is in the conversation's
@@ -10559,20 +10609,37 @@ impl Host {
     /// The turn says nothing: [`AgentDriver::listen_only`] is what tells the driver that, and it is
     /// set here rather than carried on the wire because it is true of exactly the turn about to
     /// start and of nothing else.
+    ///
+    /// A turn already running is *deferred*, never dropped. See [`Self::unheard`]: the report is
+    /// raised by the driver letting go of the pipe, which happens a moment before the ending that
+    /// frees this conversation gets here, so "a turn is running" is the ordinary case rather than
+    /// the exception — and a report dropped here is the only one that was ever going to be made.
     fn hear_out(&mut self, session: neosh_proto::SessionId) {
-        // A turn is already reading that pipe. Nothing to open, and opening one would put an empty
-        // message into a conversation that is mid-answer.
-        if self.turns.contains_key(&session) {
-            return;
-        }
-        // Gone since the driver said so — closed, or a workspace shutting down.
+        // Gone since the driver said so — closed, or a workspace shutting down. Asked first, so a
+        // conversation that is not there does not leave a note nothing will ever spend.
         if !self.agent.sessions().list().iter().any(|s| s.id == session) {
+            self.unheard.remove(&session);
             return;
         }
+        // A turn is already reading that pipe. Opening one here would put an empty message into a
+        // conversation that is mid-answer, so this waits for the ending that is in the way.
+        if self.turns.contains_key(&session) {
+            self.unheard.insert(session);
+            return;
+        }
+        self.unheard.remove(&session);
         for d in &self.agent_drivers {
             d.listen_only(&session);
         }
-        self.start_turn_in(session, neosh_agent::Prompt::default());
+        self.start_turn_in(session.clone(), neosh_agent::Prompt::default());
+        // Said for what it is. Every other turn on this line was started by something you did, and
+        // a spinner wearing "Pondering" over a report the agent volunteered is the workspace
+        // claiming a question you never asked — which, arriving in the second between reading an
+        // answer and typing the next thing, reads as your own message having started it.
+        if let Some(r) = self.rounds.get_mut(&session) {
+            r.verb = REPORTING;
+        }
+        self.each_view_showing(&session, |me| me.draw_working());
     }
 
     /// Emit one coalesced frame.


### PR DESCRIPTION
## The bug

A `claude` CLI outlives the turn, and a turn it starts for itself — a backgrounded command finishing, enqueued as a message to itself and answered — is reported (`Unasked::began`) so the workspace can open a turn to hear it out.

That report is raised by the **previous turn letting go of the pipe**, which is strictly before that turn's `TurnEnded` reaches the host loop. So `hear_out` was always called with the finished turn still in `self.turns`, took its `if self.turns.contains_key(&session) { return; }` branch, and dropped it — and since a driver only ever reports a *new* `init`, nothing would mention it again.

Not a rare race. A turn's last act is asking how full the context is, and everything the CLI says while that answer is outstanding is deliberately held rather than read (`claude_cli.rs:905`) — which is exactly where an unasked `init` lands, so the note the reader left is never cleared and the drop is the common case.

What that looks like from the keyboard, depending on whether the CLI's own turn had finished:

- **finished** — the content sat in the pipe until the next message, where `drain_between_turns` drops unasked content by design. Your message written over it.
- **still going** — your turn read the rest of it as its own (`owed = 2`), so it streamed in *below* the message you had just typed, as though it were the answer to it.

Either way the spinner appeared the instant you pressed Enter, because your message was steered into a turn that was already winding down rather than starting one of its own.

## The fix

- **`Host::unheard`** — the report is deferred, never dropped, and spent by the ending that was in the way. Placed in the `TurnEnded` arm **before** the leftover-steering turn starts: what the agent had already begun saying came first, so it is heard first, and the message you typed meanwhile is steered into that listening turn and asked at the end of it. Cleared when a conversation is deleted.
- **The listening turn says what it is** — `REPORTING` ("Reporting back"), not one of `VERBS` — and stops saying it the moment steering hands it a question. A spinner claiming to be working on something you never asked is what made your own message look like the thing that started it.
- `AGENTS.md` records the invariant under *An agent that speaks when nobody asked is still speaking to you*.

## Tests

New driver test `a_turn_begun_while_the_last_one_was_winding_down_is_still_reported` pins the ordering the fix rests on: with no polling loop, the sink is already told by the time the turn's stream closes, so a host reading "is a turn running" at that moment always reads yes. It documents the precondition; it does not itself guard the host-side change, which is not unit-testable without a fake `claude` on `PATH`.

- `cargo check -p neosh` — clean
- `cargo test -p neosh-provider --lib claude_cli` — 27 passed, including the new test
- `cargo test -p neosh-agent` — passed
- `cargo test -p neosh --test builtin_plugins` — **not run to completion locally**: the machine's root volume filled during the run, so its exit code cannot be attributed. Left to CI.