### PR TITLE
ci: one runner per stage, and a stage compiles only what it tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,21 @@
+# How `cargo nextest` runs the suites. `scripts/check.sh` prefers it when it is installed and falls
+# back to `cargo test` when it is not; CI selects the `ci` profile through `NEXTEST_PROFILE`.
+#
+# nextest runs every test in a process of its own, which is what makes it the right tool here: the
+# integration suites each boot a whole neosh — a daemon, a socket, a deno runtime — and one of them
+# wedging must not take a binary's worth of other tests down with it.
+
+[profile.default]
+# Named after a minute, killed after three. `BUDGET` in the suites is thirty seconds, so a test
+# still going at sixty is stuck rather than slow, and a name in the log beats a runner's timeout.
+slow-timeout = { period = "60s", terminate-after = 3 }
+
+[profile.ci]
+# The pty suites are timing-sensitive under load: a starved workspace draws a row late and a
+# `wait_for` on it times out — a different test on every run, none of them a regression. The fix
+# CLAUDE.md prescribes is running the test again alone, which is exactly what one retry is. Once,
+# and reported as FLAKY in the summary rather than hidden: a test that has to be asked twice is
+# still news.
+retries = 1
+fail-fast = false
+slow-timeout = { period = "60s", terminate-after = 3 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,46 +1,97 @@
 name: CI
 
+# Every job is one stage of `scripts/check.sh`, which is the whole contract: run it with no
+# argument and you have run all of this. The stages are on a runner each so a pull request waits
+# for the slowest one rather than the sum of them, and each compiles only what it tests.
+#
+# Where the time goes, and what is left of it. Compiling the workspace crates is the floor: the
+# cache keeps the dependencies and deliberately not the crates — cargo decides freshness by mtime,
+# and a checkout gives every file the same one, so a restored crate is either always rebuilt or,
+# worse, believed when it should not be. A linker that is not `ld` takes a minute off that floor,
+# and `nextest` runs the suites two at a time with a retry, which is what a pty test under load
+# needs. Beyond that the lever is the machine: set the repository variable `CI_RUNNER` to a larger
+# runner's label and every job moves to it, threads and all.
+
 on:
   push:
     branches: [main]
+    # A change that no stage reads is a run that proves nothing. If a required check is ever
+    # configured on this repository, this has to go: a check that never reports blocks the merge.
+    paths-ignore: ["**.md", "website/**"]
   pull_request:
+    paths-ignore: ["**.md", "website/**"]
 
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CARGO_TERM_COLOR: always
+  # `.config/nextest.toml`: one retry for the pty suites, and no fail-fast, so one flaky test does
+  # not hide a real failure behind it.
+  NEXTEST_PROFILE: ci
+
 jobs:
-  # Two runners, because the halves need different things and one of them needs nothing.
-  #
-  # The node checks read only committed files — the generated types, the plugins, the `files`
-  # lists — so queueing them behind a nine-minute cargo build spent five minutes of wall clock on
-  # a dependency that does not exist. `check.sh` still runs all of it with no argument, which is
-  # what a contributor types; the argument is how CI takes half each.
-  rust:
-    name: check.sh — the half that needs cargo
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+  crates:
+    name: Rust crates — tests and generated types
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: rui314/setup-mold@v1
+      - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # This stage never builds the binary, so its dependency set is smaller than the other
+          # two's. A key of its own, or whichever job saved first would leave the others short.
+          shared-key: crates
+      - run: ./scripts/check.sh crates
+
+  binary:
+    name: neosh binary — tests and scaffold (${{ matrix.slice }}/2)
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        slice: [1, 2]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: rui314/setup-mold@v1
+      - uses: taiki-e/install-action@nextest
       - uses: actions/setup-node@v4
         with:
           node-version: 22
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: binary
+      - run: ./scripts/check.sh binary ${{ matrix.slice }}/2
 
-      # One test at a time, because the integration suites each start a whole
-      # workspace — a real daemon, a real socket, plugins and all — and a
-      # 4-vCPU runner starting several at once is how a different test timed
-      # out on every run: three runs, three different single failures, every
-      # one a wait on something a starved workspace had not drawn yet.
-      - run: ./scripts/check.sh rust
-        env:
-          RUST_TEST_THREADS: "1"
+  screen:
+    name: Bundled plugins on screen (${{ matrix.slice }}/3)
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        slice: [1, 2, 3]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: rui314/setup-mold@v1
+      - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # The same compile as `binary`, so the same cache.
+          shared-key: binary
+      - run: ./scripts/check.sh screen ${{ matrix.slice }}/3
 
   web:
-    name: check.sh — the half that does not
+    name: TypeScript — API, plugins, packages
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -895,6 +895,15 @@ is timing-sensitive: under load a handful of unrelated tests fail on a `wait_for
 different handful each run. A failure there is worth re-running alone (`--test-threads 1 <name>`)
 before believing it.
 
+`./scripts/check.sh` is everything CI runs, in four stages — `crates`, `binary`, `screen`, `web` —
+and CI runs each stage on a runner of its own, the two big ones sliced across several
+(`check.sh screen 1/3`). It prefers `cargo nextest` when installed, one process per test with one
+retry under the `ci` profile in `.config/nextest.toml`, and falls back to `cargo test`. The
+`binary` stage runs the scaffold check against the binary the suites just built rather than
+`cargo run`, which rebuilt the largest crate under the dev profile on every run. Nothing caches the
+workspace crates between runs on purpose: cargo decides freshness by mtime, a checkout gives every
+file the same one, and a restored crate that is *believed* stale-or-not is worse than one rebuilt.
+
 **Terminal behaviour is checked by driving the real binary**, not by reading the code. `scripts/shot.py`
 runs neosh under a pty and prints what the screen actually looks like:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -31,11 +31,25 @@ command palette, `<C-z>` every binding there is.
 ./scripts/check.sh              # everything CI runs — do this before committing
 ```
 
-Six steps: the workspace test suite, the ts-rs binding drift check, then `tsc` over the plugin API,
-the example plugin, the bundled plugins, and a freshly scaffolded config. The `tsc` steps matter
-because a Rust type change that silently breaks every plugin's types is exactly the failure this
-project is built to avoid — and the bundled-plugin step is what keeps "the sidebar is just a plugin"
-from quietly becoming false.
+Four stages, and CI runs each on a runner of its own so a pull request waits for the slowest
+rather than the sum: `crates` (every crate below the binary, plus the ts-rs binding drift check and
+what `cargo package` would ship), `binary` (the neosh binary's own tests, the suites that drive it,
+and a freshly scaffolded config type-checked against its own emitted types), `screen` (the bundled
+plugins, on screen, one whole neosh per test) and `web` (`tsc` over the plugin API, the example
+plugin and the bundled plugins, and what each of them publishes). The `tsc` steps matter because a
+Rust type change that silently breaks every plugin's types is exactly the failure this project is
+built to avoid — and the bundled-plugin step is what keeps "the sidebar is just a plugin" from
+quietly becoming false.
+
+```sh
+./scripts/check.sh crates       # one stage
+./scripts/check.sh screen 1/3   # one slice of one, the way a CI runner takes it
+```
+
+Tests run under [`cargo nextest`](https://nexte.st) when it is installed — one process per test,
+and a slice needs it — and under `cargo test` when it is not. Either way the pty suites run on half
+the machine's cores, because a workspace per test starved of CPU is a different timeout on every
+run; `NEOSH_TEST_THREADS` overrides that.
 
 Narrower loops:
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -2,61 +2,109 @@
 #
 # Everything CI runs. Keep this the single source of truth so "works locally" means something.
 #
-# Run with no argument and it does all of it, which is what a contributor wants. CI passes `rust`
-# or `web` to run one half on each of two runners: the node checks need only committed files, so
-# making them queue behind a nine-minute cargo build was five minutes of wall clock spent on
-# nothing. The split is here rather than in the workflow so the workflow still has exactly one
-# thing to call, and so `./scripts/check.sh` locally still means all of it.
+# Run with no argument and it does all of it, which is what a contributor wants. CI runs the stages
+# below on a runner each, in parallel, so a pull request waits for the slowest of them rather than
+# the sum — and every stage compiles only what it tests, which is why nothing builds the binary to
+# test the crates under it. The split is here rather than in the workflow so the workflow still has
+# exactly one thing to call, and so `./scripts/check.sh` locally still means all of it.
+#
+#   crates          every crate below the binary: unit and integration tests, doctests, the ts-rs
+#                   drift check, and what `cargo package` would ship
+#   binary [N/M]    the neosh binary: its unit tests, every suite that drives it except the one
+#                   below, and the config it scaffolds. N/M runs one slice of the suites
+#   screen [N/M]    tests/builtin_plugins.rs — one whole neosh booted per test, and the longest
+#                   thing here by a factor of three. N/M runs one slice of it
+#   web             the TypeScript: the plugin API, the example, the bundled plugins, what each of
+#                   them publishes, and the bits git stores on the scripts a workflow runs
+#
+# Tests run under `cargo nextest` when it is installed (https://nexte.st — one process per test,
+# and the retry policy CI uses is `.config/nextest.toml`) and under `cargo test` when it is not.
+# Slicing a stage needs nextest.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-want() { [ "${1:-all}" = "$WANT" ] || [ "$WANT" = all ]; }
+usage() { echo "usage: $0 [all | crates | binary [N/M] | screen [N/M] | web]" >&2; exit 2; }
 WANT="${1:-all}"
+SLICE="${2:-}"
 case "$WANT" in
-  all | rust | web) ;;
-  *) echo "usage: $0 [all|rust|web]" >&2; exit 2 ;;
+  all | crates | web) [ -z "$SLICE" ] || usage ;;
+  binary | screen) ;;
+  *) usage ;;
 esac
