### PR TITLE
feat(sidebar): keys beside what they act on, a key card for the row, and a delete that frees the disk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -578,14 +578,31 @@ is `docs/releasing.md`.
   and the one time something is red it has to be what the eye lands on. Merged and closed say
   nothing about checks at all, because a merged pull request's checks are *why* it merged and
   sixteen columns spent on that clipped the state it was qualifying down to `#86 mer…`.
-- **A project outlives the conversations in it.** The panel's list is written down (`sidebar.projects`,
+- **What a conversation owned goes with it, and the question says so.** A delete frees the disk it
+  was using or it has freed the wrong thing: the pictures pasted into it are files under
+  `<state>/images` minted for one paste each, so `sessions::forget` removes the ones its messages
+  name — and only those, and only inside the store, because a path in a message is a claim. A
+  worktree is made *for* the conversations in it, so the last of them going takes the checkout too:
+  `orphanedWorktrees` finds the trees a deletion empties (counted over every conversation the
+  workspace knows of, archived and on-disk-only included, because a tree with an archived
+  conversation still in it is a tree somebody may come back to), `worktreeLines` puts them in the
+  dialog — the directory, that the branch stays, and how many uncommitted changes go with it — and
+  `discardWorktrees` removes them afterwards, forced, from the repository rather than the tree.
+  Asked of `git worktree list` rather than of a var, so the repository itself is never one. The
+  sidebar's `X` and `x`-then-empty, the archive's `X`, `^X` and sweep all go through it; the git
+  plugin's `d` was already this from the other direction. `project.forget` is the row's half —
+  drop a project's row without deleting anything, for a directory that has already gone — so a
+  removed tree does not sit in the column saying `nothing here yet`.
+- **A project outlives the conversations in it — a repository does; a worktree does not.** The panel's list is written down (`sidebar.projects`,
   a workspace var) rather than worked out from where the conversations happen to be — derived, it
   deleted the directory you had worked in all month the moment you cleared out the last thread in
   it, and left nothing to start the next one from. A project arrives by being added or by a
   conversation being started in it, keeps the name the host gave it (`sidebar.name`, so emptying a
   worktree does not rename it to `wt-fe3c0d93`), and leaves by `X` on its heading and nothing else.
   Empty, that asks nothing — `o` puts it back; with conversations still in it, it is a delete of
-  every one of them and asks like one.
+  every one of them and asks like one. A *worktree* row is the exception, by the rule above it: the
+  checkout exists for the conversations in it, so the last of them going takes the directory, and
+  `X` on the row itself removes the checkout — asked, always, because a directory is not a row.
 - **"Where?" is one field, and the field is the path field.** `^N` and `^O` ask the same question and
   ask it the same way: type nothing and it is a menu, type `/`, `~` or `./` and it completes
   directories, type `linux-box:` and it completes directories **on that computer**, and paste a
@@ -1186,11 +1203,26 @@ says how many are asking, `^T` is where you go, and it opens when you get there.
 | `y` | Copy the row's directory — a worktree's path, ready to paste into a shell |
 | `p` | Bring that repository up to date — fast-forwards silently, asks *rebase or merge* when the branch has gone both ways, and goes and looks when nothing is waiting (a git-plugin contribution) |
 | `d` | Remove a worktree from disk — its branch stays, and it asks first (a git-plugin contribution) |
-| `x` `X` | Archive, delete. On a project heading, `X` takes the project off the list — the only thing that does |
+| `x` `X` | Archive, delete. Deleting the last conversation in a worktree takes the checkout with it, and the dialog says so — the branch stays. On a repository's heading, `X` takes the project off the list and leaves the directory; on a worktree's, it removes the checkout too |
 | `a` | The archive — the popup below. Nothing archived is ever a row in *this* panel, and by default not even a count. An `archive.action` contribution, not a key this panel owns |
 | `⇥` | On the plan rows: how much of it to show — the limit that binds, every limit, or all of it with the account and the sentence. `usage.sidebar.style` is where it starts, `usage.sidebar` turns it off. A key on a contributed row is named down to the section (`custom:plan`), so the panel sends the press to whichever block the cursor is over rather than to whoever registered it first |
-| `?` | The keys for whatever row you are on |
+| `?` | The keys for whatever row you are on, as a sheet |
 | `Esc` | Back to the composer |
