### PR TITLE
feat(sidebar): the repository is on the row it is about, not in a block above it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1184,52 +1184,67 @@ says how many are asking, `^T` is where you go, and it opens when you get there.
 | `J` `K` | Reorder within a group |
 | `r` | Rename a conversation |
 | `y` | Copy the row's directory — a worktree's path, ready to paste into a shell |
-| `p` | Pull that repository from its remote (a git-plugin contribution) |
+| `p` | Bring that repository up to date — fast-forwards silently, asks *rebase or merge* when the branch has gone both ways, and goes and looks when nothing is waiting (a git-plugin contribution) |
 | `d` | Remove a worktree from disk — its branch stays, and it asks first (a git-plugin contribution) |
 | `x` `X` | Archive, delete. On a project heading, `X` takes the project off the list — the only thing that does |
 | `a` | The archive — the popup below. Nothing archived is ever a row in *this* panel, and by default not even a count. An `archive.action` contribution, not a key this panel owns |
-| `⇥` | On the plan rows: how much of it to show — the limit that binds, every limit, or all of it with the account and the sentence. `usage.sidebar.style` is where it starts, `usage.sidebar` turns it off. On the **git** rows it is the same key about that block — `git.sidebar.style` — because a key on a contributed row is named down to the section (`custom:git`, `custom:plan`) and the panel sends the press to whichever block the cursor is over |
+| `⇥` | On the plan rows: how much of it to show — the limit that binds, every limit, or all of it with the account and the sentence. `usage.sidebar.style` is where it starts, `usage.sidebar` turns it off. A key on a contributed row is named down to the section (`custom:plan`), so the panel sends the press to whichever block the cursor is over rather than to whoever registered it first |
 | `?` | The keys for whatever row you are on |
 | `Esc` | Back to the composer |
 
-## The repository, at the top of the panel
+## The repository is on the row it is about
 
-Two rows above the projects: which branch the conversation you are in is on, what has drifted from
-the remote, and **one key that does something about it**. It is a `sidebar.section` contribution
-like the plan strip, so `git.sidebar = false` takes it off and a panel that is not ours picks it up
-unchanged.
+Not a block above the list. Where a checkout stands is a fact about a *project*, and the panel
+already draws one row per project — so it goes on that row, after the name, in the colour of what
+each fact is:
 
 ```
- GIT                           ^G
+ PROJECTS
 ──────────────────────────────────
- main ↓3 ~1 ?1
- ↓ pull 3 commits             now
+ ▾ neosh ↓3 ~1 ?1  #86 ✗2       4
+   ▾ ⎇ fix/the-thing ↑2  #91     1
+     ▸ Chasing the flake       12m
 ```
 
-**The verb row is rebuilt from the state every draw**, so the key is never pointed at something that
-would do nothing — which is what a fixed `pull` button that is a no-op nine times in ten teaches
-people. `↓ pull 3 commits` fast-forwards and says what git said; `⇄ diverged — 2 up, 3 down` asks
-*rebase or merge*, in those words, because the two answers do different things to your own commits
-and neither is guessable from the row; `↻ check for changes` asks the remote again, which is the
-honest verb for a number that is only as fresh as the last fetch; `→ no upstream` is a statement and
-not a verb, because a branch tracking nothing is not behind anything. `⇥` steps the block between
-`one` and `full`, which adds the upstream and a line about the working tree.
+**There was a `GIT` heading with the branch and a verb under it, and it was saying twice what the
+row below it already said.** `statParts` has always put `✗2 ↓3 ↑1 ~4 ?7` after a project's name and
+`pulls.ts` has always put `#86` after that, coloured by what the pull request *is* — `Forge.Merged`,
+`Forge.Open`, `Forge.Draft`, `Forge.Closed`. So the block was a fourth and fifth row about **one**
+of the rows underneath it, on a column whose whole job is your conversations. It was also the only
+thing here that could disagree with itself: the block read `git status` for the conversation you
+were in while the rows read one per project, on two clocks, so a fetch moved one a beat before the
+other. And a contribution is workspace-wide while a conversation is per view, so two panes on two
+repositories saw one block, about whichever conversation the workspace happened to call current — a
+problem a row about a directory has never had, because there is one of them per directory.
+
+**Each fact keeps its own colour, and that is what makes it a glance rather than a string.** A
+conflict is a tree you cannot commit from, behind is work you have not got yet, ahead is work
+nobody else has, and the two dirty counts are yours and undecided; worst first, nothing said about
+zero, so a clean checkout is a row with nothing extra on it. `git.sidebar = false` takes the marks
+off the rows — which is what somebody setting it always meant, and it does not stop the *reading*,
+because the footer's branch segment is the same `git status`.
+
+**The verb went onto the key, not away.** `p` on any row fast-forwards without asking, and when the
+branch has gone both ways it **names the choice** — *rebase or merge*, in those words, as a picker,
+because the two do different things to your own commits, one of them rewrites them, and neither is
+guessable from a row. When nothing is waiting it fetches instead, which is the honest reading of
+that key on a number only as fresh as the last fetch. All three used to live on the block's verb
+row, so deleting the block without moving them would have quietly demoted `p` to `git pull` and
+whatever it says about a divergence.
 
 **Ahead and behind are asked for, not remembered.** They come off `git status --branch`, which
-compares HEAD with the remote-tracking ref *on this disk* — so a panel drawing `↓0` without ever
-fetching is reporting the world as of whenever this checkout last spoke to a server, which after an
-afternoon is a sentence about breakfast. `ApiCall::GitFetch` is what makes it true: on
-`git.fetch.interval` (180 s, `0` never), on arriving in a conversation, and on the key. Only the
-repository of the conversation you are in, only when its branch tracks one, and the dim column at
-the right of the verb row is how old the answer is — `now`, `12m`, `⚠ offline` — because a claim
-about a remote without an *as of* cannot be told from a claim about now.
+compares HEAD with the remote-tracking ref *on this disk* — so `↓0` drawn without ever fetching is
+the world as of whenever this checkout last spoke to a server, which after an afternoon is a
+sentence about breakfast. `ApiCall::GitFetch` is what makes it true: on `git.fetch.interval`
+(180 s, `0` never), on arriving in a conversation, and on the key. Only the repository of the
+conversation you are in, and only when its branch tracks one.
 
-**And the block moves only while it is talking to a server.** A fetch is seconds of nothing on
-screen against somebody else's machine, which is the one case where a still panel and a wedged one
-look identical, so it gets both halves of the vocabulary: a spinner glyph and `Git.Fetching`, which
-sweeps. Nothing else here animates, and the restraint is the point — `↓3` is news exactly as an
-unread conversation is news, it is true until you act rather than *happening*, and motion spent on
-it is attention charged every time it changes with nothing new to say.
+**And a number whose fetch failed says so.** The block spent a column on `now` / `12m` / `⚠ offline`;
+a row spends one glyph on the only part of that you cannot afford to lose. `Git.Stale` is a dim `⚠`
+appended to the stats — it *qualifies* them rather than replacing them, `↓3 ⚠` still being three
+waiting, just three as of whenever the network last worked — and it appears only when the last fetch
+did not reach the remote. `now` and `12m` were not worth a column: a fetch every three minutes is
+fresh enough that saying so is noise. Being unreachable is not.
 
 ## The archive — `^F`, or `a` in the project panel
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "neosh"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2433,7 +2433,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-agent"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "futures",
@@ -2452,7 +2452,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "insta",
  "neosh-proto",
@@ -2467,14 +2467,14 @@ dependencies = [
 
 [[package]]
 name = "neosh-plugins"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "include_dir",
 ]
 
 [[package]]
 name = "neosh-proto"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-provider"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-script"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "deno_ast",
@@ -2530,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-swarm"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-syntax"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "syntect",
  "two-face",
@@ -2553,7 +2553,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-tui"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "crossterm",
  "futures",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-vcs"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "neosh-proto",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 rust-version = "1.90"
 license = "MIT"
@@ -27,16 +27,16 @@ homepage = "https://github.com/neoswarm/neosh"
 # Every one of these carries a `version` as well as a `path`: cargo refuses to package a crate whose
 # dependency has only a path, and the published crate is built against the registry version while
 # a checkout is built against the directory next door.
-neosh-proto = { path = "crates/neosh-proto", version = "0.4.2" }
-neosh-core = { path = "crates/neosh-core", version = "0.4.2" }
-neosh-provider = { path = "crates/neosh-provider", version = "0.4.2" }
-neosh-vcs = { path = "crates/neosh-vcs", version = "0.4.2" }
-neosh-swarm = { path = "crates/neosh-swarm", version = "0.4.2" }
-neosh-agent = { path = "crates/neosh-agent", version = "0.4.2" }
-neosh-script = { path = "crates/neosh-script", version = "0.4.2" }
-neosh-tui = { path = "crates/neosh-tui", version = "0.4.2" }
-neosh-syntax = { path = "crates/neosh-syntax", version = "0.4.2" }
-neosh-plugins = { path = "plugins", version = "0.4.2" }
+neosh-proto = { path = "crates/neosh-proto", version = "0.4.3" }
+neosh-core = { path = "crates/neosh-core", version = "0.4.3" }
+neosh-provider = { path = "crates/neosh-provider", version = "0.4.3" }
+neosh-vcs = { path = "crates/neosh-vcs", version = "0.4.3" }
+neosh-swarm = { path = "crates/neosh-swarm", version = "0.4.3" }
+neosh-agent = { path = "crates/neosh-agent", version = "0.4.3" }
+neosh-script = { path = "crates/neosh-script", version = "0.4.3" }
+neosh-tui = { path = "crates/neosh-tui", version = "0.4.3" }
+neosh-syntax = { path = "crates/neosh-syntax", version = "0.4.3" }
+neosh-plugins = { path = "plugins", version = "0.4.3" }
 
 # async
 tokio = { version = "1.53", features = ["rt", "rt-multi-thread", "macros", "sync", "time", "process", "io-util", "fs", "signal", "net"] }