+want() { [ "$1" = "$WANT" ] || [ "$WANT" = all ]; }
 
 step() { printf '\n\033[1m== %s\033[0m\n' "$1"; }
 
-# The node checks run `tsc` out of `plugins/api/node_modules`, so both halves need it installed —
-# it is the one thing neither half can do without.
+# ts-rs writes the bindings wherever this names, and an exported value beats `.cargo/config.toml`
+# — so in a git worktree an inherited one lands the export in another checkout, and the drift check
+# then compares files nothing wrote to. Pinned to *this* checkout before any cargo runs.
+export TS_RS_EXPORT_DIR="$PWD/plugins/api/src/generated"
+
+TARGET="${CARGO_TARGET_DIR:-target}"
+
+have_nextest() { cargo nextest --version >/dev/null 2>&1; }
+
+# The pty suites start a whole workspace per test, and a machine starting one per core starves
+# them all: a different test timed out on every run. Half the cores is the rate they stay honest
+# at, on a laptop and on a 4-vCPU runner alike. NEOSH_TEST_THREADS overrides it.
+cores() { nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2; }
+HEAVY="${NEOSH_TEST_THREADS:-$(( $(cores) / 2 ))}"
+[ "$HEAVY" -ge 1 ] || HEAVY=1
+
+# tests THREADS <cargo args> — the same package selection under either runner.
+tests() {
+  local threads="$1"; shift
+  if have_nextest; then
+    cargo nextest run --test-threads "$threads" "$@"
+  else
+    cargo test "$@" -- --test-threads "$threads"
+  fi
+}
+
+# sliced N/M <cargo args> — one slice of a stage, or all of it when N/M is empty. `cargo test`
+# has no partitioning, so a slice is the one thing here that needs nextest.
+sliced() {
+  local slice="$1"; shift
+  if [ -z "$slice" ]; then
+    tests "$HEAVY" "$@"
+  elif have_nextest; then
+    cargo nextest run --test-threads "$HEAVY" --partition "hash:$slice" "$@"
+  else
+    echo "error: running a slice ($slice) needs cargo-nextest — https://nexte.st" >&2
+    exit 2
+  fi
+}
+
+# The node checks run `tsc` out of `plugins/api/node_modules`, so every stage with a `tsc` in it
+# needs this first.
 npm_ready() {
   step "plugin API type-checks against the generated types"
   (cd plugins/api && npm install --silent --no-audit --no-fund && npx tsc --noEmit)
 }
 
