### PR TITLE
release: v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "neosh"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2433,7 +2433,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-agent"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-trait",
  "futures",
@@ -2452,7 +2452,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "insta",
  "neosh-proto",
@@ -2467,14 +2467,14 @@ dependencies = [
 
 [[package]]
 name = "neosh-plugins"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "include_dir",
 ]
 
 [[package]]
 name = "neosh-proto"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-provider"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-script"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "deno_ast",
@@ -2530,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-swarm"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-syntax"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "syntect",
  "two-face",
@@ -2553,7 +2553,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-tui"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "crossterm",
  "futures",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-vcs"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "neosh-proto",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.90"
 license = "MIT"
@@ -27,16 +27,16 @@ homepage = "https://github.com/neoswarm/neosh"
 # Every one of these carries a `version` as well as a `path`: cargo refuses to package a crate whose
 # dependency has only a path, and the published crate is built against the registry version while
 # a checkout is built against the directory next door.
-neosh-proto = { path = "crates/neosh-proto", version = "0.4.1" }
-neosh-core = { path = "crates/neosh-core", version = "0.4.1" }
-neosh-provider = { path = "crates/neosh-provider", version = "0.4.1" }
-neosh-vcs = { path = "crates/neosh-vcs", version = "0.4.1" }
-neosh-swarm = { path = "crates/neosh-swarm", version = "0.4.1" }
-neosh-agent = { path = "crates/neosh-agent", version = "0.4.1" }
-neosh-script = { path = "crates/neosh-script", version = "0.4.1" }
-neosh-tui = { path = "crates/neosh-tui", version = "0.4.1" }
-neosh-syntax = { path = "crates/neosh-syntax", version = "0.4.1" }
-neosh-plugins = { path = "plugins", version = "0.4.1" }
+neosh-proto = { path = "crates/neosh-proto", version = "0.4.2" }
+neosh-core = { path = "crates/neosh-core", version = "0.4.2" }
+neosh-provider = { path = "crates/neosh-provider", version = "0.4.2" }
+neosh-vcs = { path = "crates/neosh-vcs", version = "0.4.2" }
+neosh-swarm = { path = "crates/neosh-swarm", version = "0.4.2" }
+neosh-agent = { path = "crates/neosh-agent", version = "0.4.2" }
+neosh-script = { path = "crates/neosh-script", version = "0.4.2" }
+neosh-tui = { path = "crates/neosh-tui", version = "0.4.2" }
+neosh-syntax = { path = "crates/neosh-syntax", version = "0.4.2" }
+neosh-plugins = { path = "plugins", version = "0.4.2" }
 
 # async
 tokio = { version = "1.53", features = ["rt", "rt-multi-thread", "macros", "sync", "time", "process", "io-util", "fs", "signal", "net"] }

--- a/npm/neosh/package.json
+++ b/npm/neosh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neosh",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Neovim for controlling AI agents. A terminal workspace where every feature is a plugin.",
   "license": "MIT",
   "bin": {
@@ -32,9 +32,9 @@
     "!._*"
   ],
   "optionalDependencies": {
-    "@neosh/cli-darwin-arm64": "0.4.1",
-    "@neosh/cli-darwin-x64": "0.4.1",
-    "@neosh/cli-linux-x64": "0.4.1",
-    "@neosh/cli-linux-arm64": "0.4.1"
+    "@neosh/cli-darwin-arm64": "0.4.2",
+    "@neosh/cli-darwin-x64": "0.4.2",
+    "@neosh/cli-linux-x64": "0.4.2",
+    "@neosh/cli-linux-arm64": "0.4.2"
   }
 }

--- a/plugins/api/package.json
+++ b/plugins/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/api",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "The neosh plugin API. Types are generated from the Rust side and drift-checked in CI.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/approvals/package.json
+++ b/plugins/builtin/approvals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/approvals",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Asks before the agent does something the policy says to ask about.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/archive/package.json
+++ b/plugins/builtin/archive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/archive",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "What you have finished with: a panel to find it in, and the verbs that empty it.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/git/package.json
+++ b/plugins/builtin/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/git",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Branch, commit and status, with model-written names and messages you can re-prompt.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/model/package.json
+++ b/plugins/builtin/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/model",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Model and reasoning-effort switchers, in the status line and behind a picker.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/palette/package.json
+++ b/plugins/builtin/palette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/palette",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "One key to everything: commands, conversations, and what they are bound to.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/questions/package.json
+++ b/plugins/builtin/questions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/questions",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Draws the question an agent asks you, and sends back what you said.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/sidebar/package.json
+++ b/plugins/builtin/sidebar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/sidebar",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A docked panel: where you are, what changed, and what is answering.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/slash/package.json
+++ b/plugins/builtin/slash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/slash",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Type / to reach a command \u2014 neosh's own, and whatever the driver says it accepts.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/titles/package.json
+++ b/plugins/builtin/titles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/titles",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Names a conversation after what it turned out to be about.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/update/package.json
+++ b/plugins/builtin/update/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/update",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Says when there is a newer neosh, and becomes it.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/usage/package.json
+++ b/plugins/builtin/usage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/usage",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "How full the context window is, what the conversation has cost, and what the plan has left.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Version bump only: `[workspace.package]` and the ten internal pins in `[workspace.dependencies]`, `npm/neosh/package.json` (version and the four `optionalDependencies`), `plugins/api/package.json`, the eleven bundled plugin manifests, and `Cargo.lock` via `cargo update -w`.

Carries #96 — the update system: a workspace now notices when the binary under it has been replaced by `brew upgrade` or anything else, `/update` restarts when nothing is running instead of stopping half way, and a restart puts the terminal back rather than dropping it to a shell.

`cargo build -p neosh` green at 0.4.2.