+
+**The keys are beside what they act on, and the row's own keys are on a card next to it.** `^T` sits
+on the `PROJECTS` heading and becomes `esc` while you are in the panel; `^O` sits on the `+ Add
+project` row and becomes `o`. The strip at the foot keeps only the keys that have no row to sit on —
+`^N`, `^F`, `^K`, `^B`, `^Z` outside the panel; `↵`, `?`, `esc` inside — laid out in columns with
+the keys in `Sidebar.Key`, because a strip that said every verb for every row in one dim colour was
+a paragraph nobody read twice. What a row can do is the **key card**: pause on a row and a float
+appears just past the panel's rule, level with the row, one key per line — `↵ space fold or
+unfold`, `n new conversation here`, `p pull`, `d remove worktree` — with the contributed verbs
+after the panel's own. Built from the *registry* (`keymap.list` on the panel's kind, plus what each
+verb says about itself in `ABOUT` and what a `sidebar.action` says about itself), so a key moved in
+`init.ts` is printed as the letter that works. It waits `ui.keys.hint_delay` before appearing, the
+window prefix's rule, so `^T j j ↵` never flashes one; once up it follows the cursor without
+closing; it never takes the keyboard; `sidebar.legend = false` turns it off. `?` is still the whole
+sheet.
 
 ## The repository is on the row it is about
 

--- a/crates/neosh-core/src/palette.rs
+++ b/crates/neosh-core/src/palette.rs
@@ -558,6 +558,10 @@ pub fn groups(variant: Variant) -> Vec<(&'static str, HighlightDef)> {
         ("Sidebar.Dim", link("Comment")),
         ("Sidebar.Selected", link("CursorLine")),
         ("Sidebar.Favorite", spec(fg(r.favorite))),
+        // The keys on the panel — on its heading, on its add row, at its foot and on the card
+        // beside it — wear what every other key in the workspace wears, for the reason the tab
+        // strip's do: a legend whose keys are dimmer than its words is a legend nobody reads twice.
+        ("Sidebar.Key", link("Key")),
         // Work happening on another computer. Linked to `Comment` rather than given a colour of
         // its own: a remote row is still one of your conversations, and painting it a fourth
         // colour would make the panel read as two lists rather than one workspace that happens to

--- a/crates/neosh/src/sessions.rs
+++ b/crates/neosh/src/sessions.rs
@@ -308,10 +308,34 @@ pub fn stored(state: &Path, id: &SessionId) -> bool {
     is_safe_id(&id.0) && session_path(state, id).is_file()
 }
 
+/// Delete a conversation's file, and the pictures that were only ever in it.
+///
+/// An attached image is written once into `<state>/images` and the message says where — which is
+/// what keeps the transcript readable, and what left every screenshot ever pasted on disk after the
+/// conversation it was pasted into had gone. Each file is minted for one paste, so nothing else
+/// refers to it, and a delete that frees the transcript and keeps the megabytes it pointed at has
+/// freed the wrong thing. Only files *inside* the image store go: a path in a message is a claim,
+/// and a conversation is not allowed to claim a file anywhere else on the disk.
 pub fn forget(state: &Path, id: &SessionId) {
-    if is_safe_id(&id.0) {
-        let _ = std::fs::remove_file(session_path(state, id));
+    if !is_safe_id(&id.0) {
+        return;
     }
+    let path = session_path(state, id);
+    let store = state.join("images");
+    if let Some(stored) =
+        std::fs::read_to_string(&path).ok().and_then(|t| serde_json::from_str::<Stored>(&t).ok())
+    {
+        for message in &stored.messages {
+            for block in &message.content {
+                let neosh_proto::ContentBlock::Image { path, .. } = block else { continue };
+                let image = Path::new(path);
+                if image.parent() == Some(store.as_path()) && image.is_file() {
+                    let _ = std::fs::remove_file(image);
+                }
+            }
+        }
+    }
+    let _ = std::fs::remove_file(path);
 }
 
 /// Everything restorable, most recently used first, and which one was active.
@@ -390,6 +414,45 @@ mod tests {
         s.created_at = 100;
         s.updated_at = 100;
         s
+    }
+
+    /// The pictures pasted into a conversation go with it — and only those.
+    #[test]
+    fn forgetting_a_conversation_takes_its_images_off_the_disk_and_nothing_else() {
+        let t = tmp("forget-images");
+        let store = t.0.join("images");
+        std::fs::create_dir_all(&store).expect("images dir");
+        let mine = store.join("mine.png");
+        let theirs = store.join("theirs.png");
+        let elsewhere = t.0.join("elsewhere.png");
+        for f in [&mine, &theirs, &elsewhere] {
+            std::fs::write(f, b"png").expect("write");
+        }
+        let picture = |p: &PathBuf| neosh_proto::Message {
+            role: neosh_proto::Role::User,
+            content: vec![neosh_proto::ContentBlock::Image {
+                path: p.display().to_string(),
+                media_type: "image/png".into(),
+            }],
+        };
+        let mut going = session("look at this");
+        going.messages.push(picture(&mine));
+        // A message that names a file outside the store: the file is not the conversation's to
+        // delete, however the path got there.
+        going.messages.push(picture(&elsewhere));
+        let mut staying = session("and this");
+        staying.messages.push(picture(&theirs));
+        save(&t.0, &going).expect("save");
+        save(&t.0, &staying).expect("save");
+
+        forget(&t.0, &going.id);
+
+        assert!(!mine.exists(), "the deleted conversation's picture went with it");
+        assert!(theirs.exists(), "another conversation's picture stayed");
+        assert!(elsewhere.exists(), "a file outside the image store is never touched");
+        let (loaded, _) = load(&t.0);
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].id, staying.id);
     }
 
     #[test]

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -2634,7 +2634,7 @@ fn a_favourite_sorts_above_a_project_that_was_used_more_recently() {
     s.enter_panel();
     s.down();
     assert!(
-        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("JK move"))),
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("↵ fold"))),
         "the cursor is on a project\n{:?}",
         s.sidebar_now()
     );
@@ -2968,6 +2968,73 @@ fn a_worktree_is_removed_by_its_path_without_a_picker() {
     assert!(s.pump(|_| !made.exists()), "the checkout is gone from the disk");
 }
 
+/// Deleting the last conversation in a worktree takes the checkout with it.
+///
+/// A worktree is made for the conversations in it — that is what `^N`'s second row does — so
+/// the last of them going is the directory's reason for being on the disk going. The dialog is
+/// off here so the command answers at once; what it would have said is the sidebar's business
+/// and the checkout going is the host's.
+#[test]
+fn deleting_the_last_conversation_in_a_worktree_removes_the_checkout() {
+    let sb = Sandbox::new("wtdelete");
+    sb.git_init();
+    sb.write_config("[options]\n\"ui.confirm_destructive\" = false\n");
+    let mut s = sb.start_letting_config_choose();
+    s.wait_for("PROJECTS");
+
+    s.send(&command("git.worktree.new.inside"));
+    assert!(s.pump(|s| s.saw("branched ")), "the tree was made and entered\n{}", s.transcript());
+    let under = sb.work().join(".worktrees");
+    let made = std::fs::read_dir(&under)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .next()
+        .map(|p| std::fs::canonicalize(&p).unwrap_or(p))
+        .expect("one worktree");
+    // Something uncommitted in it, which is what makes `git worktree remove` refuse unless the
+    // dialog has already said the changes go — and it has.
+    std::fs::write(made.join("draft.txt"), "half done\n").expect("write");
+
+    // The conversation in the tree, found by where it is rather than by being current: closing
+    // the one you are in lands you somewhere else first, and that is the host's to arrange.
+    assert!(
+        s.pump(|_| session_in(&sb, &made).is_some()),
+        "a conversation in the worktree was saved"
+    );
+    let in_tree = session_in(&sb, &made).expect("found above");
+    // Out of the tree, so the removal is not of the checkout the workspace is standing in.
+    s.send(&command_with("project.open", &sb.work().display().to_string()));
+    assert!(s.pump(|s| s.sidebar_rows() >= 2), "back in the repository\n{:?}", s.sidebar_now());
+
+    s.send(&command_with("session.close", &in_tree));
+    assert!(
+        s.pump(|_| !made.exists()),
+        "the checkout went with its last conversation\n{}",
+        s.transcript()
+    );
+    assert!(
+        s.pump(|s| !s.projects_now().iter().any(|l| l.contains("nothing here yet"))),
+        "and its row went too\n{:?}",
+        s.sidebar_now()
+    );
+}
+
+/// The id of a saved conversation whose directory is `dir`, read off the state directory.
+///
+/// Compared canonicalised on both sides: the worktree was found through `$TMPDIR`, which on macOS
+/// is a symlink, and the conversation was created at whatever spelling git handed back.
+fn session_in(sb: &Sandbox, dir: &Path) -> Option<String> {
+    let want = std::fs::canonicalize(dir).ok()?;
+    let files = std::fs::read_dir(sb.root.join("state/sessions")).ok()?;
+    files.filter_map(|e| e.ok()).find_map(|e| {
+        let text = std::fs::read_to_string(e.path()).ok()?;
+        let v: Value = serde_json::from_str(&text).ok()?;
+        let cwd = std::fs::canonicalize(v["cwd"].as_str()?).ok()?;
+        (cwd == want).then(|| v["id"].as_str().map(str::to_string))?
+    })
+}
+
 /// `git.pull` brings the remote's commits into the conversation's checkout, and what git said
 /// about it is the answer rather than silence.
 #[test]
@@ -3147,15 +3214,16 @@ fn the_project_list_is_the_rows_below_the_projects_heading() {
     );
 }
 
-/// And it is still inside it once you have deleted everything you were doing in there.
+/// And it goes when you have deleted everything you were doing in there.
 ///
-/// Which tree belongs to which repository is read off a conversation's `repo_root` — so an emptied
-/// worktree has nobody left to say it, and a project that outlives its conversations would jump out
-/// of the repository it belongs to and land at the top level as a project of its own. A tree does
-/// not become a project by being idle: the relationship is written down (`sidebar.root`) while
-/// something still knows it.
+/// A worktree is made for the conversations in it — that is what `^N`'s second row does — so the
+/// last of them going is the checkout's reason for being on the disk going with it: the directory
+/// is removed, the branch stays, and the row goes rather than sitting under the repository saying
+/// `nothing here yet` about a place that is not there. The repository it was a tree of is untouched.
+/// This used to keep the emptied tree as a project of its own, which was a directory of a full
+/// checkout kept for a row nobody would press.
 #[test]
-fn an_emptied_worktree_is_still_inside_its_repository() {
+fn an_emptied_worktree_goes_from_the_disk_and_the_list() {
     let sb = Sandbox::new("wtempty");
     sb.git_init();
     let root = sb.root.join("trees");
@@ -3172,28 +3240,34 @@ fn an_emptied_worktree_is_still_inside_its_repository() {
         "the worktree is there to begin with\n{:?}",
         s.sidebar_now()
     );
+    let made = root.join("work").join("sideline");
+    assert!(s.pump(|_| made.is_dir()), "and on the disk at {}", made.display());
 
-    // The conversation the worktree was made for is the active one, so this empties the tree. Wait
-    // for it to actually go: every claim below is true of the panel *before* the delete as well, so
-    // a test that only asserted the shape would pass without waiting for anything to happen.
+    // The conversation the worktree was made for is the active one, so this empties the tree.
     s.send(&command("session.close"));
     assert!(
-        s.pump(|s| s.sidebar_now().iter().filter(|l| l.contains("New conversation")).count() == 1),
-        "the tree's only conversation is gone\n{:?}",
+        s.pump(|_| !made.exists()),
+        "the checkout went with its last conversation\n{}",
+        s.transcript()
+    );
+    assert!(
+        s.pump(|s| !s.sidebar_now().iter().any(|l| l.contains("sideline"))),
+        "and its row went too\n{:?}",
         s.sidebar_now()
     );
     assert!(
-        s.pump(|s| {
-            let rows = s.sidebar_now();
-            let repo = rows.iter().position(|l| l.contains("work") && !l.contains("sideline"));
-            let tree = rows.iter().position(|l| l.contains("sideline"));
-            match (repo, tree) {
-                (Some(r), Some(t)) => t > r && rows[t].starts_with(CONVERSATION_INDENT),
-                _ => false,
-            }
-        }),
-        "the emptied tree is still nested under its repository\n{:?}",
+        s.sidebar_now().iter().any(|l| l.contains("work")),
+        "the repository it was a tree of is still there\n{:?}",
         s.sidebar_now()
+    );
+    let branches = Command::new("git")
+        .current_dir(sb.work())
+        .args(["branch", "--list", "sideline"])
+        .output()
+        .expect("git runs");
+    assert!(
+        String::from_utf8_lossy(&branches.stdout).contains("sideline"),
+        "and the branch stays: the checkout was the space, the branch is the work"
     );
 }
 
@@ -3417,7 +3491,7 @@ fn a_second_project_can_be_opened_and_dragged_above_the_first() {
     s.enter_panel();
     s.down();
     assert!(
-        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("JK move"))),
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("↵ fold"))),
         "the cursor is on a project\n{:?}",
         s.sidebar_now()
     );
@@ -3500,8 +3574,8 @@ fn a_project_is_removed_by_the_key_on_its_heading() {
     s.enter_panel();
     s.down();
     assert!(
-        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("X remove"))),
-        "the cursor is on a project, and the strip says the verb\n{:?}",
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("↵ fold"))),
+        "the cursor is on a project, and the strip says so\n{:?}",
         s.sidebar_now()
     );
 
@@ -3525,25 +3599,165 @@ fn the_key_hints_follow_what_the_cursor_is_on() {
     let sb = Sandbox::new("hints");
     let mut s = sb.start();
     s.wait_for("PROJECTS");
+    // The way in is on the heading of the thing it opens, and the foot keeps the doors out.
     assert!(
-        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("^T projects"))),
-        "unfocused, it says how to get in\n{:?}",
-        s.sidebar_now()
+        s.pump(|s| {
+            s.sidebar_virt_now().iter().any(|v| v.trim() == "^T")
+                && s.sidebar_now().iter().any(|l| l.contains("^F archive"))
+        }),
+        "unfocused, the heading says how to get in and the foot says the main keys\n{:?}\n{:?}",
+        s.sidebar_now(),
+        s.sidebar_virt_now()
     );
 
     s.enter_panel();
     assert!(
-        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("x archive"))),
-        "on a conversation, it offers the conversation verbs\n{:?}",
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("↵ open"))),
+        "on a conversation, the strip says what ↵ does here\n{:?}",
         s.sidebar_now()
+    );
+    assert!(
+        s.pump(|s| s.sidebar_virt_now().iter().any(|v| v.trim() == "esc")),
+        "and the heading now says the way out\n{:?}",
+        s.sidebar_virt_now()
     );
 
     s.special("up");
     assert!(
-        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("JK move"))),
-        "on a project, it offers the project verbs\n{:?}",
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("↵ fold"))),
+        "on a project, ↵ is a fold\n{:?}",
         s.sidebar_now()
     );
+}
+
+/// The key card: pause on a row and every key for it is beside the panel, level with the row.
+///
+/// Built from the registry, so it is checked the way the sheet is — by the verbs it names — and it
+/// follows the cursor: what it said on the conversation is not what it says on the project.
+#[test]
+fn the_key_card_lists_the_row_under_the_cursor_and_follows_it() {
+    let sb = Sandbox::new("keycard");
+    let mut s = sb.start();
+    s.wait_for("PROJECTS");
+    s.enter_panel();
+    assert!(
+        s.pump(|s| s.key_card().iter().any(|l| l.contains("rename"))),
+        "on a conversation, the card says the conversation's keys\n{:?}",
+        s.key_card()
+    );
+    let card = s.key_card();
+    assert!(
+        card.iter().any(|l| l.contains("archive")) && card.iter().any(|l| l.contains("delete")),
+        "all of them\n{card:?}"
+    );
+    assert!(
+        !card.iter().any(|l| l.contains("fold")),
+        "and not a project's\n{card:?}"
+    );
+
+    s.special("up");
+    assert!(
+        s.pump(|s| s.key_card().iter().any(|l| l.contains("fold or unfold"))),
+        "on a project, the card follows\n{:?}",
+        s.key_card()
+    );
+    assert!(
+        !s.key_card().iter().any(|l| l.contains("rename")),
+        "and stops saying the conversation's\n{:?}",
+        s.key_card()
+    );
+
+    // Leaving takes the card with the keyboard: a card about a row nobody is on is a card that
+    // covers the transcript for no reason.
+    s.special("esc");
+    assert!(
+        s.pump(|s| s.window_closed_for("[sidebar keys]")),
+        "the card closed with the panel\n{:?}",
+        s.key_card()
+    );
+}
+
+/// A pinned project with a git badge is one row under the cursor, not two.
+///
+/// The badge is appended to the row after the star and the unread mark, and it used to be appended
+/// to the row's *unclipped* text as well — which has neither — so the two stopped being prefixes
+/// of each other, and the list, finding nothing to trust, said the whole row again underneath:
+/// name, badge and all, on the one row you had just moved onto.
+#[test]
+fn a_pinned_project_with_a_badge_is_not_said_twice_under_the_cursor() {
+    if !have_git() {
+        return;
+    }
+    let sb = Sandbox::new("badgeonce");
+    sb.git_init();
+    std::fs::write(sb.work().join("scratch.txt"), "untracked\n").expect("write");
+    let mut s = sb.start();
+    s.wait_for("PROJECTS");
+    assert!(
+        s.pump(|s| s.projects_now().iter().any(|l| l.contains("?1"))),
+        "the git plugin has marked the row\n{:?}",
+        s.sidebar_now()
+    );
+
+    s.enter_panel();
+    s.special("up");
+    assert!(
+        s.pump(|s| s.sidebar_cursor().is_some_and(|r| r.contains("work"))),
+        "the cursor is on the project\n{:?}",
+        s.sidebar_now()
+    );
+    s.key("f");
+    assert!(
+        s.pump(|s| s.projects_now().iter().any(|l| l.contains('★'))),
+        "and it is pinned\n{:?}",
+        s.sidebar_now()
+    );
+    s.drain_for(Duration::from_millis(600));
+    let rows = s.projects_now();
+    let badged: Vec<&String> = rows.iter().filter(|l| l.contains("?1")).collect();
+    assert_eq!(badged.len(), 1, "the badge is on one row and nowhere else\n{rows:?}");
+    let named: Vec<&String> = rows.iter().filter(|l| l.contains("work")).collect();
+    assert_eq!(named.len(), 1, "and so is the name\n{rows:?}");
+}
+
+#[test]
+fn the_key_card_can_be_switched_off() {
+    let sb = Sandbox::new("nokeycard");
+    sb.write_config("[options]\n\"sidebar.legend\" = false\n");
+    let mut s = sb.start();
+    s.wait_for("PROJECTS");
+    s.enter_panel();
+    s.drain_for(Duration::from_secs(1));
+    assert!(
+        s.buffer_named("[sidebar keys]").is_none(),
+        "no card\n{:?}",
+        s.key_card()
+    );
+}
+
+impl Session {
+    /// What the key card says right now, or nothing while there is none.
+    fn key_card(&self) -> Vec<String> {
+        match self.buffer_named("[sidebar keys]") {
+            Some(b) => self.lines_of(b),
+            None => Vec::new(),
+        }
+    }
+
+    /// Whether every window that ever showed the named buffer has since closed.
+    fn window_closed_for(&self, name: &str) -> bool {
+        let Some(buf) = self.buffer_named(name) else { return false };
+        let opened: Vec<u64> = self
+            .events
+            .iter()
+            .filter(|e| e["type"] == "window_opened" && e["buf"].as_u64() == Some(buf))
+            .filter_map(|e| e["win"].as_u64())
+            .collect();
+        !opened.is_empty()
+            && opened.iter().all(|w| {
+                self.events.iter().any(|e| e["type"] == "window_closed" && e["win"].as_u64() == Some(*w))
+            })
+    }
 }
 
 #[test]
@@ -3554,7 +3768,7 @@ fn the_hint_strip_can_be_switched_off() {
     s.wait_for("PROJECTS");
     s.drain_for(Duration::from_secs(1));
     assert!(
-        !s.sidebar_now().iter().any(|l| l.contains("^T projects")),
+        !s.sidebar_now().iter().any(|l| l.contains("^F archive")),
         "no hint strip\n{:?}",
         s.sidebar_now()
     );
@@ -3625,8 +3839,8 @@ fn archive_one(s: &mut Session) {
     assert!(s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("keep"))));
     s.down();
     assert!(
-        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("x archive"))),
-        "the cursor is on a conversation\n{:?}",
+        s.pump(|s| s.sidebar_cursor().is_some_and(|r| r.contains("keep"))),
+        "the cursor is on the conversation\n{:?}",
         s.sidebar_now()
     );
     s.key("x");
@@ -3850,8 +4064,8 @@ fn deleting_a_conversation_with_something_in_it_asks_first() {
     assert!(s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("keep"))));
     s.down();
     assert!(
-        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("X delete"))),
-        "the cursor is on a conversation\n{:?}",
+        s.pump(|s| s.sidebar_cursor().is_some_and(|r| r.contains("keep"))),
+        "the cursor is on the conversation\n{:?}",
         s.sidebar_now()
     );
     let panel_only = s.open_windows().len();
@@ -3952,7 +4166,7 @@ fn confirmation_can_be_switched_off() {
     s.enter_panel();
     assert!(s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("gone"))));
     s.down();
-    assert!(s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("X delete"))));
+    assert!(s.pump(|s| s.sidebar_cursor().is_some_and(|r| r.contains("gone"))));
     s.key("X");
     assert!(
         s.pump(|s| !s.sidebar_now().iter().any(|l| l.contains("gone"))),
@@ -4196,7 +4410,7 @@ fn escape_leaves_the_thread_list_and_typing_goes_back_to_the_composer() {
     // Leaving is a round trip to the plugin thread as well; the hint strip going back to its
     // out-of-panel form is the signal that the keyboard has been handed back.
     assert!(
-        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("^T projects"))),
+        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("^F archive"))),
         "the panel gave the keyboard back\n{:?}",
         s.sidebar_now()
     );
@@ -7565,10 +7779,12 @@ fn the_plan_strip_is_one_row_until_you_ask_for_more() {
     // rather than bound over every conversation in the panel.
     s.enter_panel();
     s.key("G");
+    // On the key card beside the panel, which is where a row's verbs are said now — and only on
+    // the plan row, which is what `custom:plan` means.
     assert!(
-        s.pump(|s| s.sidebar_now().iter().any(|l| l.contains("plan detail"))),
+        s.pump(|s| s.key_card().iter().any(|l| l.contains("plan detail"))),
         "the key is advertised on the rows it applies to\n{:?}",
-        s.sidebar_now()
+        s.key_card()
     );
     s.special("tab");
     assert!(

--- a/plugins/api/package-lock.json
+++ b/plugins/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neosh/api",
-  "version": "0.4.1",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neosh/api",
-      "version": "0.4.1",
+      "version": "0.4.4",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.0"

--- a/plugins/api/src/ui.ts
+++ b/plugins/api/src/ui.ts
@@ -25,7 +25,9 @@ import type {
   KeyContext,
   MarkOptions,
   Neosh,
+  SessionInfo,
   WindowId,
+  WorktreeInfo,
 } from "@neosh/api";
 
 /**
@@ -258,6 +260,20 @@ function watchKeys(neosh: Neosh): void {
 function keyLabel(keys: Map<WidgetAction, KeySpec[]>, action: WidgetAction): string {
   const spec = keys.get(action)?.[0];
   if (!spec) return "";
+  // The first key of `ui.keys.*` is the one that reaches this — which is why the defaults lead
+  // with the chord and keep the arrow behind it.
+  return prettyKey(spec.lhs);
+}
+
+/**
+ * A key the way a person would press it, from the way a keymap spells it.
+ *
+ * `<C-n>` is `^N` — not `^n`: nobody presses shift to send it, and the capital is how every
+ * terminal program has written a chord since curses. `<CR>` is `↵`, `<Esc>` is `esc`, `<lt>` is
+ * `<`. For a legend, which is a promise about a keyboard: it prints what the registry holds, so a
+ * rebinding shows the letter that works.
+ */
+export function prettyKey(lhs: string): string {
   const pretty: Record<string, string> = {
     "<Tab>": "⇥",
     "<S-Tab>": "⇧⇥",
@@ -267,13 +283,15 @@ function keyLabel(keys: Map<WidgetAction, KeySpec[]>, action: WidgetAction): str
     "<Down>": "↓",
     "<CR>": "↵",
     "<Esc>": "esc",
+    "<Space>": "space",
+    "<BS>": "⌫",
+    "<lt>": "<",
+    "<PageUp>": "pgup",
+    "<PageDown>": "pgdn",
   };
-  // `^N`, not `^n`: nobody presses shift to send it, and the capital is how every terminal
-  // program has written a chord since curses. The first key of `ui.keys.*` is the one that
-  // reaches this — which is why the defaults lead with the chord and keep the arrow behind it.
   return (
-    pretty[spec.lhs] ??
-    spec.lhs.replace(/^<C-(.)>$/, (_, c: string) => `^${c.toUpperCase()}`).replace(/^<|>$/g, "")
+    pretty[lhs] ??
+    lhs.replace(/^<C-(.)>$/, (_, c: string) => `^${c.toUpperCase()}`).replace(/^<|>$/g, "")
   );
 }
 
@@ -1370,6 +1388,142 @@ export async function confirmDestructive(
   return confirm(neosh, question, { ...opts, dangerous: true });
 }
 
+// ---------------------------------------------------------------------------
+// What goes with a conversation
+// ---------------------------------------------------------------------------
+
+/**
+ * A worktree checkout that a delete is about to leave with nothing in it.
+ *
+ * `dirty` is how many files in it differ from its last commit — the number a dialog has to say,
+ * because `git worktree remove` refuses a tree with changes in it and forcing it is throwing those
+ * changes away.
+ */
+export interface OrphanedWorktree {
+  /** The checkout's directory: the conversations' `cwd`. */
+  path: string;
+  /** The repository it is a tree of, which is where the removal has to run from. */
+  root: string;
+  branch: string | null;
+  dirty: number;
+}
+
+/**
+ * The worktree at `cwd`, if it is one this workspace may take off the disk.
+ *
+ * Asked of git rather than of the sidebar: a directory is a worktree because `git worktree list`
+ * says so, and the main checkout — the repository itself — is never one, whatever a conversation's
+ * `repo_root` happens to say. Nor is the tree this workspace is running in: git refuses to remove
+ * the checkout it is standing in, and it is right to.
+ */
+export async function worktreeAt(
+  neosh: Neosh,
+  cwd: string,
+  root: string,
+): Promise<OrphanedWorktree | null> {
+  if (root === "" || root === cwd) return null;
+  const trees = await neosh.git.worktrees({ cwd: root }).catch(() => [] as WorktreeInfo[]);
+  const tree = trees.find((t) => t.path === cwd);
+  if (!tree || tree.is_main || tree.is_current) return null;
+  const status = await neosh.git.status({ cwd }).catch(() => null);
+  return { path: cwd, root, branch: tree.branch ?? null, dirty: status?.changes.length ?? 0 };
+}
+
+/**
+ * The worktrees that would be left with no conversation in them if `ids` were deleted.
+ *
+ * A worktree exists for the conversations in it — that is what `^N` makes one for — so the last of
+ * them going is the checkout's reason for being on the disk going with it. Counted over every
+ * conversation the workspace knows of, archived and on-disk-only included: a tree with an archived
+ * conversation still in it is a tree somebody may come back to.
+ */
+export async function orphanedWorktrees(
+  neosh: Neosh,
+  ids: Iterable<string>,
+): Promise<OrphanedWorktree[]> {
+  const doomed = new Set(ids);
+  if (doomed.size === 0) return [];
+  const [live, disk] = await Promise.all([
+    neosh.session.list({ includeArchived: true }).catch(() => [] as SessionInfo[]),
+    neosh.session.stored().catch(() => [] as SessionInfo[]),
+  ]);
+  const all = new Map<string, SessionInfo>();
+  for (const s of disk) all.set(s.id, s);
+  for (const s of live) all.set(s.id, s);
+  // Which checkouts the deletion empties: every conversation in them is going.
+  const roots = new Map<string, string>();
+  for (const s of all.values()) {
+    if (!s.repo_root || s.repo_root === s.cwd) continue;
+    if (doomed.has(s.id)) roots.set(s.cwd, s.repo_root);
+  }
+  for (const s of all.values()) {
+    if (!doomed.has(s.id)) roots.delete(s.cwd);
+  }
+  const found = await Promise.all(
+    [...roots].map(([cwd, root]) => worktreeAt(neosh, cwd, root)),
+  );
+  return found.filter((t): t is OrphanedWorktree => t !== null);
+}
+
+/**
+ * What a delete dialog says about the checkouts it takes with it.
+ *
+ * Lines for {@link ConfirmOptions.detail}: which directory goes, that the branch stays, and — the
+ * part that must never be a surprise — how many uncommitted changes go with it.
+ */
+export function worktreeLines(trees: OrphanedWorktree[]): string[] {
+  if (trees.length === 0) return [];
+  const lines: string[] = [];
+  if (trees.length === 1) {
+    const t = trees[0]!;
+    lines.push(
+      `Nothing else is in the worktree at ${t.path}, so the checkout goes too${
+        t.branch ? `; the branch ${t.branch} stays` : ""
+      }.`,
+    );
+  } else {
+    lines.push(
+      `${trees.length} worktrees are left with nothing in them and go from disk too; their branches stay.`,
+    );
+  }
+  const dirty = trees.reduce((n, t) => n + t.dirty, 0);
+  if (dirty > 0) {
+    lines.push(
+      trees.length === 1
+        ? `It has ${dirty} uncommitted ${dirty === 1 ? "change" : "changes"}, which go with it.`
+        : `${dirty} uncommitted ${dirty === 1 ? "change" : "changes"} across them go with them.`,
+    );
+  }
+  return lines;
+}
+
+/**
+ * Take the checkouts off the disk, after the dialog that named them has been answered.
+ *
+ * Through the git plugin's `git.worktree.discard` rather than the API directly, because a write
+ * to a repository is that plugin's verb — it holds the permission, it runs the removal from the
+ * repository rather than from the tree, and it drops the panel's row for the directory. Forced
+ * there, because the dialog already said what was in the tree, and git refusing now would be the
+ * same question asked twice. A tree that would not go is reported by path and left, with its
+ * conversations already gone; `^O` on the directory brings it back as a project. Answers with how
+ * many went.
+ */
+export async function discardWorktrees(
+  neosh: Neosh,
+  trees: OrphanedWorktree[],
+): Promise<number> {
+  let removed = 0;
+  for (const t of trees) {
+    try {
+      await neosh.cmd.exec("git.worktree.discard", [t.path, t.root]);
+      removed += 1;
+    } catch (e) {
+      neosh.notify(`could not remove the worktree at ${t.path}: ${String(e)}`, "warn");
+    }
+  }
+  return removed;
+}
+
 /**
  * Break text into lines of at most `width` characters.
  *
@@ -2026,6 +2180,8 @@ export interface CursoredListOptions {
 export class CursoredList<T = unknown> {
   private rows: ListRow<T>[] = [];
   private cursor = 0;
+  /** Where the last render put the cursor's row: its buffer line, and the window's top line. */
+  private placed: { line: number; top: number } | null = null;
 
   constructor(
     private readonly neosh: Neosh,
@@ -2053,6 +2209,19 @@ export class CursoredList<T = unknown> {
 
   get length(): number {
     return this.rows.length;
+  }
+
+  /**
+   * The window row the cursor's row was drawn on, as of the last `render` that had a window to
+   * measure — `null` before one has.
+   *
+   * For a panel beside this one that wants to sit level with the row under the cursor. Counted in
+   * drawn lines rather than in rows, because an unfolded row above the cursor is several, and it
+   * is read back from the scroll `render` settled on rather than from the viewport it was handed,
+   * which was where the window *had* been.
+   */
+  get cursorScreenRow(): number | null {
+    return this.placed === null ? null : Math.max(0, this.placed.line - this.placed.top);
   }
 
   /**
@@ -2277,11 +2446,11 @@ export class CursoredList<T = unknown> {
         // The whole of the row, not only the line it starts on: scrolling until the *first* line
         // is visible leaves the continuation you unfolded it for below the bottom edge.
         const end = at + Math.min(block, v.height) - 1;
-        const top = v.top_line;
-        if (at < top) await this.neosh.win.scrollTo(opts.win, at);
-        else if (end >= top + v.height) {
-          await this.neosh.win.scrollTo(opts.win, end - v.height + 1);
-        }
+        let top = v.top_line;
+        if (at < top) top = at;
+        else if (end >= top + v.height) top = end - v.height + 1;
+        if (top !== v.top_line) await this.neosh.win.scrollTo(opts.win, top);
+        this.placed = { line: at, top };
       }
     }
   }
@@ -3155,7 +3324,12 @@ export function decorateRow<T>(
     // badge's, and a span over it would be one colour claiming a column it does not fill.
     let at = byteLength(row.text) + 1;
     row.text = `${row.text}${mark}`;
-    if (row.full !== undefined) row.full = `${row.full}${mark}`;
+    // Not onto `full`. The badge goes *after* the clip — past the ellipsis, on the end of the row,
+    // where an unread dot or a count already sits — so it survives the clip and is on screen
+    // whether or not the name was cut. `overflowOf` compares the two strings as prefixes of each
+    // other, and a `full` that ends in the badge while `text` has a star and a mark between the
+    // name and the badge is a prefix of nothing: the whole of `full` was then said again under the
+    // cursor row, name and badge and all.
     const spans = [...(row.spans ?? [])];
     for (const part of d.badge.parts) {
       const to = at + byteLength(part.text);

--- a/plugins/builtin/archive/main.ts
+++ b/plugins/builtin/archive/main.ts
@@ -56,7 +56,15 @@ import type {
   SessionInfo,
   WindowId,
 } from "@neosh/api";
-import { confirmDestructive, CursoredList, type ListRow, prompt } from "@neosh/api/ui";
+import {
+  confirmDestructive,
+  CursoredList,
+  discardWorktrees,
+  type ListRow,
+  orphanedWorktrees,
+  prompt,
+  worktreeLines,
+} from "@neosh/api/ui";
 
 const NS = "neosh.archive";
 /** What this panel's buffer says it is. Everything a third party binds or finds hangs off this. */
@@ -1048,6 +1056,10 @@ async function confirmDelete(
     ? `Delete all ${n} archived conversations shown?`
     : `Empty the archive — all ${n} conversations?`;
 
+  // The checkouts these were the last conversations in. Emptying the archive is the one moment
+  // a workspace sheds a season's worth of scratch worktrees, and a dialog that counted the
+  // messages and not the directories would be counting the small thing.
+  const trees = await orphanedWorktrees(neosh, chosen.map((e) => e.info.id));
   const detail = [
     `${messages} ${messages === 1 ? "message" : "messages"} in ${
       n === 1 ? "it" : "them"
@@ -1057,6 +1069,7 @@ async function confirmDelete(
     n === 1
       ? "It goes from disk, and there is no undo."
       : "They go from disk, and there is no undo.",
+    ...worktreeLines(trees),
     "`u` puts one back into your list instead, and costs nothing.",
   ];
 
@@ -1065,6 +1078,9 @@ async function confirmDelete(
 
 /** Delete them, saying what went and stopping at the first thing that would not. */
 async function destroy(neosh: Neosh, chosen: Entry[]): Promise<number> {
+  // Asked before anything goes, because afterwards there is nothing left to ask about: a
+  // worktree is orphaned by the conversations that *were* in it.
+  const trees = await orphanedWorktrees(neosh, chosen.map((e) => e.info.id));
   let done = 0;
   for (const e of chosen) {
     try {
@@ -1074,10 +1090,23 @@ async function destroy(neosh: Neosh, chosen: Entry[]): Promise<number> {
       // Named, because "12 of 40" with no reason is a state nobody can act on. The commonest cause
       // is a conversation that stopped being archived while the panel was open.
       neosh.notify(`stopped after ${done}: ${String(err)}`, "warn");
-      return done;
+      break;
     }
   }
-  if (done > 0) neosh.notify(done === 1 ? "deleted" : `deleted ${done} conversations`);
+  // Only the checkouts actually emptied. A stop halfway leaves conversations behind, and a tree
+  // one of them is in is a tree somebody may still come back to.
+  const gone = new Set(chosen.slice(0, done).map((e) => e.info.id));
+  const kept = new Set(chosen.slice(done).map((e) => e.info.cwd));
+  const emptied = trees.filter((t) => !kept.has(t.path));
+  const removed = gone.size === 0 ? 0 : await discardWorktrees(neosh, emptied);
+  if (done > 0) {
+    const what = done === 1 ? "deleted" : `deleted ${done} conversations`;
+    neosh.notify(
+      removed === 0
+        ? what
+        : `${what}, and ${removed === 1 ? "the worktree" : `${removed} worktrees`} they were in`,
+    );
+  }
   return done;
 }
 
@@ -1262,7 +1291,10 @@ const POINT_SIDEBAR_ACTION = "sidebar.action";
 async function contributeToSidebar(neosh: Neosh, subscriptions: Disposable[]): Promise<void> {
   await neosh.ext.contribute(POINT_SIDEBAR_ACTION, "browse", {
     key: "a",
-    label: "archive",
+    // Said as the door it is. On the panel's key card this sits two lines under `x archive`, and
+    // the same word for putting a conversation away and for going to see what was put away is two
+    // verbs the card could not tell apart.
+    label: "open the archive",
     command: "archive.open",
     on: "any",
   });

--- a/plugins/builtin/git/main.ts
+++ b/plugins/builtin/git/main.ts
@@ -205,6 +205,17 @@ two-word scratch name it was created with.",
       "Remove a worktree — `git.worktree.remove [path] [cwd]`",
     ],
     [
+      "git.worktree.discard",
+      // The half of `git.worktree.remove` that comes *after* the question. For a caller that has
+      // already asked — the sidebar deleting a worktree's last conversation, the archive emptying
+      // itself — and said in its own dialog which directory goes and what is uncommitted in it.
+      // Forced for that reason: git refusing a dirty tree here would be the same question asked
+      // twice. Needs a path, so `^K` cannot run it by accident; without one it points at the verb
+      // that asks.
+      (args: string[]) => discardWorktree(neosh, arg(args, 0), arg(args, 1)),
+      "Remove a worktree without asking — `git.worktree.discard <path> [cwd]`, for a caller that already did",
+    ],
+    [
       "git.worktree.move",
       // Same shape one argument further: the tree, then where it goes. Both optional and both
       // asked for when missing, so this is the palette's verb, the panel's verb and a script's
@@ -1403,7 +1414,35 @@ async function removeWorktree(
       await neosh.session.close(s.id).catch(() => {});
     }
   }
+  // And so is its row: with the checkout gone, a project row for it says `nothing here yet` about
+  // a directory that is not there. By name, so a sidebar that is not ours can answer the same call.
+  await neosh.cmd.exec("project.forget", [chosen.path]).catch(() => {});
   neosh.notify(`removed ${chosen.path}`);
+}
+
+/**
+ * Remove a worktree that somebody else has already asked about.
+ *
+ * Run from the repository rather than from the tree, for the reason {@link removeWorktree} is:
+ * git will not saw off the branch it is standing on. The row goes with it, so the panel does not
+ * keep a project for a directory that is no longer there. What is *not* here is any check on the
+ * conversations in the tree — the caller deleted them, which is how the tree came to be empty.
+ */
+async function discardWorktree(neosh: Neosh, path?: string, cwd?: string): Promise<void> {
+  if (!path) {
+    neosh.notify(
+      "git.worktree.discard removes without asking, so it needs a path — `git.worktree.remove` asks",
+      "warn",
+    );
+    return;
+  }
+  const all = await neosh.git.worktrees(cwd ? { cwd } : undefined).catch(() => []);
+  const main = all.find((t) => t.is_main)?.path;
+  const named = all.find((t) => t.path === path);
+  if (!named) throw new Error(`no worktree at ${path}`);
+  if (named.is_main) throw new Error(`${path} is the repository itself`);
+  await neosh.git.removeWorktree(path, { cwd: main ?? cwd, force: true });
+  await neosh.cmd.exec("project.forget", [path]).catch(() => {});
 }
 
 /**

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -28,7 +28,7 @@
  * - **`sidebar.section` is a contribution point.** Anything you can describe as rows appears in the
  *   column, in the position you ask for, invoking your commands.
  * - **`sidebar.action` is a verb on a row.** Say the key, the label and the command; this panel
- *   binds it, shows it in the hint strip when it applies, and invokes your command with the row
+ *   binds it, shows it on the key card when it applies, and invokes your command with the row
  *   under the cursor as arguments.
  *
  * What a project *is* — pinned, ordered, folded — lives in shared project vars rather than in this
@@ -36,7 +36,7 @@
  * favourites rather than each starting empty.
  */
 
-import { byteLength, projectScope } from "@neosh/api";
+import { byteLength, projectScope, width } from "@neosh/api";
 import { CLONE_EVENT } from "@neosh/api";
 import type {
   AgentSummary,
@@ -44,6 +44,7 @@ import type {
   Contribution,
   Disposable,
   DrawnRow,
+  KeymapEntry,
   Neosh,
   PluginContext,
   NodeInfo,
@@ -63,6 +64,10 @@ import {
   confirmDestructive,
   configureMotion,
   CursoredList,
+  discardWorktrees,
+  orphanedWorktrees,
+  worktreeAt,
+  worktreeLines,
   type Decoration,
   type DecorationItem,
   badgeWidth as badgeColumns,
@@ -82,6 +87,7 @@ import {
   pathPicker,
   picker,
   type PickerItem,
+  prettyKey,
   prompt,
   pulseBright,
   pulseHl,
@@ -155,7 +161,7 @@ function targetKey(t: Target | undefined): string | null {
 interface ActionItem {
   /** Key notation, as `keymap.set` takes it: `d`, `<C-y>`, `gd`. */
   key: string;
-  /** What it does, for the hint strip and for `^Z`. */
+  /** What it does, for the key card and for `^Z`. */
   label: string;
   command: string;
   /**
@@ -173,6 +179,17 @@ interface ActionItem {
    * panel is what resolves it — see {@link applies}.
    */
   on?: string;
+}
+
+/** A contributed verb as this panel bound it: whose it is, and the binding its key points at. */
+interface BoundAction extends ActionItem {
+  plugin: string;
+  /**
+   * The command the key was bound to here — the panel's wrapper, not the contributor's `command`,
+   * which is what the wrapper runs. `null` when the key was refused, one of ours, and so was never
+   * bound at all.
+   */
+  binding: string | null;
 }
 
 /** A project as the panel thinks of it: a directory, and what is going on in it. */
@@ -202,6 +219,20 @@ const KIND = "neosh.sidebar";
 
 /** Emitted on every cursor move, with the row under it as `data` — a {@link Target} or `null`. */
 const EVENT_CURSOR = "sidebar.cursor";
+
+/** The key card beside the panel. A kind of its own, so a theme or a plugin can find it. */
+const KIND_KEYS = "neosh.sidebar.keys";
+
+/**
+ * What each of this panel's verbs says on each kind of row, for the key card.
+ *
+ * Keyed by command name and holding only the *words*: the key itself is read out of the registry
+ * when the card is drawn, so a binding somebody moved in `init.ts` shows the letter that works —
+ * a legend is a promise about a keyboard. A verb with no entry here is about the panel rather than
+ * about a row (a motion, the width, the way out) and the card's foot covers those. Two keys with
+ * the same words on one kind of row share a line, which is what `↵` and `space` on a project are.
+ */
+const ABOUT = new Map<string, Partial<Record<Target["kind"], string>>>();
 
 /**
  * What this panel offers a plugin that imports it: `import { api } from "plugin:sidebar"`.
@@ -361,6 +392,12 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
     const count = { pending: "" };
     let capture: Disposable | null = null;
     let running = false;
+    // The keys for the row under the cursor, beside the panel. Through `here`, so it opens on the
+    // terminal this panel is on; `arming` is the delay before it appears, cancelled by leaving.
+    const card = new KeyCard(here);
+    let arming: Disposable | null = null;
+    /** Where the card goes: just past the panel's rule, level with the cursor's row. */
+    const cardAt = (): [number, number] => [panelWidth + 1, list.cursorScreenRow ?? 0];
 
     // Serialises redraws. Two overlapping refreshes interleave their `setLines` and `mark` calls
     // and leave highlights pointing at rows that have already been replaced.
@@ -407,6 +444,12 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
             win: win ?? undefined,
             pinned: built.pinned,
           });
+          // After the render, which is what decides which screen row the cursor's row is on. A
+          // draw that changed nothing the card says is a draw the card ignores.
+          if (focused && win !== null && card.isOpen()) {
+            const [col, row] = cardAt();
+            await card.draw(list.value, actions(), win, col, row);
+          }
         } while (again);
       } finally {
         drawing = false;
@@ -459,8 +502,35 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
       focused = false;
       capture?.dispose();
       capture = null;
+      arming?.dispose();
+      arming = null;
+      await card.close();
       await here.focus.pop().catch(() => {});
       await draw();
+    };
+
+    /**
+     * Put the key card up, after the delay the window prefix's list waits.
+     *
+     * `ui.keys.hint_delay` rather than a setting of this panel's own, because it is the same
+     * bargain: a panel that appears while you are still typing is a flash, and one that appears
+     * when you have paused is an answer. Both are read here rather than at activation, so a change
+     * in `config.toml` takes effect the next time the panel is entered.
+     */
+    const armCard = async () => {
+      const wanted = (await neosh.opt.get<boolean>("sidebar.legend").catch(() => null)) ?? true;
+      if (!wanted) return;
+      const delay = (await neosh.opt.get<number>("ui.keys.hint_delay").catch(() => null)) ?? 300;
+      arming?.dispose();
+      arming = neosh.timer.after(Math.max(0, delay), () => {
+        arming = null;
+        void (async () => {
+          if (!focused || win === null) return;
+          const [col, row] = cardAt();
+          await card.open(win, col, row);
+          await card.draw(list.value, actions(), win, col, row);
+        })().catch((e: unknown) => neosh.log.warn(`sidebar: key card: ${String(e)}`));
+      });
     };
 
     const close = async () => {
@@ -495,6 +565,7 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
         list.select((t) => t.kind === "session" && t.id === current.id);
       }
       await draw();
+      await armCard();
     };
 
     return {
@@ -523,9 +594,12 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
       dispose: () => {
         capture?.dispose();
         capture = null;
+        arming?.dispose();
+        arming = null;
         // Not closed here: the terminal has gone and the host took its windows with it. Closing a
         // window that is already gone is an error message about nothing.
         win = null;
+        card.forget();
       },
     };
   };
@@ -750,7 +824,14 @@ async function declareOptions(neosh: Neosh): Promise<void> {
     type: { type: "bool" },
     default: true,
     description:
-      "Show the keys for whatever the cursor is on, at the foot of the panel. Turn it off once they are in your fingers.",
+      "Show the main keys at the foot of the panel. Turn it off once they are in your fingers.",
+  });
+  await neosh.opt.declare({
+    name: "sidebar.legend",
+    type: { type: "bool" },
+    default: true,
+    description:
+      "While the panel has the keyboard, a card beside it lists every key for the row under the cursor. It appears after `ui.keys.hint_delay`, so moving through the list never flashes one.",
   });
   await neosh.opt.declare({
     name: "sidebar.refresh_ms",
@@ -1125,8 +1206,12 @@ async function registerCommands(w: Wiring): Promise<void> {
     key: string | null,
     desc: string,
     fn: (p: Panel, target: Target | undefined, args: string[]) => Promise<void> | void,
-    opts: { redraw?: boolean } = {},
+    opts: { redraw?: boolean; on?: Partial<Record<Target["kind"], string>> } = {},
   ): Promise<void> => {
+    // What the card beside the panel says for it, per kind of row it applies to. `desc` is the
+    // sentence `^Z` prints for every row at once; this is the short form for the one row you are
+    // on, which is a different sentence on a project than on a conversation.
+    if (opts.on) ABOUT.set(name, opts.on);
     w.subscriptions.push(
       // The panel the key was pressed in. Every verb below acts on one terminal's column — its
       // cursor, its fold state, its half-typed count — and with several open, "the panel" is not
@@ -1266,12 +1351,21 @@ async function registerCommands(w: Wiring): Promise<void> {
     "<CR>",
     "Open a conversation, fold a project, or run the row",
     (p, target) => activateTarget(neosh, arrangement, target, p),
-    { redraw: false },
+    {
+      redraw: false,
+      on: {
+        session: "open",
+        project: "fold or unfold",
+        add: "add a project",
+        custom: "run it",
+        remote: "watch it",
+      },
+    },
   );
   await verb(`${NS}.fold`, "<Space>", "Fold or unfold this project", async (p, target) => {
     if (target?.kind !== "project") return;
     await arrangement.toggleFold(target.cwd);
-  });
+  }, { on: { project: "fold or unfold" } });
   await verb(`${NS}.favorite`, "f", "Pin this project to the top", async (p, target) => {
     let cwd = owningProject(target);
     if (cwd === null) return;
@@ -1285,7 +1379,7 @@ async function registerCommands(w: Wiring): Promise<void> {
     // is already in — saying so in the corner as well is the same fact twice, and a corner that is
     // usually restating something visible is one people stop reading.
     await arrangement.toggleFavorite(cwd);
-  });
+  }, { on: { project: "pin to the top", session: "pin its project to the top" } });
 
   // Shift moves the thing rather than the cursor — the one convention every list that can be
   // rearranged already shares.
@@ -1298,13 +1392,15 @@ async function registerCommands(w: Wiring): Promise<void> {
     if (cwd === null) return;
     await arrangement.move(await groups(), cwd, delta);
   };
-  await verb(`${NS}.move.down`, "J", "Move this project down", reorder(1));
-  await verb(`${NS}.move.up`, "K", "Move this project up", reorder(-1));
+  // One line on the card for the pair — the same words on both, so they share it.
+  const moving = { project: "move up or down", session: "move its project up or down" };
+  await verb(`${NS}.move.down`, "J", "Move this project down", reorder(1), { on: moving });
+  await verb(`${NS}.move.up`, "K", "Move this project up", reorder(-1), { on: moving });
 
   await verb(`${NS}.rename`, "r", "Rename this conversation", async (p, target) => {
     if (target?.kind !== "session") return;
     await renameSession(neosh, target.id);
-  });
+  }, { on: { session: "rename" } });
   // The panel's own copy verb, same letter the transcript uses. What a row is *at* is the thing
   // you paste into a terminal, an editor or a message, and retyping a generated worktree path is
   // the kind of chore this panel exists to remove.
