### PR TITLE
fix(update): the command we print has to be one that actually updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "neosh"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2433,7 +2433,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-agent"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "futures",
@@ -2452,7 +2452,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-core"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "insta",
  "neosh-proto",
@@ -2467,14 +2467,14 @@ dependencies = [
 
 [[package]]
 name = "neosh-plugins"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "include_dir",
 ]
 
 [[package]]
 name = "neosh-proto"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-provider"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-script"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "deno_ast",
@@ -2530,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-swarm"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-syntax"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "syntect",
  "two-face",
@@ -2553,7 +2553,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-tui"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "crossterm",
  "futures",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-vcs"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "neosh-proto",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 rust-version = "1.90"
 license = "MIT"
@@ -27,16 +27,16 @@ homepage = "https://github.com/neoswarm/neosh"
 # Every one of these carries a `version` as well as a `path`: cargo refuses to package a crate whose
 # dependency has only a path, and the published crate is built against the registry version while
 # a checkout is built against the directory next door.
-neosh-proto = { path = "crates/neosh-proto", version = "0.4.3" }
-neosh-core = { path = "crates/neosh-core", version = "0.4.3" }
-neosh-provider = { path = "crates/neosh-provider", version = "0.4.3" }
-neosh-vcs = { path = "crates/neosh-vcs", version = "0.4.3" }
-neosh-swarm = { path = "crates/neosh-swarm", version = "0.4.3" }
-neosh-agent = { path = "crates/neosh-agent", version = "0.4.3" }
-neosh-script = { path = "crates/neosh-script", version = "0.4.3" }
-neosh-tui = { path = "crates/neosh-tui", version = "0.4.3" }
-neosh-syntax = { path = "crates/neosh-syntax", version = "0.4.3" }
-neosh-plugins = { path = "plugins", version = "0.4.3" }
+neosh-proto = { path = "crates/neosh-proto", version = "0.4.4" }
+neosh-core = { path = "crates/neosh-core", version = "0.4.4" }
+neosh-provider = { path = "crates/neosh-provider", version = "0.4.4" }
+neosh-vcs = { path = "crates/neosh-vcs", version = "0.4.4" }
+neosh-swarm = { path = "crates/neosh-swarm", version = "0.4.4" }
+neosh-agent = { path = "crates/neosh-agent", version = "0.4.4" }
+neosh-script = { path = "crates/neosh-script", version = "0.4.4" }
+neosh-tui = { path = "crates/neosh-tui", version = "0.4.4" }
+neosh-syntax = { path = "crates/neosh-syntax", version = "0.4.4" }
+neosh-plugins = { path = "plugins", version = "0.4.4" }
 
 # async
 tokio = { version = "1.53", features = ["rt", "rt-multi-thread", "macros", "sync", "time", "process", "io-util", "fs", "signal", "net"] }