-if want rust; then
-  step "cargo test --workspace"
-  cargo test --workspace
+if want crates; then
+  step "the crates below the binary"
+  # Everything but `neosh`, which is the crate that costs half the build and is tested by the two
+  # stages after this one. Light tests, so every core.
+  tests "$(cores)" --workspace --exclude neosh
+
+  # nextest does not run doctests; `cargo test` already did.
+  if have_nextest; then
+    step "the crates below the binary: doctests"
+    cargo test --doc --workspace --exclude neosh
+  fi
 
   # The plugin API's wire types are generated from Rust by ts-rs and committed. If a Rust type
   # changed without the generated TypeScript being regenerated, the plugin ecosystem is now
-  # compiling against a lie — so that is a build failure, not a warning.
+  # compiling against a lie — so that is a build failure, not a warning. The export is a test in
+  # `neosh-proto` and has just run, into the directory pinned at the top.
   step "TypeScript bindings are in sync with the Rust types"
-  # Pinned to *this* checkout. ts-rs reads the directory from the environment, and an exported
-  # `TS_RS_EXPORT_DIR` beats `.cargo/config.toml` — so in a git worktree the export lands in
-  # whichever checkout that variable happens to name, and the diff below then compares files
-  # nothing wrote to. A drift check that passes because it looked at the wrong tree is worse than
-  # no drift check.
-  TS_RS_EXPORT_DIR="$PWD/plugins/api/src/generated" cargo test -p neosh-proto --quiet >/dev/null
   if ! git diff --exit-code -- plugins/api/src/generated; then
     echo
     echo "error: generated TypeScript is out of date with the Rust types."
     echo "       run 'TS_RS_EXPORT_DIR=\"$PWD/plugins/api/src/generated\" cargo test -p neosh-proto'"
     exit 1
   fi