@@ -1313,14 +1409,14 @@ async function registerCommands(w: Wiring): Promise<void> {
     if (cwd === null) return;
     await neosh.edit.copy(cwd);
     neosh.notify(`copied ${cwd}`);
-  }, { redraw: false });
+  }, { redraw: false, on: { project: "copy its directory", session: "copy its directory" } });
   // The everyday verb, and it is reversible. Archiving takes a conversation out of the list without
   // taking anything away, which is what people were reaching for `x` to do before `x` deleted
   // things. Where it goes is `a`, not four dim rows at the foot of this panel.
   await verb(`${NS}.archive`, "x", "Archive this conversation", async (p, target) => {
     if (target?.kind !== "session") return;
     await setArchived(neosh, target.id, true);
-  });
+  }, { on: { session: "archive" } });
   // Shifted, because this is the one that cannot be undone.
   //
   // One key, two rows, and the same sentence: take this off the list for good. On a heading that is
@@ -1338,6 +1434,7 @@ async function registerCommands(w: Wiring): Promise<void> {
       if (target?.kind !== "session") return;
       await deleteSession(neosh, target.id);
     },
+    { on: { session: "delete", project: "remove from the list" } },
   );
   await verb(`${NS}.new`, "n", "New conversation in this project", async (p, target) => {
     // The same question `^N` asks, about the project you are looking at — which is the whole reason
@@ -1348,7 +1445,10 @@ async function registerCommands(w: Wiring): Promise<void> {
     const cwd = owningProject(target) ?? undefined;
     await p.leave();
     await newConversation(neosh, arrangement, cwd);
-  }, { redraw: false });
+  }, {
+    redraw: false,
+    on: { project: "new conversation here", session: "new conversation in this project" },
+  });
 
   // ---- doors out of the panel ----
   //