--- a/crates/neosh-proto/src/api.rs
+++ b/crates/neosh-proto/src/api.rs
@@ -2210,7 +2210,21 @@ impl InstallMethod {
     /// The command that updates this install, for the kinds neosh will not do itself.
     pub fn upgrade_command(self) -> Option<&'static str> {
         match self {
-            Self::Homebrew => Some("brew upgrade neosh"),
+            // `brew update` first, and it is not politeness — it is the difference between this
+            // command working and this command lying.
+            //
+            // Homebrew reads formulae out of a git clone of the tap on this disk, and it only
+            // refreshes that clone on its own every `HOMEBREW_AUTO_UPDATE_SECS` — 24 hours by
+            // default. So for the whole first day of a release, which is exactly when somebody is
+            // told there is one, `brew upgrade neosh` consults a stale clone and answers that the
+            // version they already have is the newest there is. Reported from a real machine: the
+            // tap had 0.4.3, `brew upgrade neosh` said 0.4.2 was current, and the only thing wrong
+            // was the command we had printed.
+            //
+            // The other two do not need it. npm resolves `@latest` against the registry on every
+            // install, and cargo refreshes its index as part of `install`; only Homebrew keeps
+            // metadata on disk and ages it.
+            Self::Homebrew => Some("brew update && brew upgrade neosh"),
             Self::Npm => Some("npm install -g neosh@latest"),
             Self::Cargo => Some("cargo install neosh --force"),
             Self::Standalone | Self::Development => None,

--- a/crates/neosh/src/update.rs
+++ b/crates/neosh/src/update.rs
@@ -795,4 +795,34 @@ mod tests {
         assert!(!InstallMethod::Development.self_updatable());
         assert!(InstallMethod::Development.upgrade_command().is_none());
     }
+
+    /// The command we print has to be one that actually updates.
+    ///
+    /// Homebrew resolves formulae out of a git clone of the tap **on this disk** and only refreshes
+    /// it every `HOMEBREW_AUTO_UPDATE_SECS` — 24 hours by default. So for the first day of a
+    /// release, which is precisely when somebody has been told there is one, a bare
+    /// `brew upgrade neosh` reads a stale clone and reports that the version they already have is
+    /// the newest published. That happened: the tap had 0.4.3, brew said 0.4.2 was current, and the
+    /// only thing wrong was the string in this file — `docs/releasing.md` had described the caching
+    /// all along.
+    ///
+    /// Asserted on the *content* rather than on equality, so rewording the command is free and
+    /// dropping the refresh is not.
+    #[test]
+    fn the_homebrew_command_refreshes_the_tap_before_it_upgrades() {
+        let brew = InstallMethod::Homebrew.upgrade_command().expect("homebrew names a command");
+        assert!(brew.contains("brew update"), "must refresh the tap clone first: {brew}");
+        assert!(brew.contains("brew upgrade"), "and then upgrade: {brew}");
+        assert!(
+            brew.find("brew update") < brew.find("brew upgrade"),
+            "and in that order, or the upgrade still reads the stale clone: {brew}"
+        );
+        // The other two resolve against the network on every run — npm against the registry for
+        // `@latest`, cargo against its index as part of `install` — so neither needs a refresh
+        // step, and adding one would be cargo-culting this fix onto tools that never had the bug.
+        for m in [InstallMethod::Npm, InstallMethod::Cargo] {
+            let c = m.upgrade_command().expect("names a command");
+            assert!(!c.contains("&&"), "{m:?} needs no refresh step: {c}");
+        }
+    }
 }

--- a/npm/neosh/package.json
+++ b/npm/neosh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neosh",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Neovim for controlling AI agents. A terminal workspace where every feature is a plugin.",
   "license": "MIT",
   "bin": {
@@ -32,9 +32,9 @@
     "!._*"
   ],
   "optionalDependencies": {
-    "@neosh/cli-darwin-arm64": "0.4.3",
-    "@neosh/cli-darwin-x64": "0.4.3",
-    "@neosh/cli-linux-x64": "0.4.3",
-    "@neosh/cli-linux-arm64": "0.4.3"
+    "@neosh/cli-darwin-arm64": "0.4.4",
+    "@neosh/cli-darwin-x64": "0.4.4",
+    "@neosh/cli-linux-x64": "0.4.4",
+    "@neosh/cli-linux-arm64": "0.4.4"
   }
 }