-
-  # `neosh init` writes a starter config *and* the types it is checked against, both emitted from
-  # the binary. If the template drifts from the API, every new user's first experience is a type
-  # error. This one needs both halves — a cargo build and a `tsc` — which is why it is on the rust
-  # runner and why that runner installs npm too.
-  npm_ready
-  step "the scaffolded config type-checks against its own emitted types"
-  scaffold="$(mktemp -d)"
-  trap 'rm -rf "$scaffold"' EXIT
-  cargo run --quiet -p neosh -- --config-dir "$scaffold" init >/dev/null
-  ./plugins/api/node_modules/.bin/tsc --noEmit --project "$scaffold/tsconfig.json"
 
   # The plugin tree is embedded with `include_dir!`, which reads the filesystem — so it embeds
   # whatever is next to the checkout and says nothing about what a *published* crate would carry.
@@ -81,8 +129,37 @@ if want rust; then
   fi
 fi
 
+if want binary; then
+  step "the neosh binary: unit tests, and every suite that drives it but one${SLICE:+ — slice $SLICE}"
+  # Named one by one rather than `--tests`, so that the one suite the `screen` stage owns is not
+  # compiled, linked and run here as well. A new file under tests/ is picked up by the glob.
+  suites=()
+  for f in crates/neosh/tests/*.rs; do
+    name="$(basename "$f" .rs)"
+    [ "$name" = builtin_plugins ] || suites+=(--test "$name")
+  done
+  sliced "$SLICE" -p neosh --bins "${suites[@]}"
+
+  # `neosh init` writes a starter config *and* the types it is checked against, both emitted from
+  # the binary. If the template drifts from the API, every new user's first experience is a type
+  # error. The binary is the one the suites above just drove — `cargo run` would build it again
+  # under the dev profile, which was two minutes of every run spent relinking the largest crate
+  # for no new information.
+  npm_ready
+  step "the scaffolded config type-checks against its own emitted types"
+  scaffold="$(mktemp -d)"
+  trap 'rm -rf "$scaffold"' EXIT
+  "$TARGET/debug/neosh" --config-dir "$scaffold" init >/dev/null
+  ./plugins/api/node_modules/.bin/tsc --noEmit --project "$scaffold/tsconfig.json"
+fi
+
+if want screen; then
+  step "the bundled plugins, on screen, through the binary${SLICE:+ — slice $SLICE}"
+  sliced "$SLICE" -p neosh --test builtin_plugins
+fi
+
 if want web; then
-  # `all` has already done this on its way through the rust half; doing it twice is a wasted
+  # `all` has already done this on its way through the binary stage; doing it twice is a wasted
   # `npm install` rather than a wrong answer, so it is guarded rather than reordered.
   if [ "$WANT" = web ]; then
     npm_ready


### PR DESCRIPTION
## What

CI took 12–13 minutes, all of it in one job. This splits `check.sh` into named stages and runs each on its own runner, so a PR waits for the slowest stage rather than the sum.

| Was | Now |
|---|---|
| Second `cargo test` to export ts-rs bindings already exported — 48s | The crates stage's own run exports them |
| `cargo run … init` relinking the largest crate under the dev profile — 1m48 | The scaffold is written by the binary the suites just built |
| Every suite on one thread in one job — 5m32 | Five runners, two threads each, under `cargo nextest` with one retry for the pty suites |
| GNU ld | mold |
| The binary built to test the crates under it | The crates job excludes it and has its own cache |

Jobs are named for what a person reads on the checks list: *Rust crates*, *neosh binary (1/2)*, *Bundled plugins on screen (1/3)*, *TypeScript*.

`./scripts/check.sh` with no argument still runs all of it; `check.sh screen 1/3` runs one slice the way a runner does. It uses nextest when installed and `cargo test` otherwise.

## Not done, on purpose

Workspace crates are still not cached: cargo decides freshness by mtime, and a checkout gives every file the same one, so a restored crate is either always rebuilt or believed when it should not be. The lever beyond this PR is the machine — the repository variable `CI_RUNNER` moves every job to a larger runner.

Docs-only pushes skip CI through `paths-ignore`; remove that if a required check is ever configured.

## Verified

Locally on macOS, each stage: crates 1029/1029, web green, binary 254/255 and screen 65/66 with the failures being the two known macOS path artefacts (`/var` vs `/private/var`, pid-length welcome row). The scaffold check passes against the nextest-built binary. The real timings are this PR's own run.