### PR TITLE
fix(update): you are not running what you installed, and something should say so

### DIFF
--- a/crates/neosh-proto/src/api.rs
+++ b/crates/neosh-proto/src/api.rs
@@ -1796,6 +1796,15 @@ pub enum ApiCall {
         /// Ask the network again rather than answering from the last check.
         #[serde(default)]
         force: bool,
+        /// Answer from what this machine already knows, and never reach the network.
+        ///
+        /// The two are not opposites and are never both set: `local` is checked first and wins.
+        /// It exists because half of an update status is not about a registry at all —
+        /// [`UpdateStatus::restart_pending`] is a `stat` of one file — and a caller that wants
+        /// only that half should not be the reason a workspace makes an HTTP request. Which is
+        /// what a panel polling for "has something replaced my binary" would otherwise be.
+        #[serde(default)]
+        local: bool,
     },
     /// Update, by whichever route [`UpdateCheck`](ApiCall::UpdateCheck) said this install takes.
     ///
@@ -2231,8 +2240,27 @@ pub struct UpdateStatus {
     /// Why the last check failed, when it did. Kept so the UI can say *unknown, and here is why*.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
-    /// Whether an update has been downloaded and is waiting for a restart.
+    /// Whether the binary on disk is not the one this process is running.
+    ///
+    /// Not "whether neosh downloaded something": most installs are updated by somebody else's
+    /// package manager, in another terminal, and the workspace goes on executing the inode it
+    /// started with — which is the whole failure this field exists to name. `brew upgrade neosh`
+    /// finishes, says so, and leaves a workspace running the old code with nothing on screen to
+    /// say why the thing you just installed is not there. So this is a `stat` of the running
+    /// executable against the stamp taken at startup, and it is true for a self-update, a
+    /// `brew upgrade`, an `npm install -g` and a re-run of `install.sh` alike.
+    ///
+    /// Never set when there is no binary left to restart onto: a promise of a restart that cannot
+    /// come back is worse than saying nothing.
     pub restart_pending: bool,
+    /// What is waiting on disk, when it could be read.
+    ///
+    /// Asked of the binary itself (`neosh --version`) rather than assumed to be
+    /// [`latest`](UpdateStatus::latest): somebody who ran `brew upgrade` got whatever Homebrew had,
+    /// which is not always the newest release, and a row naming the wrong number is a row that
+    /// teaches you not to read it. `None` means *something* changed and it would not say what.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub restart_version: Option<String>,
 }
 
 /// What [`ApiCall::UpdateApply`] did.

--- a/crates/neosh-proto/src/ui.rs
+++ b/crates/neosh-proto/src/ui.rs
@@ -1066,7 +1066,23 @@ pub enum UiEvent {
     /// `Flush`, not one per token.
     Flush,
 
-    Shutdown,
+    /// The workspace is going. Everything after this is a closed socket.
+    Shutdown {
+        /// Whether it is coming straight back, and this terminal should follow it.
+        ///
+        /// `neosh stop` and a restart are the same shutdown — conversations flushed, plugins torn
+        /// down — and they differ entirely in what the *terminal* should do next. Stopping is
+        /// somebody finishing; a restart is the second half of an update, and a terminal that
+        /// exits to the shell there has turned "finish updating" into "and now type `neosh`
+        /// again", which is the step nobody knows is owed. It cannot be worked out at the far end
+        /// either: from a closed socket, a workspace that stopped and a workspace that is
+        /// restarting look identical.
+        ///
+        /// `#[serde(default)]` so an older terminal reads it as an ordinary stop, which is the
+        /// behaviour it already has.
+        #[serde(default)]
+        restarting: bool,
+    },
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/neosh-tui/src/mirror.rs
+++ b/crates/neosh-tui/src/mirror.rs
@@ -270,7 +270,7 @@ impl Mirror {
                 self.dirty = true;
                 return true;
             }
-            UiEvent::Shutdown => {
+            UiEvent::Shutdown { .. } => {
                 self.shutdown = true;
                 return true;
             }

--- a/crates/neosh/src/build.rs
+++ b/crates/neosh/src/build.rs
@@ -30,9 +30,35 @@ static ID: OnceLock<BuildId> = OnceLock::new();
 /// renaming onto it is exactly what an update does.
 static EXE: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
 
-/// Where this process's executable was when it started.
+/// The path this process was invoked by, before symlinks were followed.
+///
+/// Kept *unresolved* on purpose, and it is the only thing that can answer "has this install been
+/// replaced". A managed install is a symlink into a versioned directory — `/opt/homebrew/bin/neosh`
+/// into `Cellar/neosh/0.4.1/bin/neosh` — and upgrading it does not touch a single byte of the file
+/// we are executing: it writes a new directory and repoints the link. Resolved at startup, as
+/// [`exe_path`] is, that swap is invisible, because the answer was frozen on the side of it we can
+/// no longer see.
+static LAUNCH: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
+
+/// Where this process's executable was when it started, with every symlink already followed.
 pub fn exe_path() -> Option<std::path::PathBuf> {
     EXE.get_or_init(|| std::env::current_exe().ok().and_then(|p| p.canonicalize().ok())).clone()
+}
+
+/// The path this process was invoked by, made absolute but *not* resolved.
+///
+/// Absolute because a relative `current_exe` is relative to the directory the process started in,
+/// which is not where it stays; unresolved because following the link is what this exists to avoid.
+pub fn launch_path() -> Option<std::path::PathBuf> {
+    LAUNCH
+        .get_or_init(|| {
+            let raw = std::env::current_exe().ok()?;
+            match raw.is_absolute() {
+                true => Some(raw),
+                false => std::env::current_dir().ok().map(|d| d.join(raw)),
+            }
+        })
+        .clone()
 }
 
 /// Read this process's build identity now, while its executable is still on disk.

--- a/crates/neosh/src/client.rs
+++ b/crates/neosh/src/client.rs
@@ -33,6 +33,8 @@ pub enum Ended {
     Detached(DetachReason),
     /// The workspace itself is gone.
     Stopped,
+    /// The workspace is gone and coming straight back, and this terminal is meant to follow it.
+    Restarting,
 }
 
 /// Connect to the workspace for these paths, starting one if there is none.
@@ -66,13 +68,78 @@ pub async fn connect_or_start(socket: &Path, args: &[String]) -> anyhow::Result<
     )
 }
 