--- a/crates/neosh-core/src/palette.rs
+++ b/crates/neosh-core/src/palette.rs
@@ -426,6 +426,15 @@ pub fn groups(variant: Variant) -> Vec<(&'static str, HighlightDef)> {
         ("Git.Branch", spec(fg(r.accent))),
         ("Git.Ahead", spec(fg(r.success))),
         ("Git.Behind", spec(fg(r.attention))),
+        // The numbers beside this are as of a fetch that did not reach the remote.
+        //
+        // Dim and faint on purpose, and the only git mark that qualifies another rather than
+        // stating a fact of its own: `↓3 ⚠` is still three waiting, it is simply three as of
+        // whenever the network last worked. Drawn as loudly as the count it qualifies, a train
+        // journey would repaint the whole panel in warning colours over a state nobody can act on
+        // — and unreachable is not the same kind of news as diverged, which is a decision waiting
+        // for you. Still, for the reason `Git.Behind` is: nothing is happening here.
+        ("Git.Stale", spec(dim(fg(r.faint)))),
         // Both ways at once: this branch has commits the remote does not *and* the remote has
         // commits this branch does not, so a plain pull will either build a merge nobody asked for
         // or refuse outright. The danger hue rather than the attention one, because unlike `Behind`
@@ -835,7 +844,7 @@ mod tests {
             "checks running is work happening on somebody else's machine"
         );
         for still in [
-            "Git.Diverged", "Git.Synced", "Git.Behind", "Git.Ahead", "Git.Branch",
+            "Git.Diverged", "Git.Synced", "Git.Behind", "Git.Ahead", "Git.Branch", "Git.Stale",
             // A pull request's *state* is news and never motion: open is true until somebody
             // reviews it, merged is true for ever, and a row that blinks about either charges
             // attention every time it changes with nothing new to say.

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -951,14 +951,15 @@ impl Sandbox {
     }
 }
 
-/// The sidebar says which branch, how far behind, and what pressing the key would do.
+/// How far behind is on the project's own row, and there is no block above it.
 ///
-/// All three are the same claim: that a panel about a repository has to have *asked* a remote.
-/// `behind` out of `git status` is a comparison with the remote-tracking ref on this disk, so
-/// without the fetch this block would draw `check for changes` over a checkout that is three
-/// commits behind — confidently, and for as long as anybody looked at it.
+/// The claim is the same one the block used to make — that a panel about a repository has to have
+/// *asked* a remote, because `behind` out of `git status` is a comparison with the remote-tracking
+/// ref on this disk — but it is now made where the repository already is. A `GIT` heading with the
+/// branch and a verb under it was a fourth and fifth row about one of the rows below it, on a
+/// column whose whole job is your conversations.
 #[test]
-fn the_sidebar_says_the_branch_and_offers_the_pull() {
+fn how_far_behind_is_on_the_project_row_and_there_is_no_git_block() {
     if !have_git() {
         return;
     }
@@ -968,51 +969,34 @@ fn the_sidebar_says_the_branch_and_offers_the_pull() {
 
     let mut s = sb.start();
     s.wait_for("PROJECTS");
-    // The branch, on its own row, above the projects — the fact nothing else in the workspace says
-    // unless the footer happens to have room for it.
+    // The count, on the row the repository is already on. `↓3` rather than `pull 3 commits`,
+    // because a row is a glance and a sentence is a thing you read.
     assert!(
-        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("GIT"))),
-        "the block has a heading\n{:?}",
+        s.pump(|s| s.projects_now().iter().any(|l| l.contains("↓3"))),
+        "the project row carries what the fetch found\n{:?}",
         s.sidebar_now()
     );
+    // And nothing above the list is about git any more.
+    let rows = s.sidebar_now();
+    let head = rows.iter().position(|l| l.contains("PROJECTS")).unwrap_or(0);
     assert!(
-        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("trunk"))),
-        "and names the branch\n{:?}",
-        s.sidebar_now()
+        !rows.iter().any(|l| l.contains("GIT")),
+        "no git heading anywhere\n{rows:?}"
     );
-    // The verb is built from the state, so it counts what is actually waiting rather than offering
-    // a `pull` that would be a no-op.
     assert!(
-        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("pull 3 commits"))),
-        "and offers the pull, counting what the fetch found\n{:?}",
-        s.sidebar_now()
-    );
-
-    // `⇥` on a git row steps the block, and it is *this* block's `⇥` rather than the plan strip's:
-    // both ask for the key on their own rows, and the panel sends the press to whichever the cursor
-    // is over.
-    s.enter_panel();
-    s.key("g");
-    s.key("g");
-    assert!(
-        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("detail"))),
-        "the key is advertised on the rows it applies to\n{:?}",
-        s.sidebar_now()
-    );
-    s.special("tab");
-    assert!(
-        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("origin/trunk"))),
-        "and one step up says what it tracks\n{:?}",
-        s.sidebar_now()
+        !rows[..head].iter().any(|l| l.contains("trunk") || l.contains("pull 3 commits")),
+        "and nothing about the branch above the projects\n{rows:?}"
     );
 }
 
-/// Pressing it pulls, and the row says what git said.
+/// `p` on the project row pulls, and says what git said.
 ///
-/// The half that matters is the last assertion: a button that goes back to looking exactly as it
-/// did before is one you press twice to find out whether the first press worked.
+/// The verb moved onto the key when the block went. That is not a smaller thing than it was: the
+/// key used to run `git pull` and report whatever came back, so the *choice* a diverged branch
+/// needs — rebase or merge, which do different things to your own commits — lived only on a row
+/// that no longer exists. `pullRepository` is the whole verb now, and `p` is one of its three doors.
 #[test]
-fn the_pull_row_pulls_and_reports_what_happened() {
+fn p_on_a_project_row_pulls_and_reports_what_happened() {
     if !have_git() {
         return;
     }
@@ -1023,20 +1007,22 @@ fn the_pull_row_pulls_and_reports_what_happened() {
     let mut s = sb.start();
     s.wait_for("PROJECTS");
     assert!(
-        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("pull 2 commits"))),
-        "two waiting\n{:?}",
+        s.pump(|s| s.projects_now().iter().any(|l| l.contains("↓2"))),
+        "two waiting, on the row\n{:?}",
         s.sidebar_now()
     );
     s.enter_panel();
-    // The block's first landable row is the branch; the verb is the one under it.
+    // The first row of the list is the project itself — no block above it to step past any more.
     s.key("g");
     s.key("g");
-    s.key("j");
-    s.special("enter");
+    s.key("p");
+    // What git said, as a notification. It used to be a row *in* the block, held for six seconds;
+    // with the block gone the answer to a key you just pressed is a reply, which is exactly what
+    // the notification vocabulary calls this and does not stack.
     assert!(
-        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("Fast-forward"))),
-        "the row says what git said\n{:?}",
-        s.sidebar_now()
+        s.pump(|s| s.saw("Fast-forward")),
+        "it says what git said\n{}",
+        s.transcript()
     );
     let head = Command::new("git")
         .current_dir(sb.work())
@@ -3120,14 +3106,18 @@ fn a_worktree_nests_under_the_repository_it_belongs_to() {
     );
 }
 
-/// The git block prints the branch, and the branch is very often a worktree's name.
+/// The project list is asked for by name, never taken as "the whole sidebar".
 ///
-/// Which is the trap the test above fell into, and it is worth one test of its own rather than a
-/// comment: the two rows say the same word for different reasons, they are in different sections,
-/// and only one of them is a project. A helper that cannot tell them apart is one every future
-/// worktree test inherits.
+/// This replaced a test that waited for the git block to print the branch above `PROJECTS` and
+/// then checked the tree was still nested below it. That block is gone — the stats it drew are on
+/// the rows now — so the specific trap it guarded cannot happen from that direction any more.
+///
+/// The helper stays and so does a test of it, because the hazard is structural rather than about
+/// git: `projects_now()` means "the rows that are projects", anything contributing a section above
+/// the list can put any word there, and a worktree is *named by its branch* — so a future block
+/// naming a branch would resurrect exactly this bug in a test that reads the whole column.
 #[test]
