### PR TITLE
test(slash): trim the extra slash, and never wait on a predicate that can stay false

### DIFF
--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -5366,23 +5366,27 @@ fn open_slash_menu(s: &mut Session) {
     for _ in 0..20 {
         s.type_text("/");
         s.drain_for(Duration::from_millis(150));
-        // Both halves, and the second is what this used to get wrong. The menu opening is not the
-        // whole success condition: the backspace below races the very `/` that opens it, so an
-        // attempt that timed out at 150ms and then had the menu appear anyway left the slash in the
-        // field *and* the menu up — and the next attempt's `/` landed on top of it. The composer
-        // then held `//`, the test typed `compact` after it, and the failure was
-        // `//compact` in a test about what the composer says.
-        //
-        // Asking about the field rather than lengthening the timeout, because no timeout fixes a
-        // race — a slower machine just moves it.
-        if s.buffer_named("[Run]").is_some()
-            && s.pump(|s| s.composer_now().iter().any(|l| l == "/"))
-        {
+        if s.buffer_named("[Run]").is_some() {
+            // The menu can open from a slash this loop had already given up on — the backspace
+            // below races the very keystroke that opens it — which leaves the field holding *two*
+            // slashes and the menu up. The tests after this then type into that, and the failure is
+            // `//compact` in a test about what the composer says.
+            //
+            // So trim, rather than trusting the count. Bounded and drain-only: `pump` waits the
+            // full 30s `BUDGET` when its predicate is false, and a predicate that can stay false —
+            // which this one can, because once the menu is up a typed `/` goes to its filter and
+            // never reaches the composer — turns twenty retries into ten minutes and then fails
+            // anyway. That is exactly what the first attempt at this did to CI.
+            for _ in 0..4 {
+                if s.composer_now().iter().any(|l| l == "/") {
+                    return;
+                }
+                s.special("backspace");
+                s.drain_for(Duration::from_millis(50));
+            }
             return;
         }
-        // `^U` rather than one backspace: what needs clearing is however many slashes got through,
-        // which is exactly the number this loop cannot know.
-        s.ctrl("u");
+        s.special("backspace");
         s.drain_for(Duration::from_millis(50));
     }
     panic!("the slash menu never opened\n{}", s.transcript());


### PR DESCRIPTION
Fixes my own #100, which made this worse rather than better.

**The bug is real and unchanged.** The menu can open from a slash `open_slash_menu` had already given up on — the backspace races the keystroke that opens it — leaving the field holding two slashes with the menu up. The tests after it type into that: `//compact`, in a test about what the composer says.

**What #100 got wrong was the remedy.** It made success `[Run]` present *and* `pump(composer == "/")`. `pump` waits the full 30 s `BUDGET` when its predicate is false — and that predicate can stay false for ever, because once the menu is up a typed `/` goes to its filter and never reaches the composer, so `^U` cleared the field and nothing ever put a slash back. Twenty retries × 30 s turned a 171 s suite into **681 s** and then failed anyway with "the slash menu never opened".

**This trims instead of re-typing**: bounded at four backspaces, drain-only, no `pump`. Worst case four 50 ms drains rather than ten minutes.

The general rule, now in the comment: `pump` is for a condition the workspace will reach on its own. One that depends on a key going somewhere it may no longer go is not, and waiting on it is how a test spends its entire budget being wrong.

## Verification

- The test passes 3/3 in ~1.7 s (was 30 s+ per retry)
- Full suite 94 s — the 681 s regression is gone — with only the two known macOS `/var` vs `/private/var` failures that pass on Linux