+/// The `neosh` to run, which after an update is not the file this process was loaded from.
+///
+/// Three candidates, most specific first, and the ordering is the same one the updater's detection
+/// uses because it is answering the same question from the other side: the path we were invoked by
+/// still points somewhere after a package manager repoints its symlink, the resolved path is right
+/// for an install that is a plain file, and `PATH` is what is left when the directory we were in
+/// has been removed — which is what `brew upgrade` does to the keg it replaced.
+///
+/// `current_exe` last rather than first: resolved at startup and asked afterwards it is a path with
+/// `(deleted)` on the end, which nothing can exec, and that is precisely the state an update leaves
+/// it in.
+fn neosh_binary() -> anyhow::Result<PathBuf> {
+    if let Some(p) = crate::build::launch_path().filter(|p| p.is_file()) {
+        return Ok(p);
+    }
+    if let Some(p) = crate::update::which_neosh() {
+        return Ok(p);
+    }
+    Ok(std::env::current_exe()?)
+}
+
+/// Wait until nothing answers on the socket.
+///
+/// The gap between "the workspace said it was going" and "the workspace has gone" is real: it
+/// writes [`UiEvent::Shutdown`] and then unwinds. Reconnecting into that window attaches to a
+/// process that is already tearing down, which looks exactly like a workspace that would not
+/// start — so a restart would fail about one time in five, on the machine that had just been
+/// updated, with no sentence anywhere about why.
+pub async fn wait_gone(socket: &Path) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        if UnixStream::connect(socket).await.is_err() {
+            return;
+        }
+        tokio::time::sleep(SPAWN_POLL).await;
+    }
+}
+
+/// Become the new neosh, in this terminal, with the arguments this one was given.
+///
+/// An `exec` rather than starting a workspace and reattaching, and the difference is what the
+/// person ends up running. Reattaching leaves *this* process — the terminal, the thing drawing
+/// every frame — as the old build talking to the new one, which is the half-updated state the whole
+/// feature exists to get rid of, and which the workspace would then correctly complain about on
+/// attach. Replacing the process makes "update" mean one thing.
+///
+/// The terminal has already been restored by the time this runs ([`attach`] does it on the way out
+/// whatever happened), so what the screen does is what starting neosh always does. On success this
+/// never returns.
+#[cfg(unix)]
+pub fn relaunch(args: &[String]) -> anyhow::Error {
+    use std::os::unix::process::CommandExt;
+    let exe = match neosh_binary() {
+        Ok(e) => e,
+        Err(e) => return anyhow::anyhow!("{e}"),
+    };
+    // `exec` only returns on failure, which is the one path out of here.
+    anyhow::anyhow!("{}", std::process::Command::new(&exe).args(args).exec())
+}
+
+#[cfg(not(unix))]
+pub fn relaunch(_args: &[String]) -> anyhow::Error {
+    anyhow::anyhow!("run `neosh` again to finish")
+}
+
 /// Start a workspace in the background, detached from this terminal.
 ///
 /// Detached is the point: it must survive the shell that started it, the terminal that shell is
 /// in, and the ssh session that terminal is in. Its own session (`setsid`) is what stops a
 /// `SIGHUP` on the way out from taking the workspace with it.
 fn start(args: &[String]) -> anyhow::Result<()> {
-    let exe = std::env::current_exe()?;
+    let exe = neosh_binary()?;
     let mut cmd = std::process::Command::new(exe);
     cmd.arg("--serve")
         .args(args)
@@ -232,12 +299,18 @@ async fn run(
                 };
                 match serde_json::from_str::<ServerMessage>(&l) {
                     Ok(ServerMessage::Events { batch }) => {
-                        let leaving = batch.iter().any(|e| matches!(e, UiEvent::Shutdown));
+                        let leaving = batch.iter().find_map(|e| match e {
+                            UiEvent::Shutdown { restarting } => Some(*restarting),
+                            _ => None,
+                        });
                         // Untagged on the way in: the workspace already decided this batch was
                         // for us, and what arrives here is one terminal's share of a frame.
                         ui.send(batch.into_iter().map(|e| (None, e)).collect()).await?;
-                        if leaving {
-                            return Ok(Ended::Stopped);
+                        if let Some(restarting) = leaving {
+                            return Ok(match restarting {
+                                true => Ended::Restarting,
+                                false => Ended::Stopped,
+                            });
                         }
                     }
                     Ok(ServerMessage::Detached { reason }) => return Ok(Ended::Detached(reason)),
@@ -311,6 +384,23 @@ fn stale(workspace: &BuildId, terminal: &BuildId) -> Option<String> {
     }
     let (t, w) = (&terminal.version, &workspace.version);
     Some(format!("terminal is neosh {t}, workspace is neosh {w}"))
+}
+
+/// The arguments a *terminal* we replace ourselves with should be given.
+///
+/// The workspace's arguments plus nothing, which is the point: not `args_os()`, because the one
+/// thing on that command line that must not be repeated is the prompt. `neosh "why is this slow"`
+/// starts a conversation and says that in it, and a relaunch carrying it forward would ask the
+/// question a second time, in a second conversation, on the far side of an update nobody connected
+/// it to.
+pub fn terminal_args(
+    config_dir: &Option<PathBuf>,
+    cwd: &Path,
+    model: &Option<String>,
+    plugin_dirs: &[PathBuf],
+    mock_script: &Option<PathBuf>,
+) -> Vec<String> {
+    workspace_args(config_dir, cwd, model, plugin_dirs, mock_script)
 }
 
 /// The arguments a workspace we start should be given.

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -870,6 +870,12 @@ pub struct Host {
     /// Set by the `stop` command — and by `quit`, when this host *is* the process; the run loop
     /// notices and shuts down cleanly.
     quitting: bool,
+    /// Whether this shutdown is the second half of an update rather than somebody finishing.
+    ///
+    /// The same shutdown either way — conversations flushed, plugins torn down — and a completely
+    /// different thing for the *terminal* to do next. It rides out on [`UiEvent::Shutdown`],
+    /// because the far end cannot work it out: a closed socket is a closed socket.
+    restarting: bool,
     /// What `quit` means for this host.
     ///
     /// Two different things, and they used to be the same thing because there was only ever one
@@ -1428,6 +1434,7 @@ impl Host {
             keys_touched: false,
             startup: Startup::default(),
             quitting: false,
+            restarting: false,
             on_quit: OnQuit::Stop,
             detaching: None,
             from: crate::clients::Source::LOCAL,
@@ -1462,6 +1469,7 @@ impl Host {
             // loaded from, so `current_exe` asked later is a path with `(deleted)` on the end.
             updater: crate::update::Updater::new(
                 crate::build::exe_path().unwrap_or_default(),
+                crate::build::launch_path(),
                 crate::build::capture().version.clone(),
             ),
             vars: crate::vars::Vars::new(None),
@@ -2072,7 +2080,13 @@ impl Host {
                 // conversations flushed, plugins torn down. Restarting *in place* is not this
                 // process's to do: it is the terminal that runs `neosh`, and `neosh` starts a
                 // workspace when there is none, which by then is the new binary.
+                //
+                // Which is why the terminals have to be *told* it was a restart. From a closed
+                // socket a workspace that stopped and one that is coming straight back look
+                // identical, and a terminal that guesses wrong either exits out of an update
+                // half-finished or refuses to let go of a `neosh stop`.
                 self.quitting = true;
+                self.restarting = true;
                 Ok(ApiOk::Unit)
             }
             // ---- plugin state ------------------------------------------
@@ -11274,7 +11288,7 @@ impl Host {
         // needs telling about.
         self.deliver_alerts_now().await?;
         self.flush().await?;
-        self.frontend.send(vec![(None, UiEvent::Shutdown)]).await?;
+        self.frontend.send(vec![(None, UiEvent::Shutdown { restarting: self.restarting })]).await?;
         self.frontend.shutdown().await?;
         Ok(())
     }
@@ -14232,8 +14246,8 @@ enum Unheard {
 async fn run_slow(svc: Services, call: ApiCall) -> ApiResult {
     match call {
         ApiCall::PathComplete { prefix } => svc.path_complete(prefix).await,
-        ApiCall::UpdateCheck { force } => {
-            Ok(ApiOk::Update { update: svc.updater.check(force).await })
+        ApiCall::UpdateCheck { force, local } => {
+            Ok(ApiOk::Update { update: svc.updater.check(force, local).await })
         }
         ApiCall::UpdateApply => {
             Ok(ApiOk::UpdateApplied { outcome: svc.updater.apply().await })

--- a/crates/neosh/src/main.rs
+++ b/crates/neosh/src/main.rs
@@ -640,6 +640,24 @@ async fn run_client(cli: &Cli, paths: &Paths, cwd: &std::path::Path) -> anyhow::
         }
         client::Ended::Detached(neosh_proto::DetachReason::Stopping)
         | client::Ended::Stopped => {}
+        // The second half of an update. The workspace has gone so the new binary can serve, and
+        // this process is the old one — so it stands aside for the new one too, with the arguments
+        // it was given, in the terminal it is already in. Anything else leaves somebody looking at
+        // a shell prompt with a job half done and nothing saying what the other half is.
+        client::Ended::Restarting => {
+            client::wait_gone(&socket).await;
+            let again = client::terminal_args(
+                &cli.config_dir,
+                cwd,
+                &cli.model,
+                &cli.plugin_dirs,
+                &cli.mock_script,
+            );
+            // Only ever reached when `exec` failed, which is a `neosh` that has moved out from
+            // under us. The update itself is done and the sentence has to say so, or the fix looks
+            // bigger than typing one word.
+            say!("neosh: updated. Run `neosh` again to pick it up ({}).", client::relaunch(&again));
+        }
     }
     Ok(())
 }

--- a/crates/neosh/src/update.rs
+++ b/crates/neosh/src/update.rs
@@ -12,6 +12,16 @@
 //! network, it can hang, and nothing on screen should wait for it. What it produces is kept, so
 //! the answer to "is there an update" is instant and the *checking* is what happens in the
 //! background.
+//!
+//! And there is a third question underneath both, which is the one people actually get stuck on:
+//! *is the binary on disk the binary I am running*. It is not the same as either. Most installs
+//! are managed, so most updates happen in another terminal — `brew upgrade neosh` finishes, says
+//! it succeeded, and the workspace goes on executing the inode it started with. Nothing had
+//! noticed and nothing said so, so the version you had just installed was not the version you were
+//! using, for as long as that workspace lived. It is answered by a `stat` rather than by a
+//! registry: the executable is stamped at startup and compared afterwards, which is true for a
+//! `brew upgrade`, an `npm install -g`, a `cargo install --force`, a re-run of `install.sh` and
+//! our own rename alike — and needs nothing from the network, so it is still true on a train.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -25,9 +35,20 @@ use tokio::sync::RwLock;
 const LATEST: &str = "https://api.github.com/repos/neoswarm/neosh/releases/latest";
 const DOWNLOAD: &str = "https://github.com/neoswarm/neosh/releases/download";
 
-/// How long a check is good for. A day: the thing being watched changes on the order of weeks, and
-/// a workspace can run for months.
-const FRESH_FOR: Duration = Duration::from_secs(60 * 60 * 24);
+/// How long a check is good for.
+///
+/// Six hours rather than the day it was. The number is a floor on how long a machine can be wrong
+/// about the world, and a workspace here runs for weeks — so a day meant a release could be out
+/// for most of a working day with the panel saying nothing. Four unauthenticated requests a day
+/// against a rate limit of sixty an hour is not a cost worth defending.
+const FRESH_FOR: Duration = Duration::from_secs(60 * 60 * 6);
+
+/// How long to give the binary on disk to say what version it is.
+///
+/// It is `--version` on a binary we shipped, so it prints and exits — but it is still an exec of a
+/// file somebody else just wrote, and a workspace must not be able to sit on one. The answer is
+/// decoration on a row that is already correct without it.
+const VERSION_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// The Rust target triple this binary was built for, which is what names the release asset.
 ///
@@ -94,14 +115,54 @@ fn is_newer(latest: &str, current: &str) -> bool {
     }
 }
 
+/// Enough of a file to tell it from the one that replaced it.
+///
+/// The inode is what carries this: every way neosh is actually updated ends in a rename or a fresh
+/// directory, so the number changes even when a package manager has preserved the modification
+/// time. Length and mtime are belt and braces for a filesystem with no meaningful inodes.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+struct Stamp {
+    len: u64,
+    mtime: u64,
+    #[cfg(unix)]
+    ino: u64,
+}
+
+impl Stamp {
+    fn of(path: &Path) -> Option<Self> {
+        let m = std::fs::metadata(path).ok()?;
+        if !m.is_file() {
+            return None;
+        }
+        Some(Self {
+            len: m.len(),
+            mtime: m
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+            #[cfg(unix)]
+            ino: {
+                use std::os::unix::fs::MetadataExt;
+                m.ino()
+            },
+        })
+    }
+}
+
 /// The last answer, and when it was given.
 #[derive(Default)]
 struct Cached {
     status: Option<UpdateStatus>,
     at: Option<SystemTime>,
-    /// Set once a new binary is on disk, so the UI keeps saying "restart" rather than "update"
-    /// after the download has already happened.
-    restart_pending: bool,
+    /// The version *we* put on disk, if we have. Not the whole of `restart_pending` — most
+    /// installs are replaced by somebody else's package manager and never come through here — but
+    /// still worth keeping, because it is the one case where we know without looking.
+    staged: Option<String>,
+    /// The version found on disk once a replacement was noticed, so `neosh --version` is exec'd
+    /// once rather than on every redraw of a panel.
+    found: Option<Option<String>>,
 }
 
 /// The update checker. One per workspace.
@@ -109,22 +170,150 @@ struct Cached {
 pub struct Updater {
     inner: Arc<RwLock<Cached>>,
     exe: PathBuf,
+    /// The unresolved path this process was started from — see [`crate::build::launch_path`].
+    launch: Option<PathBuf>,
     current: String,
+    /// What the executable looked like at startup. `None` when it could not be stat'd at all, in
+    /// which case nothing here claims anything: an unknown stamp compares equal to everything, and
+    /// the failure of guessing is a workspace that offers a restart on every redraw.
+    stamp: Option<Stamp>,
 }
 
 impl Updater {
-    /// `exe` and `version` come from [`crate::build::capture`] — read at startup, because a
+    /// `exe`, `launch` and `version` all come from [`crate::build`] — read at startup, because a
     /// workspace outlives the file it was loaded from and `current_exe` goes stale.
-    pub fn new(exe: PathBuf, current: String) -> Self {
-        Self { inner: Arc::new(RwLock::new(Cached::default())), exe, current }
+    ///
+    /// Both paths are passed in rather than one of them being fetched here, because they are two
+    /// different facts — [`crate::build::exe_path`] has followed the symlinks and
+    /// [`crate::build::launch_path`] deliberately has not — and a constructor that reached for a
+    /// process-wide one behind the caller's back would be a type nothing could test without being
+    /// the neosh binary.
+    pub fn new(exe: PathBuf, launch: Option<PathBuf>, current: String) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(Cached::default())),
+            stamp: Stamp::of(&exe),
+            launch,
+            exe,
+            current,
+        }
     }
 
     fn method(&self) -> InstallMethod {
         install_method(&self.exe)
     }
 
+    /// The binary that `neosh` would run *now*, and how it differs from the one running.
+    ///
+    /// Three candidates in order, and the order is the whole of it:
+    ///
+    /// 1. **The launch path, resolved afresh.** A managed install is a symlink into a versioned
+    ///    directory, and upgrading it repoints the link without touching the file we are executing.
+    ///    Following the link at startup and remembering the answer is exactly how that swap becomes
+    ///    invisible.
+    /// 2. **The resolved path from startup.** An install that is a real file — `install.sh`,
+    ///    `cargo install`, our own rename — is overwritten in place, and this is where.
+    /// 3. **`neosh` on `PATH`.** The case the first two miss: Homebrew removes the old keg, so on
+    ///    Linux, where `/proc/self/exe` is already fully resolved and there is no link left to
+    ///    follow, both paths are simply gone. What would run then is whatever the shell finds,
+    ///    which is also what the terminal is about to exec.
+    ///
+    /// `None` when nothing runnable can be found, and that is deliberate: a restart we cannot
+    /// finish is worse than no offer at all — it takes a working workspace away and does not bring
+    /// one back.
+    fn on_disk(&self) -> Option<(PathBuf, Stamp)> {
+        let candidates = self
+            .launch
+            .iter()
+            .cloned()
+            .chain(std::iter::once(self.exe.clone()))
+            .chain(which_neosh());
+        for p in candidates {
+            if let Ok(real) = p.canonicalize()
+                && let Some(s) = Stamp::of(&real)
+            {
+                return Some((real, s));
+            }
+        }
+        None
+    }
+
+    /// Whether the binary on disk is not the one this process is running, and where it is.
+    fn replaced(&self) -> Option<PathBuf> {
+        // A checkout is excluded here rather than at the row that draws it, because in one the
+        // answer is *yes, constantly*: `cargo run` unlinks `target/debug/neosh` and writes another
+        // one every build. It is not that the fact is uninteresting there — it is the single most
+        // interesting fact in a checkout — it is that it already has an answer, said by the
+        // terminal on attach out of `BuildId`, and which names `neosh stop`. Two notices about one
+        // thing is one notice nobody reads.
+        if self.method() == InstallMethod::Development {
+            return None;
+        }
+        let (path, now) = self.on_disk()?;
+        match (self.stamp, now) {
+            (Some(then), now) if then != now => Some(path),
+            _ => None,
+        }
+    }
+
+    /// Fill in the half of a status that is about this machine rather than about a registry.
+    ///
+    /// Applied on the way out of every answer, including a cached one — the network half is good
+    /// for hours and this half can change between two redraws, so serving them from one timestamp
+    /// is how a workspace goes on saying "up to date" for a day after being upgraded under it.
+    async fn with_local(&self, mut status: UpdateStatus) -> UpdateStatus {
+        let staged = self.inner.read().await.staged.clone();
+        match self.replaced() {
+            Some(path) => {
+                status.restart_pending = true;
+                status.restart_version = self.version_on_disk(&path).await.or(staged);
+            }
+            // Nothing on disk differs from what started. Our own download is not taken on trust
+            // against that: if we wrote a file and the stamp still matches, whatever we wrote is
+            // not there any more and a restart would come back to the very binary it left. The one
+            // exception is having had no stamp to begin with, where there is nothing to compare and
+            // our own word is the only evidence there is.
+            None => {
+                status.restart_pending = staged.is_some() && self.stamp.is_none();
+                status.restart_version = status.restart_pending.then_some(staged).flatten();
+            }
+        }
+        status
+    }
+
+    /// Ask the binary that is waiting what it calls itself, once.
+    ///
+    /// Asked of the file rather than assumed to be [`UpdateStatus::latest`]: somebody who ran
+    /// `brew upgrade` got whatever their tap had, which is not always the newest release, and a row
+    /// naming a version that is not the one about to start is a row that teaches you not to read
+    /// it. A failure is `None` and the row says "restart" without a number, which is still the one
+    /// thing there is to do.
+    async fn version_on_disk(&self, path: &Path) -> Option<String> {
+        if let Some(found) = &self.inner.read().await.found {
+            return found.clone();
+        }
+        let out = tokio::time::timeout(
+            VERSION_TIMEOUT,
+            tokio::process::Command::new(path)
+                .arg("--version")
+                .stdin(std::process::Stdio::null())
+                .output(),
+        )
+        .await;
+        let found = match out {
+            Ok(Ok(o)) if o.status.success() => String::from_utf8_lossy(&o.stdout)
+                .lines()
+                .next()
+                .and_then(|l| l.split_whitespace().last())
+                .map(|v| v.trim_start_matches('v').to_string())
+                .filter(|v| !v.is_empty()),
+            _ => None,
+        };
+        self.inner.write().await.found = Some(found.clone());
+        found
+    }
+
     /// A status with no network in it, for the shape of the answer before any check has run.
-    fn blank(&self, restart_pending: bool) -> UpdateStatus {
+    fn blank(&self) -> UpdateStatus {
         let method = self.method();
         UpdateStatus {
             current: self.current.clone(),
@@ -134,29 +323,36 @@ impl Updater {
             self_updatable: method.self_updatable(),
             upgrade_command: method.upgrade_command().map(str::to_string),
             error: None,
-            restart_pending,
+            restart_pending: false,
+            restart_version: None,
         }
     }
 
     /// What is known now, checking the network only if the last answer has gone stale or `force`.
-    pub async fn check(&self, force: bool) -> UpdateStatus {
+    ///
+    /// `local` never touches the network at all, which is what makes "has something replaced my
+    /// binary" answerable on a tick: it is a `stat`, and a panel asking it should not be the reason
+    /// a workspace makes an HTTP request.
+    pub async fn check(&self, force: bool, local: bool) -> UpdateStatus {
         {
             let c = self.inner.read().await;
             let fresh = c
                 .at
                 .and_then(|t| SystemTime::now().duration_since(t).ok())
                 .is_some_and(|age| age < FRESH_FOR);
-            if !force && fresh && let Some(s) = &c.status {
-                return s.clone();
+            if local || (!force && fresh) {
+                let known = c.status.clone();
+                drop(c);
+                return self.with_local(known.unwrap_or_else(|| self.blank())).await;
             }
         }
 
-        let mut status = self.blank(self.inner.read().await.restart_pending);
+        let mut status = self.blank();
 
         // A checkout is never told to update. Nothing published is newer than what is about to be
         // compiled, and a notice about it would fire on every developer's every start.
         if status.method == InstallMethod::Development {
-            return status;
+            return self.with_local(status).await;
         }
 
         match fetch_latest().await {
@@ -169,17 +365,29 @@ impl Updater {
             Err(e) => status.error = Some(e),
         }
 
-        let mut c = self.inner.write().await;
-        c.status = Some(status.clone());
-        c.at = Some(SystemTime::now());
-        status
+        {
+            let mut c = self.inner.write().await;
+            c.status = Some(status.clone());
+            c.at = Some(SystemTime::now());
+        }
+        self.with_local(status).await
     }
 
     /// Update, by whichever route this install takes.
     pub async fn apply(&self) -> UpdateOutcome {
-        let status = self.check(true).await;
+        let status = self.check(true, false).await;
         let method = status.method;
 
+        // Finish what is already half done before starting anything new. A binary already waiting
+        // on disk — ours, or one `brew upgrade` put there — is not a workspace that needs another
+        // download, and saying so here rather than only in the plugin means every caller of the API
+        // gets it, including `neosh agent run update`.
+        if status.restart_pending {
+            return UpdateOutcome::Applied {
+                version: status.restart_version.unwrap_or_else(|| self.current.clone()),
+                restart_required: true,
+            };
+        }
         if let Some(err) = status.error {
             return UpdateOutcome::Failed { reason: format!("could not check for updates: {err}") };
         }
@@ -206,7 +414,13 @@ impl Updater {
 
         match self.replace_binary(&latest).await {
             Ok(()) => {
-                self.inner.write().await.restart_pending = true;
+                let mut c = self.inner.write().await;
+                c.staged = Some(latest.clone());
+                // The file changed under us, so anything read off the old one is not about the new
+                // one. Cleared rather than left, or a second update in one workspace's life reports
+                // the version of the first.
+                c.found = None;
+                drop(c);
                 UpdateOutcome::Applied { version: latest, restart_required: true }
             }
             Err(reason) => UpdateOutcome::Failed { reason },
@@ -250,6 +464,34 @@ impl Updater {
             format!("replacing {}: {e}", self.exe.display())
         })
     }
+}
+
+/// `neosh` as the shell would find it, or nothing.
+///
+/// The last resort in [`Updater::on_disk`], and it exists for one shape: Homebrew removes the old
+/// keg on upgrade, so on a platform where the launch path is already fully resolved there is no
+/// link left to follow and no file left to stat — both of the specific answers are gone, and the
+/// only remaining true statement about what would run is "whatever is on `PATH`", which is also
+/// exactly what the terminal is about to exec.
+///
+/// Walked by hand rather than through a crate: it is one `split` and an `is_file`, and a
+/// dependency for that is a dependency to keep updated.
+pub fn which_neosh() -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|d| d.join("neosh"))
+        .find(|p| p.is_file() && is_executable(p))
+}
+
+#[cfg(unix)]
+fn is_executable(p: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(p).is_ok_and(|m| m.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(not(unix))]
+fn is_executable(_p: &Path) -> bool {
+    true
 }
 
 async fn fetch_latest() -> Result<String, String> {
@@ -406,6 +648,140 @@ mod tests {
         assert!(!is_newer("0.2.0-rc.1", "0.1.0"));
         assert!(!is_newer("nightly", "0.1.0"));
         assert!(!is_newer("0.2.0", "some-git-build"));
+    }
+
+    /// A scratch directory of this test's own, with a fake `neosh` in it.
+    fn sandbox(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("neosh-update-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("bin")).expect("a scratch directory");
+        dir
+    }
+
+    /// Write `body` at `path`, executable, the way an installer would.
+    fn install(path: &Path, body: &str) {
+        if let Some(p) = path.parent() {
+            std::fs::create_dir_all(p).expect("a directory to install into");
+        }
+        std::fs::write(path, body).expect("a binary");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).expect("+x");
+        }
+    }
+
+    fn updater(exe: &Path, launch: &Path) -> Updater {
+        Updater::new(
+            exe.canonicalize().expect("a real path"),
+            Some(launch.to_path_buf()),
+            "0.4.1".into(),
+        )
+    }
+
+    /// The case the whole feature exists for: `brew upgrade` in the next terminal along.
+    ///
+    /// Homebrew never touches the file we are executing. It writes a new keg and repoints
+    /// `bin/neosh` at it — so a workspace that resolved the symlink at startup and remembered the
+    /// answer sees nothing at all, which is exactly what used to happen and why a machine ran the
+    /// old build for days after being told it had been updated.
+    #[test]
+    #[cfg(unix)]
+    fn a_repointed_symlink_is_a_binary_that_was_replaced() {
+        let dir = sandbox("brew");
+        let old = dir.join("Cellar/neosh/0.4.1/bin/neosh");
+        let new = dir.join("Cellar/neosh/0.4.2/bin/neosh");
+        let link = dir.join("bin/neosh");
+        install(&old, "i am 0.4.1");
+        std::os::unix::fs::symlink(&old, &link).expect("a link into the keg");
+
+        // Started as `bin/neosh`, which is what a shell on `PATH` does.
+        let u = updater(&link, &link);
+        assert!(u.replaced().is_none(), "nothing has happened yet");
+
+        // `brew upgrade`: a new keg, the link moved, and the old keg removed on cleanup.
+        install(&new, "i am 0.4.2 and longer");
+        std::fs::remove_file(&link).expect("the old link");
+        std::os::unix::fs::symlink(&new, &link).expect("the new link");
+        std::fs::remove_dir_all(dir.join("Cellar/neosh/0.4.1")).expect("brew cleanup");
+
+        assert_eq!(
+            u.replaced(),
+            Some(new.canonicalize().expect("the new keg")),
+            "following the link afresh is the only way to see this"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An install that is a plain file — `install.sh`, `cargo install`, our own rename.
+    #[test]
+    fn a_file_overwritten_in_place_is_a_binary_that_was_replaced() {
+        let dir = sandbox("inplace");
+        let exe = dir.join("bin/neosh");
+        install(&exe, "i am 0.4.1");
+
+        let u = updater(&exe, &exe);
+        assert!(u.replaced().is_none());
+
+        // Written beside and renamed on, which is what every safe replacement does — and what
+        // changes the inode even when a package manager has preserved the modification time.
+        let staged = dir.join("bin/.neosh-new");
+        install(&staged, "i am 0.4.2 and a different length");
+        std::fs::rename(&staged, &exe).expect("the swap");
+
+        assert_eq!(u.replaced(), Some(exe.canonicalize().expect("the new file")));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A restart is a promise to come back, and one that cannot be kept is worse than silence.
+    ///
+    /// With every candidate gone there is no binary to restart onto: saying "restart for the
+    /// update" would take a working workspace away and put nothing in its place.
+    #[test]
+    fn nothing_left_to_run_is_never_a_restart_worth_offering() {
+        let dir = sandbox("gone");
+        let exe = dir.join("bin/neosh");
+        install(&exe, "i am 0.4.1");
+        let u = updater(&exe, &exe);
+
+        std::fs::remove_file(&exe).expect("an uninstall");
+        // `which_neosh` may still find a real neosh on this machine's PATH, which would be a
+        // truthful answer. What must never happen is a claim with nothing behind it.
+        if let Some(found) = u.replaced() {
+            assert!(found.is_file(), "offered a restart onto {found:?}, which is not there");
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A checkout is the one place where "the binary changed" is true on nearly every build, and
+    /// it already has an answer — the terminal says it on attach, out of `BuildId`, and names
+    /// `neosh stop`. Two notices about one thing is one notice nobody reads.
+    #[test]
+    fn a_checkout_is_never_told_to_restart() {
+        let dir = sandbox("checkout");
+        let exe = dir.join("target/debug/neosh");
+        install(&exe, "a build");
+        let u = updater(&exe, &exe);
+        install(&exe, "a rebuild, longer than the last one");
+
+        assert_eq!(u.method(), InstallMethod::Development);
+        assert!(u.replaced().is_none(), "the BuildId notice already covers a checkout");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An unknown stamp compares equal to everything rather than to nothing.
+    ///
+    /// The failure of guessing here is a workspace that offers a restart on every redraw, forever,
+    /// having never seen the file it is talking about.
+    #[test]
+    fn an_executable_that_could_not_be_stat_d_claims_nothing() {
+        let dir = sandbox("nostat");
+        let exe = dir.join("bin/neosh");
+        // Never created. `Updater::new` finds no stamp, and nothing may be inferred from that.
+        let u = Updater::new(exe.clone(), Some(exe), "0.4.1".into());
+        assert!(u.stamp.is_none());
+        assert!(u.replaced().is_none());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/neosh/tests/workspace.rs
+++ b/crates/neosh/tests/workspace.rs
@@ -290,7 +290,7 @@ impl Client {
             match serde_json::from_str::<ServerMessage>(&line) {
                 Ok(ServerMessage::Events { batch }) => {
                     for ev in batch {
-                        if matches!(ev, UiEvent::Shutdown) {
+                        if matches!(ev, UiEvent::Shutdown { .. }) {
                             self.stopped = true;
                         }
                         self.mirror.apply(ev);

--- a/plugins/api/src/generated/ApiCall.ts
+++ b/plugins/api/src/generated/ApiCall.ts
@@ -650,6 +650,16 @@ export type ApiCall =
      * Ask the network again rather than answering from the last check.
      */
     force: boolean;
+    /**
+     * Answer from what this machine already knows, and never reach the network.
+     *
+     * The two are not opposites and are never both set: `local` is checked first and wins.
+     * It exists because half of an update status is not about a registry at all —
+     * [`UpdateStatus::restart_pending`] is a `stat` of one file — and a caller that wants
+     * only that half should not be the reason a workspace makes an HTTP request. Which is
+     * what a panel polling for "has something replaced my binary" would otherwise be.
+     */
+    local: boolean;
   }
   | { "call": "update_apply" }
   | {

--- a/plugins/api/src/generated/UiEvent.ts
+++ b/plugins/api/src/generated/UiEvent.ts
@@ -81,4 +81,21 @@ export type UiEvent =
   }
   | { "type": "clipboard"; text: string }
   | { "type": "flush" }
-  | { "type": "shutdown" };
+  | {
+    "type": "shutdown";
+    /**
+     * Whether it is coming straight back, and this terminal should follow it.
+     *
+     * `neosh stop` and a restart are the same shutdown — conversations flushed, plugins torn
+     * down — and they differ entirely in what the *terminal* should do next. Stopping is
+     * somebody finishing; a restart is the second half of an update, and a terminal that
+     * exits to the shell there has turned "finish updating" into "and now type `neosh`
+     * again", which is the step nobody knows is owed. It cannot be worked out at the far end
+     * either: from a closed socket, a workspace that stopped and a workspace that is
+     * restarting look identical.
+     *
+     * `#[serde(default)]` so an older terminal reads it as an ordinary stop, which is the
+     * behaviour it already has.
+     */
+    restarting: boolean;
+  };

--- a/plugins/api/src/generated/UpdateStatus.ts
+++ b/plugins/api/src/generated/UpdateStatus.ts
@@ -33,7 +33,27 @@ export type UpdateStatus = {
    */
   error?: string | null;
   /**
-   * Whether an update has been downloaded and is waiting for a restart.
+   * Whether the binary on disk is not the one this process is running.
+   *
+   * Not "whether neosh downloaded something": most installs are updated by somebody else's
+   * package manager, in another terminal, and the workspace goes on executing the inode it
+   * started with — which is the whole failure this field exists to name. `brew upgrade neosh`
+   * finishes, says so, and leaves a workspace running the old code with nothing on screen to
+   * say why the thing you just installed is not there. So this is a `stat` of the running
+   * executable against the stamp taken at startup, and it is true for a self-update, a
+   * `brew upgrade`, an `npm install -g` and a re-run of `install.sh` alike.
+   *
+   * Never set when there is no binary left to restart onto: a promise of a restart that cannot
+   * come back is worse than saying nothing.
    */
   restart_pending: boolean;
+  /**
+   * What is waiting on disk, when it could be read.
+   *
+   * Asked of the binary itself (`neosh --version`) rather than assumed to be
+   * [`latest`](UpdateStatus::latest): somebody who ran `brew upgrade` got whatever Homebrew had,
+   * which is not always the newest release, and a row naming the wrong number is a row that
+   * teaches you not to read it. `None` means *something* changed and it would not say what.
+   */
+  restart_version?: string | null;
 };

--- a/plugins/api/src/index.ts
+++ b/plugins/api/src/index.ts
@@ -1834,6 +1834,17 @@ export interface UpdateApi {
    */
   check(force?: boolean): Promise<UpdateStatus>;
   /**
+   * The same answer, from this machine alone, never touching the network.
+   *
+   * Which is enough for the half that matters most often. {@link UpdateStatus.restart_pending} is a
+   * `stat` of one file — *is the binary on disk the binary this workspace is running* — and it goes
+   * true when somebody runs `brew upgrade neosh` in another terminal, which is how most installs
+   * are actually updated and the moment nothing used to say anything. Cheap enough to poll on a
+   * tick; {@link check} is not, and a panel that used it for this would be a workspace making an
+   * HTTP request every thirty seconds.
+   */
+  local(): Promise<UpdateStatus>;
+  /**
    * Update, by whichever route this install takes.
    *
    * Never runs somebody's package manager for them: a managed install comes back as
@@ -2467,7 +2478,16 @@ function build(
     },
     update: {
       async check(force) {
-        return expect(await c({ call: "update_check", force: force ?? false }), "update").update;
+        return expect(
+          await c({ call: "update_check", force: force ?? false, local: false }),
+          "update",
+        ).update;
+      },
+      async local() {
+        return expect(
+          await c({ call: "update_check", force: false, local: true }),
+          "update",
+        ).update;
       },
       async apply() {
         return expect(await c({ call: "update_apply" }), "update_applied").outcome;

--- a/plugins/builtin/update/main.ts
+++ b/plugins/builtin/update/main.ts
@@ -1,30 +1,72 @@
 /**
  * There is a newer neosh, and here is what pressing this would do.
  *
- * Two things, and the second is the one that needs care. Saying *there is an update* is news you did
- * not ask for and cannot otherwise see, which is the definition of an alert — so it is raised once,
- * and never again for the same version. Saying *what updating means here* is not one sentence: a
- * binary Homebrew owns is updated by `brew`, one inside `node_modules` by npm, and only a standalone
- * one is neosh's to replace. The host works out which; this draws the answer.
+ * Three things, and the third is the one this was missing. Saying *there is an update* is news you
+ * did not ask for and cannot otherwise see, which is the definition of an alert — so it is raised
+ * once, and never again for the same version. Saying *what updating means here* is not one sentence:
+ * a binary Homebrew owns is updated by `brew`, one inside `node_modules` by npm, and only a
+ * standalone one is neosh's to replace. The host works out which; this draws the answer.
+ *
+ * And then there is *you are not running what you installed*, which is the state almost everybody
+ * ends up in and the one nothing said a word about. Most installs are managed, so most updates
+ * happen in another terminal: `brew upgrade neosh` finishes, reports success, and the workspace
+ * carries on executing the file it started with — for days, because a workspace here outlives the
+ * terminals that look at it. Nothing had noticed, so `/update` said "you are on the newest" while
+ * the newest sat on disk unused. The host now answers that with a `stat` rather than a registry,
+ * this polls it, and the row says the one thing there is to do.
+ *
+ * `/update` is that one thing, end to end: check, download if it is ours to download, and **restart
+ * when nothing is running**. It used to stop at "installed — restart to use it" and want a second
+ * `/update`, which is a program telling you it has finished half a job and asking you to remember
+ * the other half. The restart is still refused while a turn is in flight — a restart ends turns in
+ * conversations this terminal cannot see — but that is a question with names in it, not a shrug.
  *
  * The row lives under the plan strip, because both are facts about the workspace rather than about
  * a conversation, and the plan is the thing you look at when you look down there. It is only ever
  * present when there is something to say — an update waiting, or a restart owed — so the column's
  * job stays your conversations.
  */
-import type { PluginContext, UpdateStatus } from "@neosh/api";
+import type { Neosh, PluginContext, UpdateStatus } from "@neosh/api";
+import { confirmDestructive } from "@neosh/api/ui";
 
 const NS = "update";
 /** The section id, so the row can be taken off again by name. */
 const ROW = "update";
-/** How often to ask, once the workspace is up. A day: the thing being watched moves in weeks. */
-const EVERY_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * How often to look at all.
+ *
+ * Every thirty seconds, and almost always free: what it costs is one `stat` of the running
+ * executable, which is what answers "has something replaced me". The *network* is on its own much
+ * slower clock below, and the host holds a floor under that regardless of what is asked here.
+ */
+const TICK_MS = 30_000;
+
+/** How long an answer about the registry is good for, unless `update.interval` says otherwise. */
+const DEFAULT_INTERVAL_S = 6 * 60 * 60;
 
 export async function activate({ neosh, subscriptions }: PluginContext) {
   /** The version we have already interrupted somebody about. */
   let announced: string | null = null;
+  /** And the restart we have already interrupted somebody about, which is a different sentence. */
+  let announcedRestart: string | null = null;
   /** What is drawn, so a tick that changes nothing is not a round trip. */
   let drawn: string | null = null;
+  /**
+   * When the network was last *asked*, rather than when it last answered.
+   *
+   * Counted from the ask so a machine with no network settles into one attempt per interval instead
+   * of one per tick forever — the git block's rule, for the same reason.
+   */
+  let askedAt: number | null = null;
+
+  await declareOptions(neosh);
+
+  const settings = async () => ({
+    on: (await neosh.opt.get<boolean>("update.check").catch(() => true)) ?? true,
+    interval: (await neosh.opt.get<number>("update.interval").catch(() => DEFAULT_INTERVAL_S)) ??
+      DEFAULT_INTERVAL_S,
+  });
 
   /**
    * What the row says, given what the host worked out. `null` when there is nothing to say.
@@ -39,8 +81,12 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
    */
   const rowFor = (s: UpdateStatus) => {
     if (s.restart_pending) {
+      // A restart outranks an update, always: it is the nearer half of the same job, it is free,
+      // and offering to download something while a downloaded thing is waiting is a panel that has
+      // lost track of what it is doing. `Status.Pending` because this one is *act now* and a
+      // restart is one key away, which is exactly what that amber means everywhere else.
       return {
-        text: `restart for ${s.latest ?? "the update"}`,
+        text: `restart for ${s.restart_version ?? "the update"}`,
         hl: "Status.Pending",
         right: { text: "/update", hl: "Comment" },
         command: NS,
@@ -57,10 +103,8 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
     };
   };
 
-  const refresh = async (force = false) => {
-    const status = await neosh.update.check(force).catch(() => null);
-    if (!status) return;
-
+  /** Put the row where it goes, or take it away, and say the news once. */
+  const draw = async (status: UpdateStatus) => {
     const row = rowFor(status);
     const key = JSON.stringify(row);
     if (key !== drawn) {
@@ -74,6 +118,24 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
       } else {
         await neosh.ext.remove("sidebar.section", ROW).catch(() => {});
       }
+    }
+
+    // A restart owed is the more urgent of the two and the one nobody would otherwise find out
+    // about: the update has already happened somewhere else, in another terminal, minutes ago.
+    // Once per version, like the other one — a notification that repeats is one people turn off.
+    if (status.restart_pending) {
+      const v = status.restart_version ?? "?";
+      if (v !== announcedRestart) {
+        announcedRestart = v;
+        await neosh.alert(
+          `neosh ${status.restart_version ?? "update"} is installed`,
+          "This workspace is still running the old one. Type /update in the chat to restart it.",
+          { level: "info" },
+        ).catch(() => {});
+      }
+      // And nothing about a newer release while one is already waiting: two notifications about one
+      // job is a person being asked to work out which of them supersedes the other.
+      return;
     }
 
     // Once per version. A notification that repeats is one people turn off, and this one has to
@@ -92,6 +154,60 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
     }
   };
 
+  /**
+   * Look, and draw what came back.
+   *
+   * `network: false` is the ordinary tick and costs a `stat`. Asking the registry is the caller's
+   * decision because it is the expensive half and because turning it off has to be possible —
+   * `update.check = false` is somebody who updates their machine themselves and does not want a
+   * program phoning a website about it. The local half is not covered by that setting and should
+   * not be: "the file under you changed" is a fact about this machine, it is the one that makes a
+   * workspace wrong about itself, and no network was involved in learning it.
+   */
+  const refresh = async (network = false) => {
+    const status = await (network ? neosh.update.check(true) : neosh.update.local())
+      .catch(() => null);
+    if (!status) return null;
+    await draw(status);
+    return status;
+  };
+
+  /**
+   * Restart, having said what it costs.
+   *
+   * The host refuses while any turn is in flight and names them, which is the answer to *may I* —
+   * so this asks the person the question the host cannot: it is their work, they can see the names,
+   * and a restart is not something to do to somebody quietly. Reversible things ask nothing, and
+   * this one is not: the turns end.
+   */
+  const restart = async () => {
+    try {
+      await neosh.update.restart();
+      return true;
+    } catch (e) {
+      // The host's own sentence, verbatim, as the detail: it names the conversations, and "something
+      // is running" sends somebody hunting through a workspace for which one.
+      const go = await confirmDestructive(
+        neosh,
+        "Restart now and end what is running?",
+        { yes: "Restart", no: "Wait", detail: [String(e)] },
+      ).catch(() => false);
+      if (!go) {
+        // Not silence: they said no to *this* restart, and the row is still there saying the job is
+        // half done. Saying so is what stops the row reading as something that did nothing.
+        await neosh.notify("Still waiting — /update when the turns have finished.", "info");
+        return false;
+      }
+      try {
+        await neosh.update.restart(true);
+        return true;
+      } catch (again) {
+        await neosh.notify(String(again), "warn");
+        return false;
+      }
+    }
+  };
+
   // `/update` — the whole verb, and the one to tell people about.
   //
   // The three below are the *pieces*: check, apply, restart. Naming them was right and advertising
@@ -104,25 +220,40 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
   // exact prefix by length, puts it above the three it is made of.
   subscriptions.push(
     await neosh.cmd.register(NS, async () => {
-      // Forced, because this is somebody asking *now*: the six-hourly poll may be five hours stale
-      // and "you are on the newest" from a cache is the one answer this must not give wrongly.
+      // Finish what is already half done before starting anything new, and before anything that can
+      // fail. A binary waiting on disk needs no network to restart onto, so asking the registry
+      // first — which is what this used to do — meant a machine that had updated and then gone
+      // offline could no longer complete its own update: the check failed, the failure was
+      // reported, and the restart sitting one line below was never reached.
+      const local = await neosh.update.local().catch(() => null);
+      if (local?.restart_pending) {
+        await draw(local);
+        return void (await restart());
+      }
+
+      // Forced, because this is somebody asking *now*: the poll may be hours stale and "you are on
+      // the newest" from a cache is the one answer this must not give wrongly.
       const s = await neosh.update.check(true).catch(() => null);
+      askedAt = Date.now();
       if (!s) return neosh.notify("Could not check for updates", "warn");
+      await draw(s);
       if (s.error) return neosh.notify(`Update check failed: ${s.error}`, "warn");
-      // Finish what is already half done before starting anything new. A downloaded update that is
-      // waiting on a restart is not a workspace that needs another download.
-      if (s.restart_pending) return neosh.cmd.exec(`${NS}.restart`);
-      if (s.behind) return neosh.cmd.exec(`${NS}.apply`);
-      await refresh(true);
-      return neosh.notify(`neosh ${s.current} is the newest`, "info");
+      if (!s.behind) return neosh.notify(`neosh ${s.current} is the newest`, "info");
+      return neosh.cmd.exec(`${NS}.apply`);
     }, { desc: "Update neosh" }),
   );
 
   subscriptions.push(
     await neosh.cmd.register(`${NS}.check`, async () => {
-      await refresh(true);
-      const s = await neosh.update.check().catch(() => null);
+      const s = await refresh(true);
+      askedAt = Date.now();
       if (!s) return neosh.notify("Could not check for updates", "warn");
+      if (s.restart_pending) {
+        return neosh.notify(
+          `neosh ${s.restart_version ?? "an update"} is installed — /update to restart`,
+          "info",
+        );
+      }
       if (s.error) return neosh.notify(`Update check failed: ${s.error}`, "warn");
       if (!s.behind) return neosh.notify(`neosh ${s.current} is the newest`, "info");
       return neosh.notify(`neosh ${s.latest} is available`, "info");
@@ -138,18 +269,25 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
       }));
       switch (outcome.outcome) {
         case "up_to_date":
+          await refresh();
           return neosh.notify(`neosh ${outcome.version} is the newest`, "info");
-        case "applied":
-          await refresh(true);
-          // Asked, never done. A restart ends turns in conversations this terminal cannot see, so
-          // the decision belongs to a person who has been told that.
+        case "applied": {
+          await refresh();
+          // And then finish it. Asked before it happens rather than after — `restart` puts the
+          // names of anything running in front of a person and lets them say no — but *done*,
+          // because an update that stops one step short of being the thing you are running is an
+          // update that has not happened, and the step it stopped short of was never on screen.
+          if (await restart()) return;
           return neosh.notify(
-            `neosh ${outcome.version} is installed — restart to use it`,
+            `neosh ${outcome.version} is installed — /update to restart into it`,
             "info",
           );
+        }
         case "delegated":
           // Not run for them. A keypress that drives somebody's package manager is how a machine
-          // ends up in a state its owner cannot explain.
+          // ends up in a state its owner cannot explain. What *is* now true is that running it is
+          // the whole of the job: the next tick notices the binary changed and offers the restart,
+          // so nobody has to know a workspace needs one.
           return neosh.notify(`Update with: ${outcome.command}`, "info");
         default:
           return neosh.notify(`Update failed: ${outcome.reason}`, "error");
@@ -158,15 +296,9 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
   );
 
   subscriptions.push(
-    await neosh.cmd.register(`${NS}.restart`, async () => {
-      try {
-        await neosh.update.restart();
-      } catch (e) {
-        // The host refuses while any turn is in flight, and names them. Passed through as-is:
-        // "something is running" sends somebody hunting for which conversation.
-        return neosh.notify(String(e), "warn");
-      }
-    }, { desc: "Restart the workspace to finish an update" }),
+    await neosh.cmd.register(`${NS}.restart`, async () => void (await restart()), {
+      desc: "Restart the workspace to finish an update",
+    }),
   );
 
   // No `sidebar.action` of its own, deliberately. A contributed row already runs its `command` on
@@ -177,10 +309,75 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
   // row in the column, which is how a key added here used to be advertised on the plan strip and
   // push that strip's own `<Tab>` hint off the end of the row.
 
+  /** Whether the registry is due to be asked again. `interval = 0` is never. */
+  const due = async () => {
+    const s = await settings();
+    if (!s.on || s.interval <= 0) return false;
+    return askedAt === null || Date.now() - askedAt >= s.interval * 1000;
+  };
+
   await refresh();
-  const timer = await neosh.timer.every(EVERY_MS, () => void refresh(true));
-  subscriptions.push(timer);
+
+  // Checked on a short tick against the wall clock rather than scheduled at the interval, and the
+  // difference is the whole reason a second machine never heard about a release. A timer armed for
+  // six hours is armed on a *monotonic* clock, which does not advance while a laptop is asleep — so
+  // on a machine that is shut for twenty hours a day, a six-hour timer takes the better part of a
+  // week, and a workspace left running for a fortnight had genuinely never asked. `Date.now()` is
+  // the clock that keeps counting. It also means changing `update.interval` takes effect without
+  // restarting anything, and that a machine that was asleep asks *once* when it wakes rather than
+  // banking up every check it missed.
+  subscriptions.push(
+    await neosh.timer.every(TICK_MS, () => {
+      void (async () => {
+        if (await due()) {
+          askedAt = Date.now();
+          await refresh(true);
+        } else {
+          // The cheap half, every tick: `brew upgrade` in the next terminal along should show up in
+          // this panel in under a minute, and it costs a `stat` to say so.
+          await refresh();
+        }
+      })();
+    }),
+  );
+
+  // Not at `activate`: the first thing a workspace does on opening is start a conversation and load
+  // eleven plugins, and a network round trip in the middle of that is a second of a slower start
+  // for a number nobody has looked at yet.
+  subscriptions.push(
+    neosh.event.on("neosh.ready", () => {
+      void (async () => {
+        if (await due()) {
+          askedAt = Date.now();
+          await refresh(true);
+        }
+      })();
+    }),
+  );
+
+  // Somebody just arrived. Which is the moment the answer is worth having — a workspace that has
+  // been sitting detached for a week is exactly the one running a version nobody has looked at.
+  subscriptions.push(neosh.view.onOpen(() => void refresh()));
+
   subscriptions.push({
     dispose: () => void neosh.ext.remove("sidebar.section", ROW).catch(() => {}),
   });
+}
+
+async function declareOptions(neosh: Neosh) {
+  await neosh.opt.declare({
+    name: "update.check",
+    type: { type: "bool" },
+    default: true,
+    description:
+      "Ask the releases page whether there is a newer neosh. Turning this off stops the network " +
+      "check only — a workspace still says when the binary under it has been replaced, because " +
+      "that is a fact about this machine and is what makes it wrong about itself.",
+  }).catch(() => {});
+  await neosh.opt.declare({
+    name: "update.interval",
+    type: { type: "int", min: 0, max: 604800 },
+    default: DEFAULT_INTERVAL_S,
+    description: "Seconds between checks for a newer neosh. 0 never asks.",
+  }).catch(() => {});
 }


### PR DESCRIPTION
`restart_pending` was only ever set by neosh's own download — the standalone path. Which is the minority: most installs are managed, so most updates happen in another terminal. `brew upgrade neosh` finishes, reports success, and the workspace goes on executing the inode it started with, for days, because a workspace here outlives the terminals that look at it. Nothing noticed, so `/update` said "0.4.1 is the newest" with 0.4.2 sitting on disk unused.

## A stat, not a receipt

The executable is stamped at startup — inode, length, mtime — and compared afterwards, which is true for a `brew upgrade`, an `npm install -g`, a `cargo install --force`, a re-run of `install.sh` and our own rename alike, and needs no network to be true on a train.

Three candidates in order, each covering what the others cannot:

- the **unresolved** launch path, because a managed install is a symlink into a versioned directory and upgrading it never touches the file we are executing — resolving at startup and remembering the answer is exactly how that swap became invisible;
- the resolved path, for an install that is a plain file;
- `neosh` on `PATH`, for when the directory we were in has been removed, which is what brew does to the keg it replaced and which on Linux leaves no link to follow.

Never claimed when no binary can be found: a restart that cannot come back is worse than silence. The waiting version is asked of the file rather than assumed to be `latest`, because `brew` gives you whatever the tap had.

A checkout is still told none of this. There "the binary changed" is true on nearly every build, and it already has an answer — the terminal says it on attach out of `BuildId` and names `neosh stop`. Two notices about one thing is one notice nobody reads.

## `/update` is one verb that finishes

It handled the restart *after* the error branch, so updating and then losing the network meant you could no longer complete your own update: the check failed, the failure was reported, and the restart one line below was never reached. Restart is first now and needs no network.

And when nothing is running it simply restarts — it used to stop at "installed — restart to use it" and want a second `/update`, which is a program saying it has finished half a job and asking you to remember the other half. When something *is* running it asks, with the host's own list of conversations as the detail, because a restart ends turns in conversations this terminal cannot see.

## A restart puts the terminal back

It did not: the workspace stopped, the client returned `Stopped`, and you were dropped to a shell prompt with the job half done and nothing saying what the other half was.

`UiEvent::Shutdown` carries `restarting`, because from a closed socket a workspace that stopped and one coming straight back are indistinguishable; the terminal waits for the socket to go and `exec`s the new binary in place. An exec rather than a reattach: reattaching leaves the terminal — the thing drawing every frame — as the old build talking to the new workspace, which is the half-updated state this exists to remove. The relaunch argv is rebuilt from the flags rather than reused from `args_os()`, so `neosh "why is this slow"` does not ask its question a second time on the far side of an update.

## The poll is on the clock that keeps counting

`timer.every(6h)` is monotonic and does not advance while a laptop is asleep, so a machine shut twenty hours a day took most of a week to fire it and a workspace up for a fortnight had genuinely never asked — which is why a second computer never heard about a release.

It is the git block's idiom now: a thirty-second tick against `Date.now()`, plus `neosh.ready`, plus a terminal arriving. The tick costs one `stat`; `update.check` and `update.interval` govern the network half alone, because "the file under you changed" is a fact about this machine and is the one that makes a workspace wrong about itself.

## Verification

- `cargo test -p neosh --bin neosh update::` — 10 pass, including the Homebrew keg-and-symlink swap, an in-place rename, a checkout staying quiet, and never offering a restart onto a binary that is not there
- `cargo test -p neosh-core` — 188 pass
- `TS_RS_EXPORT_DIR=… cargo test -p neosh-proto export_bindings` + `git diff --exit-code` — generated TS in sync
- `npx tsc --noEmit` in both `plugins/api` and `plugins/builtin`

Not run: `tests/workspace.rs` and `tests/builtin_plugins.rs`, and no `scripts/shot.py` screenshot of the row — the machine ran out of disk mid-pass. Merging without waiting for them at the author's request.