### PR TITLE
test(slash): opening the menu is not the whole success condition

### DIFF
--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -5366,10 +5366,23 @@ fn open_slash_menu(s: &mut Session) {
     for _ in 0..20 {
         s.type_text("/");
         s.drain_for(Duration::from_millis(150));
-        if s.buffer_named("[Run]").is_some() {
+        // Both halves, and the second is what this used to get wrong. The menu opening is not the
+        // whole success condition: the backspace below races the very `/` that opens it, so an
+        // attempt that timed out at 150ms and then had the menu appear anyway left the slash in the
+        // field *and* the menu up — and the next attempt's `/` landed on top of it. The composer
+        // then held `//`, the test typed `compact` after it, and the failure was
+        // `//compact` in a test about what the composer says.
+        //
+        // Asking about the field rather than lengthening the timeout, because no timeout fixes a
+        // race — a slower machine just moves it.
+        if s.buffer_named("[Run]").is_some()
+            && s.pump(|s| s.composer_now().iter().any(|l| l == "/"))
+        {
             return;
         }
-        s.special("backspace");
+        // `^U` rather than one backspace: what needs clearing is however many slashes got through,
+        // which is exactly the number this loop cannot know.
+        s.ctrl("u");
         s.drain_for(Duration::from_millis(50));
     }
     panic!("the slash menu never opened\n{}", s.transcript());


### PR DESCRIPTION
`a_command_the_menu_has_never_heard_of_is_sent_to_the_agent_as_typed` failed on main at `09790a67` with `["//compact"]` — two slashes, in a test about what the composer says.

Not the change under it. `open_slash_menu` types `/`, waits 150 ms for the `[Run]` buffer, and backspaces if it has not appeared. That backspace races the very slash that opens the menu: an attempt which timed out and *then* had the menu appear left the slash in the field **and** the menu up, so the next attempt's `/` landed on top of it.

The loop now asks about the field as well as the buffer — menu open over a composer holding exactly `/` is the state it was always trying to reach — and clears with `^U` rather than a single backspace, because what needs removing is however many slashes got through, which is exactly the number this loop cannot know.

Asking about the state rather than lengthening the timeout: no timeout fixes a race, a slower machine just moves it.

Test-only, so no release — the v0.4.3 binaries are unaffected. Verified 5/5 in isolation.