@@ -1496,6 +1596,28 @@ async function registerCommands(w: Wiring): Promise<void> {
       w.each((p) => p.draw());
     }, { desc: "Take a project off the list" }),
   );
+  w.subscriptions.push(
+    await neosh.cmd.register("project.forget", async (args) => {
+      // The row, and only the row: no dialog and nothing deleted. For a directory that has already
+      // gone — a worktree the git plugin or the archive just took off the disk — whose row would
+      // otherwise sit here saying `nothing here yet` about a place that is not there. A project
+      // with conversations still in it is refused, because forgetting it would not empty it and a
+      // caller that wanted them deleted has `project.remove`.
+      const cwd = args[0]?.trim();
+      if (!cwd) {
+        neosh.notify("project.forget needs a directory", "warn");
+        return;
+      }
+      const inside = (await neosh.session.list({ includeArchived: true }).catch(() => []))
+        .some((s) => s.cwd === cwd);
+      if (inside) {
+        neosh.notify(`${short(cwd)} still has conversations in it — \`project.remove\` deletes them`, "warn");
+        return;
+      }
+      await arrangement.forget(cwd);
+      w.each((p) => p.draw());
+    }, { desc: "Drop a project's row without deleting anything — for a directory that has gone" }),
+  );
 
   await neosh.keymap.set("chat", "<C-b>", "sidebar.toggle", { desc: "Toggle the sidebar" });
   await neosh.keymap.set("chat", "<C-t>", "sidebar.focus", { desc: "Projects and conversations" });