--- a/plugins/api/package.json
+++ b/plugins/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/api",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "The neosh plugin API. Types are generated from the Rust side and drift-checked in CI.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/approvals/package.json
+++ b/plugins/builtin/approvals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/approvals",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Asks before the agent does something the policy says to ask about.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/archive/package.json
+++ b/plugins/builtin/archive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/archive",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "What you have finished with: a panel to find it in, and the verbs that empty it.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/git/package.json
+++ b/plugins/builtin/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/git",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Branch, commit and status, with model-written names and messages you can re-prompt.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/model/package.json
+++ b/plugins/builtin/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/model",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Model and reasoning-effort switchers, in the status line and behind a picker.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/palette/package.json
+++ b/plugins/builtin/palette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/palette",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "One key to everything: commands, conversations, and what they are bound to.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/questions/package.json
+++ b/plugins/builtin/questions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/questions",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Draws the question an agent asks you, and sends back what you said.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/sidebar/package.json
+++ b/plugins/builtin/sidebar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/sidebar",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "A docked panel: where you are, what changed, and what is answering.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/slash/package.json
+++ b/plugins/builtin/slash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/slash",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Type / to reach a command \u2014 neosh's own, and whatever the driver says it accepts.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/titles/package.json
+++ b/plugins/builtin/titles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/titles",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Names a conversation after what it turned out to be about.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/update/main.ts
+++ b/plugins/builtin/update/main.ts
@@ -262,7 +262,25 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
 
   subscriptions.push(
     await neosh.cmd.register(`${NS}.apply`, async () => {
+      // Raised and *always* cleared. A progress notice is keyed and replaced in place because it is
+      // a **state**, so one that is never `done` is a state with no end: `Updating neosh…` sat
+      // there, and the reply that followed it — including the one naming the command a managed
+      // install needs — never got a look in. From the keyboard that is the whole bug in a sentence:
+      // `/update` says "updating…", the row goes, and nothing has happened or been said.
+      //
+      // `finally`, not a call per branch. Every arm of the switch below returns, and one added
+      // later that forgets would put the hang straight back.
       neosh.progress(`${NS}`, "Updating neosh…");
+      try {
+        return await applyUpdate();
+      } finally {
+        neosh.done(`${NS}`);
+      }
+    }, { desc: "Update neosh to the newest version" }),
+  );
+
+  async function applyUpdate() {
+    {
       const outcome = await neosh.update.apply().catch((e) => ({
         outcome: "failed" as const,
         reason: String(e),
@@ -288,12 +306,17 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
           // ends up in a state its owner cannot explain. What *is* now true is that running it is
           // the whole of the job: the next tick notices the binary changed and offers the restart,
           // so nobody has to know a workspace needs one.
+          //
+          // The command is the host's and carries whatever that install method actually needs —
+          // for Homebrew that is `brew update` before the upgrade, because brew reads a tap clone
+          // it only refreshes daily, and the bare upgrade spends the first day of a release saying
+          // the old version is the newest one.
           return neosh.notify(`Update with: ${outcome.command}`, "info");
         default:
           return neosh.notify(`Update failed: ${outcome.reason}`, "error");
       }
-    }, { desc: "Update neosh to the newest version" }),
-  );
+    }
+  }
 
   subscriptions.push(
     await neosh.cmd.register(`${NS}.restart`, async () => void (await restart()), {

--- a/plugins/builtin/update/package.json
+++ b/plugins/builtin/update/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/update",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Says when there is a newer neosh, and becomes it.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/usage/package.json
+++ b/plugins/builtin/usage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/usage",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "How full the context window is, what the conversation has cost, and what the plan has left.",
   "license": "MIT",
   "type": "module",

--- a/website/src/pages/docs/installation.md
+++ b/website/src/pages/docs/installation.md
@@ -67,7 +67,7 @@ neosh paths    # where config, data and state live on this machine
 
 ## Updating
 
-Re-run the install script, or `brew upgrade neosh`, or re-run the `cargo install` command. Each replaces the binary in place. A workspace that is already running keeps executing the old binary until you stop it; the terminal tells you when the two have drifted.
+Re-run the install script, or `brew update && brew upgrade neosh`, or re-run the `cargo install` command. (The `brew update` is not optional: Homebrew reads formulae from a clone of the tap on your disk and only refreshes it once a day, so a bare `brew upgrade` spends the first day of a release insisting the version you have is the newest one.) Each replaces the binary in place. A workspace that is already running keeps executing the old binary until you stop it; the terminal tells you when the two have drifted.
 
 ## Uninstalling
 


### PR DESCRIPTION
Two bugs, reported together from a real machine, and they compound: `/update` said `Updating neosh…`, the row vanished, nothing happened — and the command it was trying to name would not have worked either.

## `brew upgrade neosh` is not enough

Homebrew resolves formulae out of a git clone of the tap **on this disk**, and refreshes it on its own only every `HOMEBREW_AUTO_UPDATE_SECS` — 24 hours by default. So for the first day of a release, exactly when somebody has been told there is one, the bare upgrade reads a stale clone and reports the version they already have as the newest published.

Observed: the tap had `0.4.3`, `brew upgrade neosh` insisted `0.4.2` was current, and the only thing wrong was the string in `api.rs`. `docs/releasing.md` had described this caching all along — the knowledge was in the repository and the code did not have it.

npm and cargo are untouched: `@latest` resolves against the registry every time, and cargo refreshes its index as part of `install`. Only Homebrew keeps metadata on disk and ages it.

## And the answer never reached the screen

`update.apply` raised `neosh.progress` and there was **no `neosh.done` anywhere in the plugin**. A progress notice is keyed and replaced in place because it is a *state*, so one that is never finished is a state with no end — and the reply after it, including the one naming the command a managed install needs, never got a look in.

Now in a `finally` rather than per branch: every arm of that switch returns, and an arm added later that forgot would put the hang straight back.

## Verification

Driven for real rather than reasoned about — a 0.4.2 binary at a managed path, `/update`:

```
 neosh 0.4.3 available    /update      ← the row
 Update with: npm install -g neosh@latest   ← the reply, with no progress row left behind
```

Homebrew takes the same branch and now prints the two-part command. `the_homebrew_command_refreshes_the_tap_before_it_upgrades` asserts content and ordering rather than the exact string, so rewording stays free and dropping the refresh does not. 11 updater tests pass; bindings regenerated and in sync; `tsc` clean.

Ships as v0.4.4.