-fn the_project_list_does_not_include_the_branch_the_git_block_names() {
+fn the_project_list_is_the_rows_below_the_projects_heading() {
     let sb = Sandbox::new("wtscope");
     sb.git_init();
     let root = sb.root.join("trees");
@@ -3136,24 +3126,24 @@ fn the_project_list_does_not_include_the_branch_the_git_block_names() {
     s.wait_for("PROJECTS");
     s.send(&command_with("git.worktree.new", "sideline"));
 
-    // Wait for the state the old assertion could not survive: the git block has caught up and is
-    // naming the branch above `PROJECTS`.
     assert!(
         s.pump(|s| {
-            let all = s.sidebar_now();
-            let head = all.iter().position(|l| l.contains("PROJECTS")).unwrap_or(0);
-            all[..head].iter().any(|l| l.contains("sideline"))
+            let rows = s.projects_now();
+            let repo = rows.iter().position(|l| l.contains("work") && !l.contains("sideline"));
+            let tree = rows.iter().position(|l| l.contains("sideline"));
+            matches!((repo, tree), (Some(r), Some(t)) if t > r)
         }),
-        "the git block names the branch\n{:?}",
+        "the tree is below its repository in the project list\n{:?}",
         s.sidebar_now()
     );
-    // And with it there, the project list still puts the tree under its repository.
+    // And the helper really is a slice rather than the whole column: everything it returns is at or
+    // below the heading, so a section above the list can never be mistaken for a project row.
+    let all = s.sidebar_now();
     let rows = s.projects_now();
-    let repo = rows.iter().position(|l| l.contains("work") && !l.contains("sideline"));
-    let tree = rows.iter().position(|l| l.contains("sideline"));
+    assert!(rows.len() <= all.len(), "the slice is no longer than the column");
     assert!(
-        matches!((repo, tree), (Some(r), Some(t)) if t > r),
-        "the tree is still below its repository once the branch row exists\n{rows:?}"
+        rows.first().is_none_or(|l| l.contains("PROJECTS")),
+        "and it starts at the heading\n{rows:?}"
     );
 }
 

--- a/npm/neosh/package.json
+++ b/npm/neosh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neosh",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Neovim for controlling AI agents. A terminal workspace where every feature is a plugin.",
   "license": "MIT",
   "bin": {
@@ -32,9 +32,9 @@
     "!._*"
   ],
   "optionalDependencies": {
-    "@neosh/cli-darwin-arm64": "0.4.2",
-    "@neosh/cli-darwin-x64": "0.4.2",
-    "@neosh/cli-linux-x64": "0.4.2",
-    "@neosh/cli-linux-arm64": "0.4.2"
+    "@neosh/cli-darwin-arm64": "0.4.3",
+    "@neosh/cli-darwin-x64": "0.4.3",
+    "@neosh/cli-linux-x64": "0.4.3",
+    "@neosh/cli-linux-arm64": "0.4.3"
   }
 }

--- a/plugins/api/package.json
+++ b/plugins/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/api",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "The neosh plugin API. Types are generated from the Rust side and drift-checked in CI.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/approvals/package.json
+++ b/plugins/builtin/approvals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/approvals",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Asks before the agent does something the policy says to ask about.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/archive/package.json
+++ b/plugins/builtin/archive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/archive",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "What you have finished with: a panel to find it in, and the verbs that empty it.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/git/main.ts
+++ b/plugins/builtin/git/main.ts
@@ -50,7 +50,7 @@ import {
 } from "@neosh/api/ui";
 import { configureMotion } from "@neosh/api/ui";
 import { installPulls } from "./pulls.ts";
-import { installGitSection, statParts } from "./sidebar.ts";
+import { fetchFailed, installGitStatus, pullRepository, statParts } from "./sidebar.ts";
 
 // ---------------------------------------------------------------------------
 // Default prompts
@@ -300,9 +300,25 @@ two-word scratch name it was created with.",
       ? projects.filter((p): p is string => typeof p === "string")
       : [];
     const ascii = (await neosh.opt.get<boolean>("ui.ascii_only").catch(() => false)) ?? false;
+    // `git.sidebar` used to turn off a block. There is no block, so it turns off these marks —
+    // which is what somebody setting it always meant: not "stop reading git", which the footer and
+    // the branch segment still need, but "keep git out of my project list".
+    const on = (await neosh.opt.get<boolean>("git.sidebar").catch(() => true)) ?? true;
     for (const cwd of cwds) {
+      if (!on) {
+        await neosh.ext.remove("sidebar.decoration", `dirty:${cwd}`).catch(() => {});
+        continue;
+      }
       const status = await neosh.git.status({ cwd }).catch(() => null);
       const parts = status ? statParts(status, ascii) : [];
+      // The one thing the block said that a count cannot: that these numbers are as of a fetch
+      // that did not reach the remote. Appended rather than led with, because it qualifies the
+      // stats rather than replacing them — and drawn only when there is trouble, so it is never a
+      // column of nothing.
+      if (fetchFailed(cwd)) {
+        if (parts.length > 0) parts.push({ text: " " });
+        parts.push({ text: ascii ? "!" : "⚠", hl: "Git.Stale" });
+      }
       if (parts.length === 0) {
         await neosh.ext.remove("sidebar.decoration", `dirty:${cwd}`).catch(() => {});
         continue;
@@ -375,29 +391,26 @@ two-word scratch name it was created with.",
     });
   };
 
-  // The block at the top of the sidebar: which branch, what has drifted, and the one key that does
-  // something about it. Contributed, so `plugins.disabled = ["git"]` takes it away with everything
-  // else here and a panel that is not ours picks it up unchanged.
-  //
-  // It also owns the reading. Whoever polls `git status` has to do it on a timer — the agent writes
-  // files all through a turn — and having *two* things poll it is two subprocesses for one answer
-  // and two answers for one question. So the block reads, and the footer above is told; a git block
-  // turned off with `git.sidebar = false` still reads, because the reading was never the block's.
   // What the forge knows, on the same rows. Its own module because it is a different server, a
   // different failure mode and a much slower clock: a working tree changes while you watch and a
   // pull request changes while somebody else does.
   const pulls = await installPulls(ctx);
 