@@ -1554,7 +1676,7 @@ function installActions(
   neosh: Neosh,
   panel: (view?: ViewId) => Panel | null,
   onChange: () => void,
-): { actions: () => ActionItem[]; dispose: Disposable } {
+): { actions: () => BoundAction[]; dispose: Disposable } {
   const scope = { kind: "buf_kind", name: KIND } as const;
   let current: Array<Contribution & { item: ActionItem }> = [];
   let bound: Array<{ key: string; command: string }> = [];
@@ -1613,7 +1735,7 @@ function installActions(
 
     for (const [key, claimants] of sharing) {
       // The narrow verbs first: a verb about the row you are standing on beats one about every row,
-      // which is the same ranking the hint strip prints them in and for the same reason. A key that
+      // which is the same ranking the key card prints them in and for the same reason. A key that
       // meant "cycle the plan detail" wherever the cursor was would be a key that did the wrong
       // thing on somebody else's block.
       const ranked = [
@@ -1649,7 +1771,16 @@ function installActions(
   });
 
   return {
-    actions: () => current.map((c) => c.item),
+    // With the command each one's key was bound under, which is how the key card finds the key
+    // in the registry rather than trusting the key the contributor asked for: a user who moved it
+    // in `init.ts` has the new letter on the card. A key that was refused has no binding and no
+    // command, and the card leaves it out for the reason the strip did.
+    actions: () =>
+      current.map((c) => ({
+        ...c.item,
+        plugin: c.plugin,
+        binding: bound.find((b) => b.key === c.item.key)?.command ?? null,
+      })),
     dispose: {
       dispose() {
         sub.dispose();
@@ -2511,10 +2642,16 @@ async function deleteSession(neosh: Neosh, session: string): Promise<boolean> {
   const info = (await neosh.session.list({ includeArchived: true }).catch(() => [] as SessionInfo[]))
     .find((s) => s.id === session);
   const count = info?.message_count ?? 0;
+  // The checkout this was the last conversation in, if it was one. A worktree is made for the
+  // conversations in it, so the last of them going takes the directory too — said in the same
+  // dialog, because a delete that quietly removes a directory is a delete whose question did not
+  // say what was at stake.
+  const trees = await orphanedWorktrees(neosh, [session]);
   const detail = [
     count === 0
       ? "Nothing has been said in it yet."
       : `${count} ${count === 1 ? "message" : "messages"}, in ${info?.project || basename(info?.cwd ?? "")}.`,
+    ...worktreeLines(trees),
     info?.archived
       ? "It is archived, so leaving it here costs nothing."
       : "Archiving keeps every word of it and takes it out of your list.",
@@ -2527,11 +2664,13 @@ async function deleteSession(neosh: Neosh, session: string): Promise<boolean> {
   if (!ok) return false;
   try {
     await neosh.session.close(session);
-    return true;
   } catch (e) {
     neosh.notify(String(e), "warn");
     return false;
   }
+  const removed = await discardWorktrees(neosh, trees);
+  if (removed > 0) neosh.notify(`removed the worktree at ${trees[0]?.path ?? ""}`);
+  return true;
 }
 
 /**
@@ -2558,15 +2697,31 @@ async function removeProject(
   const inside = (await neosh.session.list({ includeArchived: true }).catch(() => [] as SessionInfo[]))
     .filter((s) => s.cwd === cwd);
   const name = inside[0]?.project || arrangement.name(cwd) || basename(cwd);
+  // A worktree row is a directory this workspace made for the conversations in it, and removing
+  // the row is removing the last reason for the checkout to be on the disk. The repository itself
+  // is never this: `worktreeAt` answers only for a tree `git worktree list` says is one, and never
+  // for the main checkout, so `X` on a repository's row is what it always was — the row goes and
+  // the directory stays.
+  const root = inside.find((s) => s.repo_root)?.repo_root ?? arrangement.root(cwd) ?? "";
+  const tree = await worktreeAt(neosh, cwd, root);
+  const trees = tree ? [tree] : [];
 
-  if (inside.length > 0) {
+  if (inside.length > 0 || trees.length > 0) {
     const many = inside.length === 1 ? "conversation" : `${inside.length} conversations`;
-    const ok = await confirmDestructive(neosh, `Remove "${clip(name, 40)}" and its ${many}?`, {
-      yes: "Delete",
+    const question = inside.length === 0
+      ? `Remove the worktree "${clip(name, 40)}"?`
+      : trees.length > 0
+      ? `Remove the worktree "${clip(name, 40)}" and its ${many}?`
+      : `Remove "${clip(name, 40)}" and its ${many}?`;
+    const ok = await confirmDestructive(neosh, question, {
+      yes: trees.length > 0 ? "Remove" : "Delete",
       no: "Keep",
       detail: [
-        atStake(inside),
-        "`x` on a conversation archives it instead, and an archived one is already out of the way.",
+        ...(inside.length > 0 ? [atStake(inside)] : []),
+        ...worktreeLines(trees),
+        ...(inside.length > 0
+          ? ["`x` on a conversation archives it instead, and an archived one is already out of the way."]
+          : []),
       ],
     });
     if (!ok) return;
@@ -2580,8 +2735,11 @@ async function removeProject(
     }
   }
 
+  const removed = await discardWorktrees(neosh, trees);
   await arrangement.forget(cwd);
-  neosh.notify(`removed ${short(cwd)} — \`o\` adds it back`);
+  neosh.notify(
+    removed > 0 ? `removed the worktree at ${cwd}` : `removed ${short(cwd)} — \`o\` adds it back`,
+  );
 }
 
 /**
@@ -3357,8 +3515,8 @@ interface DrawOptions {
   hints: boolean;
   focused: boolean;
   selected: Target | undefined;
-  /** The verbs other plugins put on our rows, for the hint strip. */
-  actions: ActionItem[];
+  /** The verbs other plugins put on our rows, for the key card. */
+  actions: BoundAction[];
   /** Which conversations are waiting on an answer from you. See [`VAR_ASKING`]. */
   asking: Set<string>;
   /** Marks other plugins put on our rows, by [`targetKey`]. See [`POINT_DECORATION`]. */
@@ -3459,7 +3617,9 @@ async function collect(
       // to be widened, and `>` was bound, documented and invisible — advertised on contributed
       // rows only, which is the one kind of row most people never stand on. Only while the panel
       // has the keyboard, because that is when the key does anything.
-      rows.push(...heading("PROJECTS", opts.width, opts.focused ? "<> width" : undefined));
+      // The key on the heading is the one that gets you in, and then the one that gets you out:
+      // a key beside the thing it acts on, which is where a key is found rather than learned.
+      rows.push(...heading("PROJECTS", opts.width, opts.focused ? "esc" : "^T"));
       for (const p of projects) {
         rows.push(projectRow(p, arrangement, opts, now));
         if (arrangement.isFolded(p.cwd)) continue;
@@ -3505,6 +3665,9 @@ async function collect(
       rows.push({
         text: " + Add project",
         hl: "Accent",
+        // The key for this row, on this row. `^O` from the composer; `o` from anywhere in the
+        // panel, which is the same question asked from nearer by.
+        right: { text: `${opts.focused ? "o" : "^O"} `, hl: "Sidebar.Key" },
         value: { kind: "add" },
       });
     },
@@ -3537,9 +3700,9 @@ function heading(text: string, width: number, hint?: string): ListRow<Target>[] 
     {
       text: ` ${text}`,
       hl: "Sidebar.Heading",
-      // Dim, and on the heading rather than beside the title: it is an answer to "and then what",
-      // which is a question you ask after reading the section, not while finding it.
-      right: hint ? { text: `${hint} `, hl: "Sidebar.Dim" } : undefined,
+      // On the heading rather than beside the title: it is an answer to "and then what", which is
+      // a question you ask after reading the section, not while finding it.
+      right: hint ? { text: `${hint} `, hl: "Sidebar.Key" } : undefined,
       inert: true,
     },
     { text: "─".repeat(Math.max(1, width)), hl: "Separator", inert: true },
@@ -3937,37 +4100,44 @@ function turnFor(s: SessionInfo, now: number): string {
 }
 
 /**
- * The keys for whatever the cursor is on.
+ * The main keys, at the foot.
  *
- * Contextual rather than a fixed cheat sheet: `x` closes a conversation and means nothing on a
- * project, and a list of verbs that do not all apply is a list you learn to distrust. Everything
- * here is also reachable from `?`, which is the escape hatch when the panel is too narrow.
+ * Only the main ones. This strip used to carry every verb for the row under the cursor, packed two
+ * to a line in one dim colour, and what that looked like was a paragraph — a row of `f ★  JK move
+ * n new  y path` is read once and then never again. The verbs for a row are on the key card beside
+ * the panel now, one per line and level with the row they are about, and `?` is the whole sheet.
+ * What stays here is what you press from wherever you are: the way in, the way out, and the doors
+ * to the rest of the workspace.
+ *
+ * Laid out as a grid rather than packed: the keys line up in columns and wear `Sidebar.Key`, so
+ * the eye lands on the letters and the words are what they mean. Cells come off the end when the
+ * column is narrow, except the last, which is the way to everything that did not fit.
  */
 function hints(opts: DrawOptions): ListRow<Target>[] {
   const kind = opts.selected?.kind;
-  const lines = strip(
-    !opts.focused
-      // `^O` is not here and `+ Add project` is a row you can see: a key strip has two lines, and
-      // the verb with a row of its own is the one that can afford to give up its place on them.
-      ? ["^T projects", "^N new", "^F archive", "^K palette", "^B hide", "^Z keys"]
-      : kind === "custom"
-        ? ["↵ open it", "esc back", "? keys"]
-      : kind === "project"
-        // `X` is on the strip because a list you cannot shorten is a list that grows forever, and
-        // a project that outlives its conversations — which is the point of it — has to have a way
-        // off.
-        ? ["↵ fold", "f ★", "JK move", "n new", "y path", "X remove", "? keys"]
-        : kind === "session"
-          ? ["↵ open", "r rename", "x archive", "X delete", "y path", "? keys"]
-          : ["↵ add project", "esc back", "? keys"],
-    opts.width,
-  );
-
-  // Contributed verbs get their own line rather than being squeezed onto ours, because ours are
-  // laid out in columns that a third party's label of unknown length would break — and because a
-  // key nobody can see is a key nobody presses, which is the whole argument for this strip.
-  const mine = opts.focused ? contributedHint(opts) : "";
-
+  const cells: Array<[string, string]> = !opts.focused
+    // `^T` is on the heading and `^O` on the add row, beside what they act on. What is left is
+    // what has no row of its own.
+    ? [["^N", "new"], ["^F", "archive"], ["^K", "palette"], ["^B", "hide"], ["^Z", "keys"]]
+    : [
+      // What `↵` does *here*, because a strip that says `open` over a project is a strip you
+      // learn to distrust.
+      [
+        "↵",
+        kind === "project"
+          ? "fold"
+          : kind === "add"
+          ? "add"
+          : kind === "custom"
+          ? "run"
+          : kind === "remote"
+          ? "watch"
+          : "open",
+      ],
+      ["?", "keys"],
+      ["esc", "back"],
+    ];
+  const lines = grid(cells, opts.width);
   return [
     blank(),
     { text: "─".repeat(Math.max(1, opts.width)), hl: "Separator", inert: true },
@@ -3975,91 +4145,255 @@ function hints(opts: DrawOptions): ListRow<Target>[] {
     // effect until the next one, which is indistinguishable from a key that does nothing. On the
     // first key line rather than on the rule above it — the rule is a row of full width, and a
     // flush-right virtual text has nowhere to sit on a row that is already full.
-    ...lines.map((text, i) => ({
-      text: ` ${text}`,
+    ...lines.map((line, i) => ({
+      text: line.text,
+      spans: line.spans,
       hl: "Sidebar.Dim",
       right: i === 0 && opts.count !== "" ? { text: `${opts.count} `, hl: "Accent" } : undefined,
       inert: true,
     })),
-    ...(mine === "" ? [] : [{ text: ` ${mine}`, hl: "Sidebar.Dim", inert: true }]),
   ];
 }
 
 /**
- * A key strip packed into the column it is actually drawn in.
+ * Key cells in aligned columns, at most two lines of them.
  *
- * These lines used to be written out by hand with their columns lined up by eye, which is a layout
- * that is right at exactly one width: the project row's second line came to thirty-six columns in
- * a panel that is thirty-four wide by default, and what fell off the end was `? keys` — clipped to
- * `? k`. A strip that truncates its own escape hatch is worse than one that never mentioned it.
- *
- * So: verbs in order of how much you need them, packed greedily onto two lines, and whatever does
- * not fit is dropped. The **last** cell is the way to everything dropped — `? keys`, or `^Z keys`
- * when the panel does not have the keyboard — so if anything was dropped it takes the final slot.
- * Greedy rather than even columns because these cells are three columns wide (`f ★`) and eight
- * (`X remove`), and a grid sized for the widest fits four fewer verbs than the panel has room for.
+ * Every cell is padded to the widest, so the keys make a column and the words make another — a
+ * strip you can scan down rather than read along. How many columns is worked out from the width
+ * the panel actually has, and what does not fit in two lines is dropped from the end, keeping the
+ * last cell: that one is `keys`, the way to everything dropped, and a strip that truncates its own
+ * escape hatch is worse than one that never mentioned it.
  */
-function strip(cells: string[], width: number): string[] {
-  const cols = (s: string) => Array.from(s).length;
+function grid(
+  cells: Array<[string, string]>,
+  width: number,
+): Array<{ text: string; spans: Array<{ from: number; to: number; hl: string }> }> {
+  const cols = (t: string) => Array.from(t).length;
   const room = Math.max(1, width - 1);
-  const last = cells[cells.length - 1] ?? "";
-  const lines: string[] = [];
-  let placed = 0;
-  for (const cell of cells) {
-    const open = lines.length === 0 ? "" : lines[lines.length - 1] ?? "";
-    if (open !== "" && cols(`${open}  ${cell}`) <= room) {
-      lines[lines.length - 1] = `${open}  ${cell}`;
-    } else if (lines.length < 2 && cols(cell) <= room) {
-      lines.push(cell);
-    } else {
-      break;
-    }
-    placed++;
+  const cell = Math.max(...cells.map(([k, l]) => cols(k) + 1 + cols(l)));
+  const perLine = Math.max(1, Math.floor((room + 2) / (cell + 2)));
+  let shown = cells;
+  if (cells.length > perLine * 2) {
+    const last = cells[cells.length - 1];
+    shown = cells.slice(0, perLine * 2 - 1);
+    if (last) shown.push(last);
   }
-  // Anything left unplaced means the strip is incomplete, so its last line has to end at the way in
-  // to the rest. Verbs come off the tail to make room for it rather than it being appended, because
-  // appending is exactly what overflowed — this is counting the same columns the loop above did.
-  if (placed < cells.length && lines.length > 0) {
-    const at = lines.length - 1;
-    let tail = lines[at] ?? "";
-    while (tail !== "" && cols(`${tail}  ${last}`) > room) {
-      const cut = tail.lastIndexOf("  ");
-      tail = cut < 0 ? "" : tail.slice(0, cut);
+  const lines: Array<{ text: string; spans: Array<{ from: number; to: number; hl: string }> }> =
+    [];
+  for (let i = 0; i < shown.length; i += perLine) {
+    let text = " ";
+    const spans: Array<{ from: number; to: number; hl: string }> = [];
+    for (const [j, [key, label]] of shown.slice(i, i + perLine).entries()) {
+      if (j > 0) text += "  ";
+      const from = byteLength(text);
+      text += key;
+      spans.push({ from, to: byteLength(text), hl: "Sidebar.Key" });
+      text += ` ${label}`;
+      // Pad to the column, except the last cell on the line — trailing spaces are what a
+      // flush-right count would have to sit on top of.
+      if (j < perLine - 1) text += " ".repeat(Math.max(0, cell - cols(key) - 1 - cols(label)));
     }
-    lines[at] = tail === "" ? last : `${tail}  ${last}`;
+    lines.push({ text: text.trimEnd(), spans });
   }
   return lines;
 }
 
-/** The contributed verbs that apply to the row under the cursor, clipped to the column. */
-function contributedHint(opts: DrawOptions): string {
-  const applicable = opts.actions.filter((a) => applies(a.on ?? "any", opts.selected));
-  if (applicable.length === 0) return "";
-  // The verbs about *this row* first, then the ones about any of them.
-  //
-  // One line, in a column that is 34 wide by default, and a third plugin's verb is what takes it
-  // past the edge. Which one gets clipped is therefore a decision this makes rather than one the
-  // order plugins happened to load in makes for it — and a key that only applies to the row you are
-  // standing on is the one that has to survive: a verb about every row is a verb you will see again
-  // the moment you move.
+/** One line of the key card: the keys, and what they do on this row. */
+interface LegendLine {
+  keys: string[];
+  label: string;
+}
+
+/**
+ * What the card beside the panel says for the row under the cursor.
+ *
+ * Built from the registry and nothing else. `maps` is every binding on this panel's kind as the
+ * host holds it right now; {@link ABOUT} says which of this panel's verbs apply to this kind of row
+ * and in what words, and the contributed verbs say so themselves. So a key moved in `init.ts`
+ * shows the letter that works, a verb a plugin withdrew is gone, and a key nothing in the panel
+ * claims is not advertised. Two keys with the same words share a line.
+ *
+ * The contributed verbs about *this row* come before the ones about any row, which is the same
+ * ranking the dispatcher uses when two plugins want one key — so the line for a key is what that
+ * key would actually do here, and never a second meaning for the same press.
+ */
+function legendLines(
+  target: Target | undefined,
+  maps: KeymapEntry[],
+  actions: BoundAction[],
+): LegendLine[] {
+  const kind = target?.kind;
+  if (kind === undefined) return [];
+  const keysOf = new Map<string, string[]>();
+  for (const m of maps) {
+    if (m.scope.kind !== "buf_kind" || m.scope.name !== KIND) continue;
+    const list = keysOf.get(m.command) ?? [];
+    list.push(m.lhs);
+    keysOf.set(m.command, list);
+  }
+  const lines: LegendLine[] = [];
+  const add = (command: string, label: string, share: boolean) => {
+    const keys = keysOf.get(command);
+    if (!keys || keys.length === 0) return;
+    const pretty = keys.map(prettyKey);
+    // Only this panel's own verbs share a line, and only with each other: `↵` and `space` both
+    // say `fold or unfold` because they *are* the same verb. A contributed verb whose label
+    // happens to match one of ours is a different verb — the archive plugin's `a` opens the
+    // archive, `x` puts a conversation in it — and one line for both would be a lie about `a`.
+    const shared = share ? lines.find((l) => l.label === label) : undefined;
+    if (shared) shared.keys.push(...pretty.filter((k) => !shared.keys.includes(k)));
+    else lines.push({ keys: pretty, label });
+  };
+  for (const [command, about] of ABOUT) {
+    const label = about[kind];
+    if (label) add(command, label, true);
+  }
+  const applicable = actions.filter((a) => applies(a.on ?? "any", target));
   const ranked = [
     ...applicable.filter((a) => (a.on ?? "any") !== "any"),
     ...applicable.filter((a) => (a.on ?? "any") === "any"),
   ];
-  // One line per key, and the line is what that key would actually do here.
-  //
-  // Several plugins may want one key on their own rows and the binding sends it to whichever of
-  // them the cursor is over — so a strip that printed all of them would advertise two meanings for
-  // one press and be wrong about at least one. The ranking above is the same one the dispatcher
-  // uses, so the survivor is the verb that fires.
   const seen = new Set<string>();
-  const cells: string[] = [];
   for (const a of ranked) {
-    if (seen.has(a.key)) continue;
+    if (a.binding === null || seen.has(a.key)) continue;
     seen.add(a.key);
-    cells.push(`${a.key} ${a.label}`);
+    add(a.binding, a.label, false);
   }
-  return clip(cells.join("   "), Math.max(4, opts.width - 2));
+  return lines;
+}
+
+/** What the card is called, by the kind of row it is about. */
+function legendTitle(target: Target | undefined): string {
+  switch (target?.kind) {
+    case "session":
+      return "conversation";
+    case "project":
+      return "project";
+    case "add":
+      return "add a project";
+    case "remote":
+      return "on another machine";
+    case "custom":
+      return target.section ?? "this row";
+    default:
+      return "keys";
+  }
+}
+
+/**
+ * The key card: every key for the row under the cursor, beside the panel and level with the row.
+ *
+ * The strip at the foot used to try to say this and could not — two dim lines, packed, and the
+ * verbs that did not fit dropped. A card has room: one key per line, the key in its own colour,
+ * the words after it, as wide as the widest line and as tall as there are lines. It sits in the
+ * main region just past the panel's rule, at the row of the thing it is about, so the eye goes
+ * from the row to its keys and back without reading anything else.
+ *
+ * It appears after `ui.keys.hint_delay`, the rule the window prefix already follows: somebody who
+ * presses `^T j j ↵` fluently never sees it, and somebody who pauses is answered. Once open it
+ * follows the cursor without closing — a card that blinked on every `j` would be worse than none.
+ * It never takes the keyboard, and it goes with the panel's focus.
+ *
+ * One per panel, which is one per terminal, opened through the panel's own view-bound `neosh` so
+ * it lands on the screen the panel is on.
+ */
+class KeyCard {
+  private buf: BufferId | null = null;
+  private win: WindowId | null = null;
+  private ns: number | null = null;
+  private maps: KeymapEntry[] = [];
+  /** What is on it and where, so a tick that changes nothing costs nothing. */
+  private drawn = "";
+
+  constructor(private readonly neosh: Neosh) {}
+
+  isOpen(): boolean {
+    return this.win !== null;
+  }
+
+  /**
+   * Put the card up beside `anchor`, level with `row` of it.
+   *
+   * The registry is read here, once per opening, rather than on every move: a binding changes
+   * when a plugin loads or `init.ts` runs, both of which are before anybody is in the panel.
+   */
+  async open(anchor: WindowId, col: number, row: number): Promise<void> {
+    if (this.win !== null) return;
+    this.maps = await this.neosh.keymap.list("chat").catch(() => [] as KeymapEntry[]);
+    const buf = await this.neosh.buf.create({
+      name: "[sidebar keys]",
+      scratch: true,
+      kind: KIND_KEYS,
+    });
+    this.buf = buf;
+    this.ns = await this.neosh.ns.create(KIND_KEYS);
+    this.win = await this.neosh.float.open(buf, {
+      anchor: { kind: "window", win: anchor },
+      offset: { row, col },
+      width: { kind: "auto" },
+      height: { kind: "auto" },
+      border: "rounded",
+      focusable: false,
+      // Under the panels somebody opens on purpose — the key sheet, a picker, a question — and
+      // over the transcript it is drawn across.
+      z: 120,
+    });
+    this.drawn = "";
+  }
+
+  async draw(
+    target: Target | undefined,
+    actions: BoundAction[],
+    anchor: WindowId,
+    col: number,
+    row: number,
+  ): Promise<void> {
+    if (this.win === null || this.buf === null || this.ns === null) return;
+    const lines = legendLines(target, this.maps, actions);
+    const title = legendTitle(target);
+    const signature = JSON.stringify([title, lines, col, row]);
+    if (signature === this.drawn) return;
+    this.drawn = signature;
+    const keyWidth = Math.max(1, ...lines.map((l) => width(l.keys.join(" "))));
+    const rows = lines.length === 0
+      ? [{ text: "  nothing to do here  ", marks: [] }]
+      : lines.map((l) => {
+        const keys = l.keys.join(" ");
+        const pad = " ".repeat(keyWidth - width(keys));
+        const text = `  ${keys}${pad}   ${l.label}  `;
+        return {
+          text,
+          marks: [{ col: 2, opts: { hlGroup: "Sidebar.Key", endCol: 2 + byteLength(keys) } }],
+        };
+      });
+    await this.neosh.buf.render(this.buf, this.ns, 0, -1, rows);
+    await this.neosh.float.configure(this.win, {
+      anchor: { kind: "window", win: anchor },
+      // One row up, so the first key is level with the row it is about rather than the border.
+      offset: { row: row - 1, col },
+      width: { kind: "auto" },
+      height: { kind: "auto" },
+      border: "rounded",
+      title: ` ${title} `,
+      footer: " ? every key   esc back ",
+      focusable: false,
+      z: 120,
+    });
+  }
+
+  async close(): Promise<void> {
+    const win = this.win;
+    this.forget();
+    if (win !== null) await this.neosh.win.close(win).catch(() => {});
+  }
+
+  /** Drop the card without closing it, for when its terminal has already gone. */
+  forget(): void {
+    this.win = null;
+    this.buf = null;
+    this.ns = null;
+    this.drawn = "";
+  }
 }
 
 /**

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -4127,7 +4127,7 @@ function hints(opts: DrawOptions): ListRow<Target>[] {
         kind === "project"
           ? "fold"
           : kind === "add"
-          ? "add"
+          ? "add project"
           : kind === "custom"
           ? "run"
           : kind === "remote"

--- a/website/src/pages/docs/keys.md
+++ b/website/src/pages/docs/keys.md
@@ -157,7 +157,7 @@ What an agent gets when it asks *you* something. Every key here is bound against
 | `y` | Copy the row's directory |
 | `p` | Pull that repository (a git-plugin contribution) |
 | `d` | Remove a worktree from disk. It asks first (a git-plugin contribution) |
-| `x` `X` | Archive, delete. On a project heading, `X` takes the project off the list |
+| `x` `X` | Archive, delete. Deleting the last conversation in a worktree removes the checkout too, and says so. On a repository's heading, `X` takes the project off the list; on a worktree's, it removes the checkout |
 | `a` | The archive |
 | `⇥` | On the plan rows: how much of it to show |
 | `?` | The keys for whatever row you are on |

--- a/website/src/pages/docs/options.md
+++ b/website/src/pages/docs/options.md
@@ -82,7 +82,8 @@ The last two are the window prefix and how long you have to hold it before it li
 | --- | --- | --- |
 | `sidebar.open` | `true` | Show it at startup |
 | `sidebar.width` | `34` | Also what `>` `<` `=` in the panel adjust, so the key and the file say the same number |
-| `sidebar.hints` | `true` | The contextual key strip at the foot of the panel |
+| `sidebar.hints` | `true` | The main keys, at the foot of the panel |
+| `sidebar.legend` | `true` | While you are in the panel, a card beside it listing every key for the row under the cursor. Appears after `ui.keys.hint_delay` |
 | `sidebar.refresh_ms` | `4000` | A workspace re-read per tick |
 
 ## The repository block

--- a/website/src/pages/docs/sidebar.md
+++ b/website/src/pages/docs/sidebar.md
@@ -8,6 +8,8 @@ description: Projects, conversations, worktrees and the archive. What the panel 
 
 The sidebar groups conversations by the directory they were opened in. There is no registry to maintain: opening a conversation somewhere else is how a second project appears. `^O` adds one by path, with completion as you type — or by repository address, which clones it: paste `https://github.com/owner/repo`, the `git@` spelling, or just `owner/repo`, and it asks where it should go, remembers the folders you pick, and leaves you in the new project. `f` pins one to the top, `J`/`K` reorder, and `r` renames a conversation.
 
+You do not have to know any of that. The keys sit beside what they act on — `^T` on the `PROJECTS` heading, `^O` on the `+ Add project` row — and pausing on a row inside the panel opens a **key card** beside it, level with the row, listing every key for that row: fold, pin, pull, remove the worktree, whatever the row is and whatever plugins have added to it. It reads the live keymap, so a key you moved in `init.ts` is the key it prints. It appears after `ui.keys.hint_delay` (300 ms), never takes the keyboard, and `?` is still the whole sheet. `sidebar.legend = false` turns it off.
+
 A conversation's directory is where its work happens, not just where it is filed: the repository git answers about, the root the agent's file tools resolve against, and the directory the model's own agent is started in. Switching conversations moves all of it.
 
 The arrangement (pins, order, folds) is saved under `~/.local/state/neosh/plugin-state/`, not in your config, because an editor that rewrites the file you hand-edited because you pressed a key is one you stop trusting with it.
@@ -16,7 +18,8 @@ The arrangement (pins, order, folds) is saved under `~/.local/state/neosh/plugin
 [options]
 "sidebar.open" = true        # show it at startup
 "sidebar.width" = 34         # also what > < = in the panel adjust
-"sidebar.hints" = true       # the key strip at the foot of the panel
+"sidebar.hints" = true       # the main keys, at the foot of the panel
+"sidebar.legend" = true      # the key card beside the row you are on
 "sidebar.refresh_ms" = 4000
 ```
 
@@ -123,6 +126,8 @@ With a relative root, neosh writes the directory into the repository's `.gitigno
 
 On a worktree's sidebar row: `y` copies its path for the shell you are about to `cd` in, `p` pulls its repository from the remote, and `d` removes the checkout from disk. The branch stays, it asks first, and it tells you how many conversations go with it.
 
+It works the other way round too. A worktree exists for the conversations in it, so deleting the last one — `X` on the row, `X` or `^X` in the archive, `archive.sweep` — removes the checkout as well, and the dialog says so: which directory, that the branch stays, and how many uncommitted changes go with it. `X` on a worktree's own row does the same. The repository itself is never removed; `X` on its heading only takes the row off the list. Pictures pasted into a conversation go with it as well.
+
 ## Generated branch names and commit messages
 
 `git.branch.new` has a model name the branch and shows you the name before creating it; `git.commit` writes a message from the staged diff and shows it before committing. Every prompt behind them is a setting, in two layers: `*.instructions` appends to the built-in prompt, `*.prompt` replaces it.
@@ -139,7 +144,7 @@ On a worktree's sidebar row: `y` copies its path for the shell you are about to 
 
 `x` archives. Everything is kept, every message and the file on disk; it simply leaves the panel. It asks nothing, because it takes nothing away. Archived conversations are not rows in the sidebar at all: `^F` from anywhere, or `a` in the panel, opens the archive as a popup of its own, with filtering, ticking, restore and export. `archive.sidebar = true` puts a count row back for anybody who wants one.
 
-`X` deletes: the file goes and there is no undo, so it always asks, in numbers, saying how many messages and which project. `ui.confirm_destructive = false` turns off every such dialog, everywhere.
+`X` deletes: the file goes and there is no undo, so it always asks, in numbers, saying how many messages and which project — and which worktrees are left empty by it and go too. `ui.confirm_destructive = false` turns off every such dialog, everywhere.
 
 Three time settings, none of which deletes on a timer: `archive.auto_days` archives what has gone idle (reversible, so it may happen on its own), `archive.retention_days` only ever counts, and `archive.sweep` is the same number with a person behind it.
 


### PR DESCRIPTION
## What

**A bug.** A focused project row with a git badge repeated itself on the line below: `decorateRow` appended the badge to the row's unclipped text too, and that text deliberately leaves out the star and the unread mark, so the two strings stopped being prefixes of each other and the list said the whole row again. The badge is past the clip and already on screen, so it no longer goes onto `full`.

**Keys beside what they act on.** `^T` sits on the `PROJECTS` heading (and turns into `esc` inside the panel); `^O` on the `+ Add project` row (`o` inside). The foot keeps only the keys with no row to sit on — `^N` `^F` `^K` `^B` `^Z` outside, `↵` `?` `esc` inside — in aligned columns with the keys in a new `Sidebar.Key` group.

**A key card.** Pause on a row inside the panel and a float appears just past the panel's rule, level with the row, one key per line: the panel's own verbs for that kind of row and every `sidebar.action` that applies. Read from the live keymap, so a key moved in `init.ts` prints the letter that works. Waits `ui.keys.hint_delay` like the `<C-w>` list, follows the cursor without closing, never takes the keyboard; `sidebar.legend = false` turns it off. `?` is still the whole sheet.

**A delete that frees the disk.** Deleting a conversation removes the pictures pasted into it (files in the image store its messages name, and only those) and — when it was the last conversation in a worktree — the checkout, with the dialog naming the directory, that the branch stays, and how many uncommitted changes go with it. Shared by the sidebar's `X`, the archive's `X`, `^X` and sweep. The removal is the git plugin's (`git.worktree.discard`), and `project.forget` drops the row of a directory that has gone, which the git plugin's `d` now uses too. `X` on a repository's heading still only takes the row off the list.

## Verification

- `scripts/check.sh web` passes.
- `cargo test -p neosh-core`, the `neosh` binary's unit tests (a new one for image cleanup), and the ts-rs drift check pass.
- `builtin_plugins`: new tests for the badge row, the key card (and switching it off), the strip, a worktree going with its last conversation (dirty, forced), and the emptied-worktree test rewritten to the new expectation. The only failures locally are the two macOS `/var` vs `/private/var` path compares that fail on every branch.
- Screenshots via `scripts/shot.py` of the strip, the card on a conversation and a project row, and the delete dialog naming the worktree.