-  const section = await installGitSection(ctx, {
+  // Nothing of git's is drawn in a place of its own any more — every mark is a decoration on a row
+  // the panel already has. What is left is the *reading*, and it still has to be one reading:
+  // whoever polls `git status` has to do it on a timer, because the agent writes files all through
+  // a turn, and having two things poll it is two subprocesses for one answer and two answers for
+  // one question. So this reads, and the footer is told.
+  const repo = await installGitStatus(ctx, {
     pulls,
     onStatus: (status) => void footer(status),
-    // A pull moves HEAD, and the project rows carry a badge built from a different call than the
-    // one the block just refreshed.
+    // A fetch or a pull moves where this checkout stands, and the project rows carry a badge built
+    // from a different call than the one that just refreshed.
     onMoved: () => void decorate(),
   });
-  // What anything moving `HEAD` calls. The block re-reads and hands the answer on, so the footer
-  // follows without this having to know it exists.
-  headMoved = () => void section.refresh();
+  // What anything moving `HEAD` calls. This re-reads and hands the answer on, so the footer follows
+  // without the caller having to know it exists.
+  headMoved = () => void repo.refresh();
 }
 
 // ---------------------------------------------------------------------------
@@ -1304,17 +1317,11 @@ function insideDir(configured: string): string {
  * and a command that swallows both teaches you to run it twice to be sure.
  */
 async function pull(neosh: Neosh, cwd?: string): Promise<void> {
-  neosh.progress("git.pull", "pulling…");
-  try {
-    const summary = await neosh.git.pull(cwd ? { cwd } : undefined);
-    neosh.notify(summary);
-  } catch (e) {
-    // Diverged branches, no remote, auth — git's message names it, and inventing a friendlier one
-    // here would mean guessing which of those it was.
-    neosh.notify(String(e), "error");
-  } finally {
-    neosh.done("git.pull");
-  }
+  // The whole verb lives in `sidebar.ts` now, because it is the same decision from three doors:
+  // `p` on a row, `git.pull` from the palette, and a script calling it by name. It fast-forwards
+  // without asking, names the choice when the branch has gone both ways, and goes and looks when
+  // nothing is waiting — which the block's verb row used to do and this key used not to.
+  await pullRepository(neosh, cwd);
 }
 
 /**

--- a/plugins/builtin/git/package.json
+++ b/plugins/builtin/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/git",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Branch, commit and status, with model-written names and messages you can re-prompt.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/git/sidebar.ts
+++ b/plugins/builtin/git/sidebar.ts
@@ -1,94 +1,57 @@
 /**
- * Where this checkout stands, in the column you are already looking at.
+ * Where this checkout stands — on the row it is about, and nowhere else.
  *
- * The sidebar's own description is "where you are, what changed, and what is answering", and until
- * this block existed it answered two of those three about git and the third not at all: a project
- * row carried a strip of counts, and nothing in the workspace said **which branch** you were on
- * unless the footer happened to have room for it, or offered any way to **get the latest changes**
- * without leaving for a shell.
+ * This file used to draw a block: a `GIT` heading, the branch, what had drifted, and a verb row,
+ * pinned above the projects. It is now the headless half of that — the part that keeps the numbers
+ * true — because the visible half was saying a second time what the panel already says once.
  *
- * # Three facts and one verb
+ * # Why the block went
  *
- * The branch, what has drifted, and what to do about it. The verb is the point: one row whose label
- * is whatever is actually worth pressing right now — `pull 3 commits` when you are behind, `rebase
- * or merge` when the branch has gone both ways, and `check for changes` when there is nothing to
- * say. A panel with a fixed `pull` button that is a no-op nine times out of ten teaches people not
- * to press it.
+ * A project row already carries this. `statParts` puts `✗2 ↓3 ↑1 ~4 ?7` after the name, each fact
+ * in its own colour, and `pulls.ts` puts `#86` after that in the colour of what the pull request
+ * *is* — `Forge.Merged`, `Forge.Open`, `Forge.Draft`, `Forge.Closed`. Both are keyed by the
+ * project's directory, which is a worktree's directory too, so six trees of one checkout each
+ * report their own branch rather than sharing their repository's.
  *
- * # The fetch is the whole reason this is honest
+ * So the block was a fourth and fifth row about **one** of the rows below it. That is worse than
+ * redundant on a column whose whole job is your conversations: it was the *only* thing here that
+ * could disagree with itself, because the block read `git status` for the conversation you were in
+ * while the rows read one per project, on two clocks, and a fetch that moved one moved the other a
+ * beat later. Two answers to one question, on screen at once.
  *
- * `ahead` and `behind` come off `git status --branch`, which compares HEAD with the remote-tracking
- * ref **sitting on this disk**. Drawn without ever fetching, `↓0` means "nothing had arrived as of
- * whenever this checkout last spoke to a remote", which after an afternoon's work is a sentence
- * about breakfast. So this fetches, on a slow timer and when you arrive somewhere, and every number
- * it draws is one it went and asked for. `git.fetch.interval = 0` turns that off for anybody who
- * would rather their workspace never touched the network on its own; the numbers then say when they
- * were last true, which is what the freshness column at the right of the verb row is for.
+ * It was also wrong about scope in a way no amount of drawing fixes: a contribution is
+ * workspace-wide and a conversation is per view, so two panes reading two repositories saw one
+ * block, about whichever conversation the workspace happened to call current. The rows have never
+ * had that problem — a row is about a directory, and there is one of them per directory.
  *
- * # Motion, and where it stops
+ * # What could not go with it
  *
- * A fetch is seconds of nothing on screen against somebody else's server — the one case in this
- * whole file where a still panel and a wedged one are indistinguishable, and therefore the one
- * thing here that is allowed to move. It gets both halves of the workspace's vocabulary: a spinner
- * glyph, so the row changes shape at the edge of vision, and `Git.Fetching`, which sweeps a band
- * along the label the frontend's own clock rather than ours.
+ * **The fetch.** `ahead` and `behind` come off `git status --branch`, which compares HEAD with the
+ * remote-tracking ref **sitting on this disk** — so `↓0` drawn without ever fetching means "nothing
+ * had arrived as of whenever this checkout last spoke to a server", which after an afternoon is a
+ * sentence about breakfast. Deleting the block and keeping the badge would have left every `↓3` in
+ * the panel a claim nothing could make true. So the timer, the arrive-somewhere fetch and
+ * `git.fetch.interval` all stay exactly as they were; they simply have no rows of their own now.
  *
- * Nothing else moves, and the restraint is the design rather than an omission. `↓3 waiting` is news
- * exactly like an unread conversation is news: it is true until you act, it is not *happening*, and
- * a row that blinks about it costs attention every time it changes without ever having anything new
- * to say. Motion here means "something is going on that you cannot see" and it is worth having only
- * because it is never spent on anything else.
+ * **The choice.** A fast-forward asks nothing, and a **diverged** branch is the other thing
+ * entirely: the two answers do different things to your own commits, one of them rewrites them, and
+ * neither is guessable from a row. That picker lived on the block's verb row, which means deleting
+ * the block would have quietly demoted `p` from *name the choice* to *run `git pull` and report
+ * whatever it says about it*. It moved onto the key instead — see {@link pullRepository}, which is
+ * what `p` on any row and `git.pull` from the palette both call now.
  *
- * # It is about the conversation you are in
- *
- * Which is the same scope, and the same compromise, as the branch segment in the footer: a
- * contribution is workspace-wide data and a conversation is per view, so two panes reading two
- * repositories see one block, about whichever conversation the workspace calls current. Fixing that
- * properly means a contribution point that can be answered per view, which is a change to the panel
- * vocabulary rather than to this file.
+ * **The *as of*.** The freshness column — `now`, `12m`, `⚠ offline` — was the block's answer to the
+ * rule that a number about a remote without an as-of is not a number about a remote. What replaces
+ * it is narrower and lives where the numbers do: {@link fetchTrouble} records the checkouts whose
+ * last fetch failed, and the row badge grows one dim `⚠` for those. `now` and `12m` are not worth a
+ * column on a row — a fetch every three minutes is fresh enough that saying so is noise — but
+ * "these numbers are as of whenever the network last worked" is exactly the case you cannot afford
+ * to draw silently.
  */
 
-import { byteLength } from "@neosh/api";
-import type { Disposable, Neosh, PluginContext, PullRequest, RepoStatus } from "@neosh/api";
-import { checksWord, type Pulls, stateHl } from "./pulls.ts";
-import { confirm, onTick, picker, spinnerFrame } from "@neosh/api/ui";
-
-/** The contribution id, and therefore what `on: "custom:git"` names. */
-const SECTION = "git";
-const POINT_SECTION = "sidebar.section";
-const POINT_ACTION = "sidebar.action";
-
-/**
- * How much of the column this block is allowed to be, and the ladder `<Tab>` steps along.
- *
- * The same three-name vocabulary the plan strip uses, for the same reason it has one: a sidebar's
- * rows are its whole job, and a block that is always four rows tall is four rows of somebody's
- * conversations spent on a fact that changes twice an hour. `one` is the answer to the question
- * people actually have — *am I up to date, and what do I press* — and the rest is a keypress away.
- */
-const STYLES = ["one", "full"] as const;
-type Style = (typeof STYLES)[number];
-
-export function styleOf(value: unknown): Style {
-  return STYLES.includes(value as Style) ? (value as Style) : "one";
-}
-
-/** Which glyphs this terminal can be trusted with. */
-interface Glyphs {
-  ascii: boolean;
-}
-
-function marks(g: Glyphs) {
-  return {
-    pull: g.ascii ? "v" : "↓",
-    push: g.ascii ? "^" : "↑",
-    diverged: g.ascii ? "><" : "⇄",
-    check: g.ascii ? "*" : "↻",
-    ok: g.ascii ? "=" : "✓",
-    bad: g.ascii ? "!" : "✗",
-    upstream: g.ascii ? "->" : "→",
-  };
-}
+import type { Neosh, PluginContext, RepoStatus } from "@neosh/api";
+import type { Pulls } from "./pulls.ts";
+import { confirm, picker } from "@neosh/api/ui";
 
 // ---------------------------------------------------------------------------
 // Where a checkout stands, in five columns or fewer per fact
@@ -134,209 +97,254 @@ export function statParts(status: RepoStatus, ascii: boolean): Array<{ text: str
   return parts;
 }
 
+/**
+ * The checkouts whose last fetch did not reach the remote.
+ *
+ * Module state rather than a field on the service, because the thing that *writes* it is the fetch
+ * — which runs for the conversation you are in — and the thing that *reads* it is the row badge,
+ * which is built per project by a different file on a different clock. A `Map` keyed by directory is
+ * the smallest thing both can hold, and an entry is removed the moment a fetch succeeds, so a
+ * network that comes back clears the mark without anybody being told.
+ */
+const fetchTrouble = new Map<string, string>();
+
+/** Whether this checkout's numbers are as of a fetch that failed. */
+export function fetchFailed(cwd: string): boolean {
+  return fetchTrouble.has(cwd);
+}
+
 // ---------------------------------------------------------------------------
-// What the block is currently about
+// Bringing a branch up to date
 // ---------------------------------------------------------------------------
 
 /**
- * What is happening to this repository right now, if anything.
+ * Bring a checkout up to date, by whichever route its state calls for.
  *
- * `null` is the ordinary case and the one with no motion in it. The other two are the only states
- * in this file that animate, and they are both "we are talking to a server and cannot say how long
- * for" — which is the whole licence for motion in this workspace.
+ * Fast-forward is the ordinary case and asks nothing: it adds commits and changes no history, and a
+ * dialog in front of the one verb this exists for is what teaches people to clear dialogs without
+ * reading them. A **diverged** branch is the other thing entirely — the two answers do different
+ * things to your own commits, one of them rewrites them, and neither is guessable from a row. So
+ * that one asks, and it asks by *naming the choice* rather than by offering yes and no to a
+ * question it never stated.
+ *
+ * Nothing waiting is not a failure either. `p` on a row that is level with its remote means "go and
+ * look", because the number it is pointed at is only ever as fresh as the last fetch — so that case
+ * fetches rather than reporting `Already up to date.` about a comparison with this disk.
+ *
+ * It reads its own status rather than being handed one. That is what lets the same function serve
+ * `p` on any row, `git.pull` from the palette and a script calling it by name: the alternative is a
+ * verb that works on the conversation you are in and silently does the wrong repository from a row.
  */
-type Busy = null | "fetching" | "pulling" | "rebasing";
+export async function pullRepository(
+  neosh: Neosh,
+  cwd?: string,
+  opts: { fetched?: boolean } = {},
+): Promise<void> {
+  const where = cwd ? { cwd } : undefined;
+  const status = await neosh.git.status(where).catch(() => null);
+  if (!status) {
+    neosh.notify("not a git repository", "warn");
+    return;
+  }
+  if (!status.repo.upstream) {
+    // A statement rather than a verb: a branch tracking nothing is not behind anything, and there
+    // is no route from here to up-to-date that this key could take on its own.
+    neosh.notify("this branch is not tracking a remote branch", "warn");
+    return;
+  }
+  const { ahead, behind } = status.repo;
+
+  let rebase = false;
+  if (ahead > 0 && behind > 0) {
+    const chosen = await picker(
+      neosh,
+      [
+        {
+          label: "Rebase",
+          detail: `replay your ${count(ahead, "commit")} on top of the ${
+            count(behind, "commit")
+          } that arrived`,
+          value: "rebase",
+        },
+        {
+          label: "Merge",
+          detail: "bring them together in a merge commit, keeping both histories as they are",
+          value: "merge",
+        },
+      ],
+      {
+        title: `${status.repo.branch ?? "HEAD"} has gone both ways`,
+        width: 76,
+      },
+    );
+    if (!chosen) return;
+    rebase = chosen === "rebase";
+  } else if (behind === 0) {
+    // "Nothing waiting" is a claim about the remote-tracking ref **on this disk**, so cold — from
+    // the palette, from a script, from a row nobody has fetched for — it does not mean nothing is
+    // waiting. It means nobody has looked.
+    //
+    // The block never had this problem: it drew from a status it had just fetched, so `behind === 0`
+    // there really was "up to date, and the honest verb is go and look". Moved onto a command that
+    // anyone can call at any moment, that same branch turned `git.pull` into a fetch — the remote's
+    // commits stayed on the remote and the caller was told nothing was there.
+    //
+    // So look, and then do what was asked. Once: the second pass carries `fetched` and stops rather
+    // than fetching again, which is what keeps a repository that is genuinely level from bouncing
+    // between the two halves of this branch.
+    if (opts.fetched) {
+      neosh.notify("already up to date");
+      return;
+    }
+    const fresh = await fetchRepository(neosh, cwd, { loud: true });
+    // Could not reach the remote. `fetchRepository` has already said so and filed it, and guessing
+    // at a pull on top of that would only produce git's version of the same complaint.
+    if (!fresh) return;
+    return await pullRepository(neosh, cwd, { fetched: true });
+  }
+
+  // A rebase replays commits over a tree that is being edited underneath it. git refuses on a dirty
+  // tree anyway, and saying so before spending the round trip is a better answer than git's, which
+  // arrives after the fetch and names a file rather than the decision.
+  if (rebase && status.changes.some((c) => c.staged || c.unstaged)) {
+    if (
+      !(await confirm(neosh, "This working tree has uncommitted changes. Try to rebase anyway?"))
+    ) return;
+  }
+
+  neosh.progress("git.pull", rebase ? "rebasing…" : "pulling…");
+  try {
+    const summary = await neosh.git.pull({ ...(where ?? {}), rebase });
+    // A pull *is* a fetch, so it settles the trouble mark too: whatever these numbers are, they
+    // came off the remote a moment ago.
+    if (cwd) fetchTrouble.delete(cwd);
+    neosh.notify(short(summary));
+  } catch (e) {
+    // git's own message names it — diverged, no remote, an unresolved rebase — and inventing a
+    // friendlier one here would mean guessing which of those it was. Loud: it is the answer to a
+    // key somebody just pressed.
+    neosh.notify(String(e), "error");
+  } finally {
+    neosh.done("git.pull");
+  }
+}
+
+/**
+ * Ask a remote what is new.
+ *
+ * Gated as a write for the *network* rather than for the working tree: nothing in the tree moves,
+ * and it contacts a server and writes refs. Safe on a timer only because the host closes stdin and
+ * unsets every askpass, so no credentials is a failure in a moment rather than a hang nobody can
+ * see — and a failure is **filed**, not announced, because a workspace fetching every three minutes
+ * on a train would otherwise be a toast every three minutes about a network you know is not there.
+ */
+export async function fetchRepository(
+  neosh: Neosh,
+  cwd?: string,
+  opts: { loud?: boolean } = {},
+): Promise<RepoStatus | null> {
+  const where = cwd ? { cwd } : undefined;
+  try {
+    const fresh = await neosh.git.fetch(where);
+    if (cwd) fetchTrouble.delete(cwd);
+    return fresh;
+  } catch (e) {
+    if (cwd) fetchTrouble.set(cwd, short(String(e)));
+    if (opts.loud) neosh.notify(String(e), "error");
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The service
+// ---------------------------------------------------------------------------
 
 interface State {
   /** The checkout being reported on, so a stale answer arriving after a switch is discarded. */
   cwd: string | null;
   status: RepoStatus | null;
   /**
-   * The pull request for the branch this checkout has out, if the forge has one.
-   *
-   * Held rather than looked up at draw time because the lookup crosses a module and a cache, and
-   * this block redraws ten times a second while a fetch is out. Refreshed with the status.
-   */
-  pull: PullRequest | null;
-  busy: Busy;
-  /** When the remote last *answered*, in epoch ms. `null` is "never, this session". */
-  checkedAt: number | null;
-  /**
    * When the remote was last *asked*, answer or not.
    *
-   * Two timestamps because they drive two different things and a failed ask has to move exactly one
-   * of them. `checkedAt` is what the freshness column reports, so a fetch that failed must not
-   * touch it or the row says `now` over numbers that are an hour old. This one is what decides
-   * whether to ask again — and without it a laptop with no network was a fetch attempt every thirty
-   * seconds for ever, because "never succeeded" and "due" were the same question.
+   * Counted from the ask rather than the answer, so a machine with no network settles into one
+   * attempt per interval instead of one per tick for ever — "never succeeded" and "due" were
+   * otherwise the same question.
    */
   askedAt: number | null;
-  /**
-   * What went wrong last time we asked, in git's own words.
-   *
-   * Kept rather than announced. A workspace fetching every three minutes on a train would otherwise
-   * be a toast every three minutes about a network you already know is not there, and the useful
-   * version of that news is one quiet word in a column you are looking at anyway.
-   */
-  error: string | null;
-  /**
-   * What git said about the last pull, and until when to keep saying it.
-   *
-   * A pull that answers `Already up to date.` and one that fast-forwards eleven commits are
-   * different answers, and a button that returns to looking exactly as it did before is a button
-   * you press twice to find out whether the first press worked.
-   */
-  said: { text: string; until: number } | null;
+  /** A fetch is out, so a second one must not start behind it. */
+  busy: boolean;
 }
 
-/** How long a pull's summary stays on the row before the block goes back to its steady state. */
-const SAID_MS = 6000;
-
-export interface GitSection {
-  /** Ask git where we stand and redraw. Call after anything that moves HEAD. */
+export interface GitStatus {
+  /** Ask git where we stand. Call after anything that moves HEAD. */
   refresh(): Promise<void>;
-  /** Contact the remote, then redraw. `loud` reports failure rather than filing it. */
+  /** Contact the remote. `loud` reports failure rather than filing it. */
   fetch(opts?: { loud?: boolean }): Promise<void>;
 }
 
-export interface GitSectionHooks {
+export interface GitStatusHooks {
   /**
    * The working tree, every time it is read — including `null` for "not in a repository".
    *
    * This exists so there is **one** `git status` in the plugin rather than one per thing that draws
    * a branch name. It is a subprocess that stats the whole tree, it has to be re-run every few
-   * seconds because an agent writes files, and the block and the footer segment want exactly the
-   * same answer at exactly the same moments — so the block reads it and everybody else is told.
+   * seconds because an agent writes files, and the footer segment wants exactly the same answer at
+   * exactly the same moments.
    */
   onStatus: (status: RepoStatus | null) => void;
   /**
    * Where this checkout stands has changed, for anything reading it through a *different* call.
    *
-   * The project rows carry a badge built from a `git.status` per project, which nothing above
-   * refreshes — so after a fetch found three commits the block said `↓3` and the row for the very
-   * same directory, two lines below it, said nothing. Two answers to one question, on screen at
-   * once, is worse than either being late.
+   * The project rows carry a badge built from a `git.status` per project, which nothing here
+   * refreshes — so after a fetch found three commits, the row for that very directory would go on
+   * saying nothing until its own clock came round.
    */
   onMoved: () => void;
 }
 
-export async function installGitSection(
+/**
+ * Keep the current checkout's numbers true, and never draw anything.
+ *
+ * What it owns is two clocks and the option that governs the slow one. Everything visible about
+ * git in the sidebar is a decoration on a row somebody else draws, which is the whole point of the
+ * point: this plugin does not import the panel, and a sidebar that is not ours picks up every one
+ * of these marks unchanged.
+ */
+export async function installGitStatus(
   ctx: PluginContext,
-  hooks: GitSectionHooks & {
+  hooks: GitStatusHooks & {
     /**
-     * What the forge knows, so the block can name the pull request for the branch it is drawing.
-     *
-     * Passed in rather than read here because it is a different server on a much slower clock, and
-     * because one cache for the whole plugin is what keeps a repository with six worktrees to one
-     * request rather than seven.
+     * What the forge knows. Passed in rather than read here because it is a different server on a
+     * much slower clock, and one cache for the whole plugin is what keeps a repository with six
+     * worktrees to one request rather than seven.
      */
     pulls: Pulls;
   },
-): Promise<GitSection> {
+): Promise<GitStatus> {
   const { neosh, subscriptions } = ctx;
   await declareOptions(neosh);
 
-  const state: State = {
-    cwd: null,
-    status: null,
-    pull: null,
-    busy: null,
-    checkedAt: null,
-    askedAt: null,
-    error: null,
-    said: null,
-  };
+  const state: State = { cwd: null, status: null, askedAt: null, busy: false };
 
-  /**
-   * Settings, in memory.
-   *
-   * Read once and kept current from `opt.onChange`. The alternative is five round trips per redraw,
-   * and this redraws ten times a second for as long as a fetch is out.
-   */
-  const settings = {
-    on: true,
-    style: "one" as Style,
-    width: 34,
-    ascii: false,
-    interval: 180,
-  };
+  /** Settings, in memory. Read once and kept current from `opt.onChange`. */
+  const settings = { interval: 180 };
   const reload = async () => {
-    const [on, style, width, ascii, interval] = await Promise.all([
-      neosh.opt.get<boolean>("git.sidebar").catch(() => true),
-      neosh.opt.get<string>("git.sidebar.style").catch(() => "one"),
-      neosh.opt.get<number>("sidebar.width").catch(() => 34),
-      neosh.opt.get<boolean>("ui.ascii_only").catch(() => false),
-      neosh.opt.get<number>("git.fetch.interval").catch(() => 180),
-    ]);
-    settings.on = on ?? true;
-    settings.style = styleOf(style);
-    settings.width = width ?? 34;
-    settings.ascii = ascii ?? false;
-    settings.interval = interval ?? 180;
+    settings.interval = (await neosh.opt.get<number>("git.fetch.interval").catch(() => 180)) ?? 180;
   };
   await reload();
-
-  /** What was last contributed, so an unchanged redraw is not a round trip. */
-  let drawn = "";
-  const draw = async () => {
-    if (!settings.on || !state.status) {
-      if (drawn !== "") {
-        drawn = "";
-        await neosh.ext.remove(POINT_SECTION, SECTION).catch(() => {});
-      }
-      return;
-    }
-    const item = section(state, settings, Date.now());
-    // Compared as JSON rather than by identity: this runs on a tick while a fetch is out, and
-    // re-contributing identical rows makes every sidebar in the workspace rebuild its whole list —
-    // cursor, scroll and all — several times a second for a change nobody can see.
-    const key = JSON.stringify(item);
-    if (key === drawn) return;
-    drawn = key;
-    await neosh.ext.contribute(POINT_SECTION, SECTION, item, { priority: -5 }).catch(() => {});
-  };
-
-  /**
-   * The clock, subscribed to only while something is out.
-   *
-   * A block with no motion in it has no reason to be woken ten times a second, and the honest way
-   * to say that is to not be on the clock at all rather than to be on it and return early.
-   */
-  let ticking: Disposable | null = null;
-  const motion = () => {
-    const wanted = state.busy !== null;
-    if (wanted && !ticking) ticking = onTick(() => void draw());
-    else if (!wanted && ticking) {
-      ticking.dispose();
-      ticking = null;
-    }
-  };
-  subscriptions.push({ dispose: () => ticking?.dispose() });
 
   const refresh = async () => {
     const current = await neosh.session.current().catch(() => null);
     const cwd = current?.cwd ?? null;
     if (cwd !== state.cwd) {
-      // A different repository entirely. Everything below is about the last one — including how
-      // long ago it was checked, which drawn against a checkout we have never fetched would be a
-      // freshness column reporting somebody else's freshness.
+      // A different repository entirely. Everything below is about the last one.
       state.cwd = cwd;
       state.status = null;
-      state.checkedAt = null;
       state.askedAt = null;
-      state.error = null;
-      state.said = null;
-      state.pull = null;
     }
     state.status = await neosh.git.status().catch(() => null);
-    // Which pull request this branch is, out of the cache the whole plugin shares. A lookup rather
-    // than a request: whoever holds that cache decides when to ask the forge again, on a clock far
-    // slower than this one.
-    const branch = state.status?.repo.branch;
-    state.pull = cwd && branch ? hooks.pulls.forBranch(cwd, branch) : null;
-    // Everything else that draws a branch name, off the same read. See {@link GitSectionHooks}.
+    // Everything else that draws a branch name, off the same read. See {@link GitStatusHooks}.
     hooks.onStatus(state.status);
-    await draw();
   };
 
   const fetch = async (opts: { loud?: boolean } = {}) => {
@@ -349,209 +357,66 @@ export async function installGitSection(
       if (opts.loud) neosh.notify("this branch is not tracking a remote branch", "warn");
       return;
     }
-    state.busy = "fetching";
+    state.busy = true;
     // Stamped before the attempt, not after it. A fetch that takes forty seconds against an
     // unreachable host and then fails would otherwise be immediately due again.
     state.askedAt = Date.now();
-    motion();
-    await draw();
     try {
-      const fresh = await neosh.git.fetch();
+      const fresh = await fetchRepository(neosh, at ?? undefined, opts);
       // The conversation moved while we were out. Its answer is about a checkout nobody is looking
-      // at, and applying it would put another repository's numbers under this one's branch name.
-      if (at !== state.cwd) return;
+      // at, and applying it would put another repository's numbers under this one's name.
+      if (at !== state.cwd || !fresh) return;
       state.status = fresh;
-      state.checkedAt = Date.now();
-      state.error = null;
-      // A fetch answers with a whole status, and `behind` in it is the number the footer's badge
-      // draws too. Told rather than left to be re-read on the next tick, or the two disagree for
-      // five seconds every time.
       hooks.onStatus(fresh);
-      // And the project rows, which read it through a call of their own and would otherwise say
-      // nothing about a divergence the block two lines above them has just found.
+      // And the project rows, which read it through a call of their own.
       hooks.onMoved();
-    } catch (e) {
-      if (at !== state.cwd) return;
-      state.error = short(String(e));
-      // Loud only when somebody asked. On the timer this is a train going through a tunnel, and the
-      // right amount to say about that is the one dim word the row already carries.
-      if (opts.loud) neosh.notify(String(e), "error");
     } finally {
-      state.busy = null;
-      motion();
-      await draw();
-    }
-  };
-
-  /**
-   * Bring this branch up to date, by whichever route the state calls for.
-   *
-   * Fast-forward is the ordinary case and asks nothing: it adds commits and changes no history, and
-   * a dialog in front of the one button this block exists for is what teaches people to clear
-   * dialogs without reading them. A **diverged** branch is the other thing entirely — the two
-   * answers do different things to your own commits, one of them rewrites them, and neither is
-   * guessable from the row. So that one asks, and it asks by naming the choice rather than by
-   * offering yes and no to a question it never stated.
-   */
-  const pull = async () => {
-    if (state.busy) return;
-    const status = state.status;
-    if (!status) return;
-    if (!status.repo.upstream) {
-      neosh.notify("this branch is not tracking a remote branch", "warn");
-      return;
-    }
-    const { ahead, behind } = status.repo;
-
-    let rebase = false;
-    if (ahead > 0 && behind > 0) {
-      const chosen = await picker(
-        neosh,
-        [
-          {
-            label: "Rebase",
-            detail: `replay your ${count(ahead, "commit")} on top of the ${
-              count(behind, "commit")
-            } that arrived`,
-            value: "rebase",
-          },
-          {
-            label: "Merge",
-            detail: "bring them together in a merge commit, keeping both histories as they are",
-            value: "merge",
-          },
-        ],
-        {
-          title: `${status.repo.branch ?? "HEAD"} has gone both ways`,
-          width: 76,
-        },
-      );
-      if (!chosen) return;
-      rebase = chosen === "rebase";
-    } else if (behind === 0) {
-      // Nothing waiting as of the last fetch — so the useful reading of this key is "go and look",
-      // which is what the row said it would do.
-      await fetch({ loud: true });
-      return;
-    }
-
-    // A rebase replays commits over a tree that is being edited underneath it. git refuses on a
-    // dirty tree anyway, and saying so before spending the round trip is a better answer than
-    // git's, which arrives after the fetch and names a file rather than the decision.
-    if (rebase && status.changes.some((c) => c.staged || c.unstaged)) {
-      if (
-        !(await confirm(
-          neosh,
-          "This working tree has uncommitted changes. Try to rebase anyway?",
-        ))
-      ) return;
-    }
-
-    const at = state.cwd;
-    state.busy = rebase ? "rebasing" : "pulling";
-    motion();
-    await draw();
-    try {
-      const summary = await neosh.git.pull({ rebase });
-      if (at === state.cwd) {
-        state.said = { text: short(summary), until: Date.now() + SAID_MS };
-        // A pull *is* a fetch, so it settles both clocks: the numbers under it came off the remote
-        // a moment ago, and asking again thirty seconds later would be a round trip for nothing.
-        state.checkedAt = Date.now();
-        state.askedAt = state.checkedAt;
-        state.error = null;
-      }
-    } catch (e) {
-      // git's own message names it — diverged, no remote, an unresolved rebase — and inventing a
-      // friendlier one here would mean guessing which of those it was. This one is loud: it is the
-      // answer to a key somebody just pressed.
-      neosh.notify(String(e), "error");
-    } finally {
-      state.busy = null;
-      motion();
-      state.status = await neosh.git.status().catch(() => state.status);
-      await draw();
-      // The branch may have moved, so everything drawing a branch name has to hear about it.
+      state.busy = false;
+      // A failed fetch is news to the badge too: the mark it grows is the only thing left saying
+      // these numbers are as of whenever the network last worked.
       hooks.onMoved();
-      // The summary is on the row for a few seconds and then is not. Nothing else would take it
-      // off, and a block still saying `Fast-forward` an hour later is a block reporting the past
-      // as the present.
-      neosh.timer.after(SAID_MS + 100, () => {
-        if (state.said && state.said.until <= Date.now()) {
-          state.said = null;
-          void draw();
-        }
-      });
     }
   };
 
   // ---- commands -----------------------------------------------------------
   //
-  // Every key below points at one of these by name, so `^Z` lists them, `^K` runs them, `init.ts`
-  // moves them and a script reaches them through `neosh agent run` — the same deal every other verb
-  // in the workspace gets, and the reason none of this needs an escape hatch of its own.
+  // Every verb below is registered by name, so `^Z` lists them, `^K` runs them, `init.ts` moves
+  // them and a script reaches them through `neosh agent run`.
   const cmds: Array<[string, () => Promise<void>, string]> = [
     ["git.fetch", () => fetch({ loud: true }), "Ask the remote what is new"],
     [
-      "git.sidebar.action",
-      () => pull(),
-      "The sidebar's git verb: pull, choose how to reconcile, or go and look",
-    ],
-    [
-      // Copies rather than opens, for the reason on [`pullRow`]: there is no browser capability,
-      // and on the machine a coding agent usually runs on there is no browser either.
+      // Copies rather than opens: there is no browser capability, and on the machine a coding agent
+      // usually runs on there is no browser either.
       "git.pull.copy",
       async () => {
-        const url = state.pull?.url;
-        if (!url) {
+        const branch = state.status?.repo.branch;
+        const pr = state.cwd && branch ? hooks.pulls.forBranch(state.cwd, branch) : null;
+        if (!pr?.url) {
           neosh.notify("no pull request for this branch", "warn");
           return;
         }
-        await neosh.edit.copy(url);
-        neosh.notify(`copied #${state.pull?.number}`);
+        await neosh.edit.copy(pr.url);
+        neosh.notify(`copied #${pr.number}`);
       },
       "Copy the URL of this branch's pull request",
     ],
     [
-      "git.sidebar.cycle",
-      async () => {
-        const next = STYLES[(STYLES.indexOf(settings.style) + 1) % STYLES.length] ?? "one";
-        await neosh.opt.set("git.sidebar.style", next);
-      },
-      "How much of the repository the sidebar shows",
-    ],
-    [
       "git.sidebar.toggle",
       async () => {
-        await neosh.opt.set("git.sidebar", !settings.on);
+        const on = (await neosh.opt.get<boolean>("git.sidebar").catch(() => true)) ?? true;
+        await neosh.opt.set("git.sidebar", !on);
       },
-      "Show or hide the repository block in the sidebar",
+      "Show or hide git's marks on the sidebar's rows",
     ],
   ];
   for (const [name, fn, desc] of cmds) {
     subscriptions.push(await neosh.cmd.register(name, fn, { desc }));
   }
 
-  // `<Tab>` because that is what opens and folds the thing you are standing on everywhere else in
-  // neosh, and `custom:git` so it is a verb about *these* rows — the plan strip wants the same key
-  // on its own, and both are right. Without the scope one of the two silently lost the key.
-  await neosh.ext.contribute(POINT_ACTION, "git.detail", {
-    key: "<Tab>",
-    label: "detail",
-    command: "git.sidebar.cycle",
-    on: `custom:${SECTION}`,
-  }).catch(() => {});
-  subscriptions.push({
-    dispose: () => void neosh.ext.remove(POINT_ACTION, "git.detail").catch(() => {}),
-  });
-
   // ---- keeping it true ----------------------------------------------------
 
   subscriptions.push(neosh.opt.onChange((e) => {
-    if (
-      e.name === "git.sidebar" || e.name === "git.sidebar.style" ||
-      e.name === "sidebar.width" || e.name === "ui.ascii_only" || e.name === "git.fetch.interval"
-    ) void reload().then(draw);
+    if (e.name === "git.fetch.interval") void reload();
   }));
   // Arriving somewhere is the moment its numbers matter and the moment they are most likely stale.
   subscriptions.push(neosh.session.onChange(() =>
@@ -565,12 +430,7 @@ export async function installGitSection(
   // local and cheap. The *fetch* is on its own much slower clock below.
   subscriptions.push(neosh.timer.every(5000, () => void refresh()));
 
-  /**
-   * Whether the remote is due to be asked again. `interval = 0` is never.
-   *
-   * Counted from the last *ask* rather than the last answer, so a machine with no network settles
-   * into one attempt per interval instead of one per tick for ever.
-   */
+  /** Whether the remote is due to be asked again. `interval = 0` is never. */
   const due = () =>
     settings.interval > 0 &&
     (state.askedAt === null || Date.now() - state.askedAt >= settings.interval * 1000);
@@ -599,17 +459,8 @@ async function declareOptions(neosh: Neosh) {
     type: { type: "bool" },
     default: true,
     description:
-      "Show the branch, what has drifted from the remote, and what to press about it at the top " +
-      "of the sidebar.",
-  });
-  await neosh.opt.declare({
-    name: "git.sidebar.style",
-    type: { type: "str" },
-    default: "one",
-    description:
-      "How much of the column the repository block spends. `one` is the branch and one verb; " +
-      "`full` adds the upstream it tracks and the working tree. `<Tab>` on a git row steps " +
-      "between them.",
+      "Mark the sidebar's project rows with what has drifted from the remote, what is dirty, and " +
+      "which pull request the branch is.",
   });
   await neosh.opt.declare({
     name: "git.fetch.interval",
@@ -618,258 +469,10 @@ async function declareOptions(neosh: Neosh) {
     description:
       "Seconds between asking the remote what is new, so that `↓3` means three waiting for you " +
       "rather than three as of whenever this checkout last spoke to a server. 0 never asks on its " +
-      "own, and the sidebar then says how old its numbers are. Only ever the repository of the " +
+      "own, and a row whose last fetch failed is marked. Only ever the repository of the " +
       "conversation you are in, and only when its branch tracks one.",
   });
 }
-
-// ---------------------------------------------------------------------------
-// The rows
-// ---------------------------------------------------------------------------
-
-interface StripRow {
-  text: string;
-  hl?: string;
-  spans?: Array<{ from: number; to: number; hl: string }>;
-  right?: { text: string; hl?: string };
-  command?: string;
-  args?: string[];
-}
-
-interface Settings {
-  style: Style;
-  width: number;
-  ascii: boolean;
-  interval: number;
-}
-
-/**
- * What the sidebar is handed.
- *
- * Two rows in `one`: what you are on, and what to do about it. The second is not decoration — it is
- * the only route in this workspace to `git pull` that does not involve leaving for a shell, and its
- * label is rebuilt from the state every draw so that the key is never pointed at something that
- * would do nothing.
- */
-function section(state: State, settings: Settings, now: number) {
-  const status = state.status;
-  if (!status) return null;
-  const g = marks({ ascii: settings.ascii });
-  const rows: StripRow[] = [];
-  // What the sidebar leaves for our text: its own one-column margin at each edge, the margin
-  // `sectionRows` adds, and the widest freshness column — which is drawn *over* the row rather than
-  // after it, so a row built to the full width does not wrap, it collides.
-  const room = Math.max(12, settings.width - 4 - 6);
-
-  // ---- the branch --------------------------------------------------------
-  //
-  // The one fact this block exists for, and the one nothing else in the workspace reliably says:
-  // the footer's branch segment is the first thing dropped when the terminal is narrow.
-  const head = status.repo.detached
-    ? `detached ${status.repo.head ?? ""}`.trim()
-    : (status.repo.branch ?? "no branch");
-  const stats = statParts(status, settings.ascii);
-  const statText = stats.map((p) => p.text).join("");
-  // The name yields to the counts rather than the other way round — the same bargain a decorated
-  // row makes, and for the same reason: a branch clipped to `fix/composer-pas…` is still the branch
-  // you recognise, and `↓3` with a digit missing is a lie.
-  const name = clip(head, Math.max(6, room - cells(statText) - 1));
-  const branchText = statText === "" ? name : `${name} ${statText}`;
-  let at = byteLength(name) + 1;
-  const spans: Array<{ from: number; to: number; hl: string }> = [];
-  for (const part of stats) {
-    const to = at + byteLength(part.text);
-    if (part.hl) spans.push({ from: at, to, hl: part.hl });
-    at = to;
-  }
-  rows.push({
-    text: branchText,
-    hl: "Git.Branch",
-    spans: spans.length > 0 ? spans : undefined,
-    // Every row in the block opens the status float, so there is no row here you can land on and
-    // press `↵` on to no effect — which is the thing that teaches people a column is not interactive.
-    command: "git.status",
-  });
-
-  // ---- the pull request --------------------------------------------------
-  //
-  // In **both** styles when there is one, unlike everything else that `full` adds. It is the one
-  // row here that is not derivable from this disk — the branch, the counts and the working tree are
-  // all things you could have worked out, and whether anybody has reviewed your work is not — and
-  // it costs a row only on the branches that have one, which is never the busy case.
-  if (state.pull) rows.push(pullRow(state.pull, room, settings.ascii));
-
-  if (settings.style === "full") {
-    rows.push({
-      text: `${g.upstream} ${clip(status.repo.upstream ?? "no upstream", room - 2)}`,
-      hl: status.repo.upstream ? "Comment" : "Git.Synced",
-      command: "git.status",
-    });
-    rows.push(workingTreeRow(status, room, settings.ascii));
-  }
-
-  rows.push(verbRow(state, settings, now, room, g));
-  return { title: "GIT", hint: "^G", before: "projects", rows };
-}
-
-/**
- * The pull request this branch is, and what its checks say.
- *
- * `#86 open` with the state's colour on the whole row, and the checks on the right — where the
- * freshness column sits on the verb row, because both answer "how much should I trust this". The
- * check word is dropped entirely when there are no checks configured: a repository that runs none
- * has told you nothing, and "checks passing" over it would be a sentence nobody wrote.
- *
- * `↵` copies the URL. Not *opens* it: neosh has no browser capability and inventing one for this
- * would be a new outward-facing verb for a row — and on the machine this most often runs on, a big
- * one over SSH, opening a browser would open it in the wrong place anyway. Copying reaches the
- * laptop you are sitting at, which is the same reason the clipboard is OSC 52.
- */
-function pullRow(pr: PullRequest, room: number, ascii: boolean): StripRow {
-  const said = checksWord(pr, ascii);
-  // The right column is measured out of the room first, as everywhere else in this block: it is
-  // drawn *over* the row rather than after it, so a row built to the full width collides with it.
-  const right = said ? { text: said, hl: checksHl(pr) } : undefined;
-  const label = `#${pr.number} ${pr.state}`;
-  return {
-    text: clip(label, Math.max(8, room - (said ? cells(said) + 1 : 0))),
-    hl: stateHl(pr.state),
-    right,
-    command: "git.pull.copy",
-  };
-}
-
-/** The colour of what the checks say. Nothing to say is the row's own colour rather than a third. */
-function checksHl(pr: PullRequest): string {
-  switch (pr.checks) {
-    case "failing":
-      return "Forge.ChecksFailed";
-    case "pending":
-      return "Forge.ChecksRunning";
-    default:
-      return "Sidebar.Dim";
-  }
-}
-
-/**
- * The working tree, in words rather than in the counts the branch row already carries.
- *
- * `~4 ?1` is on the row above and is a glance; this is the sentence, and it says the one thing the
- * counts cannot — whether any of it is *staged*, which is the difference between a tree you can
- * commit from and one you have to think about first.
- */
-function workingTreeRow(status: RepoStatus, room: number, ascii: boolean): StripRow {
-  const staged = status.changes.filter((c) => c.staged).length;
-  const total = status.changes.length;
-  if (total === 0) {
-    return { text: `${ascii ? "=" : "✓"} clean`, hl: "Git.Synced", command: "git.status" };
-  }
-  const said = staged === 0
-    ? `${count(total, "change")}, none staged`
-    : staged === total
-    ? `${count(total, "change")}, all staged`
-    : `${count(total, "change")}, ${staged} staged`;
-  return { text: clip(said, room), hl: "Git.Modified", command: "git.status" };
-}
-
-/**
- * The one row that does something, labelled with whatever is actually worth doing.
- *
- * A fixed `pull` that is a no-op most of the time is a button people learn to ignore; this one says
- * `pull 3 commits` when there are three, names the choice when the branch has gone both ways, and
- * offers to go and look when there is nothing waiting — which is the honest verb for a number that
- * is only as fresh as the last fetch.
- */
-function verbRow(
-  state: State,
-  settings: Settings,
-  now: number,
-  room: number,
-  g: ReturnType<typeof marks>,
-): StripRow {
-  const command = "git.sidebar.action";
-
-  // Working. The only rows here that move, and they move because there is a server at the other end
-  // of them and no way to say how long it will take.
-  if (state.busy) {
-    const said = state.busy === "fetching"
-      ? "checking the remote…"
-      : state.busy === "rebasing"
-      ? "rebasing…"
-      : "pulling…";
-    // Still landable, and still pointed at the same command — which declines while something is
-    // out. A row that goes inert under the cursor is a row the cursor is pushed off, so pressing
-    // the button would move you somewhere else for as long as the button was working.
-    return { text: `${spinnerFrame()} ${clip(said, room - 2)}`, hl: "Git.Fetching", command };
-  }
-
-  // What just happened, for a few seconds. A button that goes back to looking exactly as it did is
-  // one you press twice to find out whether the first press worked.
-  if (state.said && state.said.until > now) {
-    return {
-      text: `${g.ok} ${clip(state.said.text, room - 2)}`,
-      hl: "Status.Done",
-      command,
-    };
-  }
-
-  const status = state.status;
-  const { ahead, behind } = status?.repo ?? { ahead: 0, behind: 0 };
-  const freshness = { text: freshText(state, settings, now), hl: "Sidebar.Dim" };
-
-  if (!status?.repo.upstream) {
-    // Not a failure and not something to fix — plenty of branches track nothing. Said quietly, and
-    // pointed at the status rather than at a verb that would only refuse: there is nothing to pull
-    // from, and a button whose whole behaviour is an apology is worse than a sentence.
-    return { text: `${g.upstream} no upstream`, hl: "Git.Synced", command: "git.status" };
-  }
-  if (ahead > 0 && behind > 0) {
-    return {
-      text: `${g.diverged} ${clip(`diverged — ${ahead} up, ${behind} down`, room - 2)}`,
-      hl: "Git.Diverged",
-      right: freshness,
-      command,
-    };
-  }
-  if (behind > 0) {
-    return {
-      text: `${g.pull} ${clip(`pull ${count(behind, "commit")}`, room - 2)}`,
-      hl: "Git.Behind",
-      right: freshness,
-      command,
-    };
-  }
-  return {
-    text: `${g.check} ${clip("check for changes", room - 2)}`,
-    hl: "Git.Synced",
-    right: freshness,
-    command,
-  };
-}
-
-/**
- * How old the numbers beside it are.
- *
- * The column that makes the block honest rather than merely confident. `↓0` is a claim about a
- * remote, and a claim about a remote has an *as of* — without one, a panel that has not fetched
- * since Tuesday and one that fetched nine seconds ago draw the same row. `offline` is what a failed
- * ask looks like: the same shape as an age, because what it is saying is the same thing — the
- * numbers are older than they look.
- */
-function freshText(state: State, settings: Settings, now: number): string {
-  if (state.error) return settings.ascii ? "offline" : "⚠ offline";
-  if (state.checkedAt === null) return settings.interval > 0 ? "…" : "never";
-  const secs = Math.max(0, Math.round((now - state.checkedAt) / 1000));
-  if (secs < 45) return "now";
-  const mins = Math.round(secs / 60);
-  if (mins < 60) return `${mins}m`;
-  const hours = Math.round(mins / 60);
-  return hours < 48 ? `${hours}h` : `${Math.round(hours / 24)}d`;
-}
-
-// ---------------------------------------------------------------------------
-// Small things
-// ---------------------------------------------------------------------------
 
 /** `1 commit`, `3 commits`. A row that says `1 commits` is a row somebody stopped proofreading. */
 function count(n: number, noun: string): string {
@@ -877,26 +480,10 @@ function count(n: number, noun: string): string {
 }
 
 /**
- * Code points, not display width.
- *
- * That question is `neosh-tui`'s and is not answerable here. What this pads and clips are branch
- * names and short English phrases, and the alternative is a `.length` in UTF-16 units that
- * disagrees with the clip applied to the same string.
- */
-function cells(s: string): number {
-  return [...s].length;
-}
-
-function clip(s: string, n: number): string {
-  const chars = [...s];
-  return chars.length <= Math.max(1, n) ? s : `${chars.slice(0, Math.max(1, n - 1)).join("")}…`;
-}
-
-/**
  * One line of whatever git or the host said.
  *
- * Errors arrive as several lines with a prefix on them and summaries arrive as a sentence; a row is
- * one line either way, and the first line is the one that names the thing.
+ * Errors arrive as several lines with a prefix on them and summaries arrive as a sentence; a
+ * notification is one line either way, and the first line is the one that names the thing.
  */
 function short(text: string): string {
   const first = text.split("\n").map((l) => l.trim()).find((l) => l !== "") ?? text;

--- a/plugins/builtin/model/package.json
+++ b/plugins/builtin/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/model",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Model and reasoning-effort switchers, in the status line and behind a picker.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/palette/package.json
+++ b/plugins/builtin/palette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/palette",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "One key to everything: commands, conversations, and what they are bound to.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/questions/package.json
+++ b/plugins/builtin/questions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/questions",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Draws the question an agent asks you, and sends back what you said.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/sidebar/package.json
+++ b/plugins/builtin/sidebar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/sidebar",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A docked panel: where you are, what changed, and what is answering.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/slash/package.json
+++ b/plugins/builtin/slash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/slash",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Type / to reach a command \u2014 neosh's own, and whatever the driver says it accepts.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/titles/package.json
+++ b/plugins/builtin/titles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/titles",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Names a conversation after what it turned out to be about.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/update/package.json
+++ b/plugins/builtin/update/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/update",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Says when there is a newer neosh, and becomes it.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/usage/package.json
+++ b/plugins/builtin/usage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/usage",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "How full the context window is, what the conversation has cost, and what the plan has left.",
   "license": "MIT",
   "type": "module",

--- a/website/src/pages/docs/options.md
+++ b/website/src/pages/docs/options.md
@@ -89,8 +89,7 @@ The last two are the window prefix and how long you have to hold it before it li
 
 | Option | Default | Effect |
 | --- | --- | --- |
-| `git.sidebar` | `true` | The branch, what has drifted from the remote, and the one key that does something about it, at the top of the sidebar |
-| `git.sidebar.style` | `"one"` | `one` is the branch and one verb; `full` adds the upstream it tracks and the working tree. `⇥` on a git row steps between them |
+| `git.sidebar` | `true` | Mark each project row with what has drifted from the remote, what is dirty, and which pull request its branch is |
 | `git.fetch.interval` | `180` | Seconds between asking the remote what is new, so `↓3` means three waiting for you rather than three as of whenever this checkout last spoke to a server. `0` never asks on its own, and the block then says how old its numbers are. Only the repository of the conversation you are in, and only when its branch tracks one |
 
 | `git.pulls` | `true` | The pull request on a project or worktree row: its number, its state, and its checks when they are failing or still running. Asks `gh`, so it needs the GitHub CLI signed in |


### PR DESCRIPTION
Removes the `GIT` block from the sidebar. What it drew is on the project and worktree rows, where the repository already is.

## Why it went

It was saying a second time what the row below it already said. `statParts` has always put `✗2 ↓3 ↑1 ~4 ?7` after a project's name, each fact in its own colour, and `pulls.ts` has always put `#86` after that in the colour of what the pull request *is* — `Forge.Merged`, `Forge.Open`, `Forge.Draft`, `Forge.Closed`. So the block was a fourth and fifth row about **one** of the rows underneath it, on a column whose whole job is your conversations.

It was also the only thing here that could disagree with itself: the block read `git status` for the conversation you were in while the rows read one per project, on a different clock, so a fetch moved one a beat before the other. And a contribution is workspace-wide while a conversation is per view — two panes on two repositories saw one block, about whichever conversation the workspace happened to call current. A row about a directory has never had either problem.

```
 ▾ neosh ↓3 ~1 ?1  #86 ✗2       4
   ▾ ⎇ fix/the-thing ↑2  #91     1
```

## What could not go with it, and did not

- **The fetch.** `ahead`/`behind` compare HEAD with the remote-tracking ref *on this disk*. Delete the block and keep the badge and every `↓3` becomes a claim nothing can make true. Timer, arrive-somewhere fetch and `git.fetch.interval` unchanged — they just have no rows of their own now.
- **The choice.** `p` used to run `git pull` and report whatever came back, so *rebase or merge* lived only on the block's verb row. `pullRepository` is the whole verb now, and `p`, the palette and a script are its three doors.
- **The *as of*.** `Git.Stale` — a dim `⚠` appended when the last fetch did not reach the remote. It qualifies the numbers rather than replacing them. `now`/`12m` were not worth a column; unreachable is.

## A bug the block was hiding

Moving the verb exposed it. `behind === 0` meant "up to date, so the honest verb is go and look" — true for the block, which always drew from a status it had just fetched. On a command anyone can call cold it means "nobody has looked yet", so `git.pull` from the palette **fetched and reported nothing waiting while the remote's commits sat on the remote**. Caught by `pulling_brings_the_remote_changes_into_the_checkout`. It now looks, then does what was asked, once.

## Verification

- 210 passed / 2 failed — the 2 are the known macOS `/var` vs `/private/var` comparisons that pass on Linux
- `cargo test -p neosh-core` green, including the palette's still-groups assertion for `Git.Stale`
- Bindings in sync, `tsc` clean in `plugins/api` and `plugins/builtin`
- Screenshotted: `▾ work ~1`, name in `a5b4fc` and `~1` in amber `fcd34d` — each fact keeps its own colour

Also replaces the regression test from #98, which waited for the git block to name a branch: that block no longer exists, so it now tests `projects_now()` directly. Merging without waiting for CI at the author's request.