### PR TITLE
Five reported bugs: a spawn that blamed the wrong thing, notices over the composer, a leaking repaint ticker, remote rows that could not say where they were, and a pull with no feedback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,6 +280,46 @@ is `docs/releasing.md`.
   connection with it, so a directory picker aimed at an older peer would knock it off the board
   rather than come back empty. It defaults to `false`, which is what an older handshake decodes to,
   so "does not say" and "cannot" are one answer and a version bump was never needed.
+- **A row that is not on this computer says so with one column, and the colour is the link.** The
+  machine's *name* was on every remote row — up to fourteen columns of the narrowest panel in the
+  workspace, on a block of rows that are all on the same machine, taking the column a local row
+  spends on how long its turn has been running and clipping the conversation's own name to make
+  room. What the row has to carry is one bit — not here — and one fact you cannot act without:
+  whether that machine can be reached, because `↵` on a row is *open and steer it* against a peer
+  that is up and nothing at all against one that is not, and the two were drawn identically. So it
+  is a cloud in the gutter, `Swarm.Up` green when the link is up, `Swarm.Linking` pulsing amber
+  while it is being dialled, `Swarm.Waiting` while it is a person at the far end being waited on,
+  `Swarm.Down` dim when nothing is dialling it. Up and down are **still**: a link that is up is a
+  condition rather than an event and the glyph is on every remote row at once, so motion on all of
+  them is the panel vibrating. Which computer, and what the link is doing in words, is the **key
+  card** — it appears beside the row you pause on and a border has room for a sentence. And the
+  panel is built from `swarm.nodes()` rather than `swarm.agents()`, which is the same list minus
+  the machines that are not up: that filter is right for *what can I act on* and wrong for a list,
+  because a machine going quiet does not take its conversations off your screen, it takes them out
+  of reach, and a list that silently shortens is one you cannot tell from a list that never had
+  them.
+- **A project that is only on other computers is a project row.** Same arrow in the same column,
+  same name beside it, same count on the right — because it is the same kind of thing, and a row
+  that reads differently is one you have to learn separately. It was an inert line with a `▹` on it
+  and the machine names where the count goes, which said "not one of yours" three ways at once,
+  none of them the way the panel says anything else. Its own `Target` kind rather than a `project`
+  with somebody else's path in it: every verb bound against a project — fold, rename, archive,
+  delete, remove from the list — is about a directory on *this* disk, and pointing one at a path
+  that is not here is how a key deletes the wrong thing. It folds on the project *key*, since there
+  is no directory to name it by, and that key is also what `same` compares — left to fall through
+  to `kind === kind` every one of them was the same row and the cursor snapped to the first on
+  every redraw.
+- **Which computer is asked before where on it, and only when there is one to ask about.** With no
+  machine paired — which is most workspaces — `^N` draws nothing extra and is the single key it has
+  always been. The moment a second computer exists, which one is the first thing you would have to
+  decide anyway, and asking it *first* is what makes it a decision rather than a path field you
+  have to know scp's spelling to use. This computer is the first row and the cursor starts on it,
+  so `^N ⏎` is unchanged. Every paired machine is a row including the ones that cannot be used,
+  greyed with the reason — the path field's rule, for the path field's argument: skipping them is
+  right about what can be *done* and wrong about what should be *said*. Choosing one hands you the
+  path field seeded `<machine>:`, which is the state typing it would have reached, so the two
+  routes cannot diverge. `n` on a project that is only elsewhere skips the question when one
+  machine has it: the row already knows which machines and where on each.
 - **What another machine knows about this one is a roster, not a snapshot.** `publish_inventory` was
   called when a peer connected and when a peer drove something here, and never once because somebody
   *sitting at this machine* started, renamed, archived or deleted a conversation — so every other
@@ -417,6 +457,18 @@ is `docs/releasing.md`.
   above every driver, on the copy of the message this turn sends — never on the transcript, never on a tool
   round, and always with a sendable value put back in the selection's place. `^E` shows *all* of
   them at once and applies as you move, because a knob you cannot see is a knob you do not have.
+- **`ENOENT` from a spawn is two different sentences, and the wrong one sends people hunting.**
+  `Command::spawn` reports a working directory it cannot `chdir` into exactly as it reports a
+  program it cannot find — "no such file or directory", os error 2 — and every driver wrote that up
+  as `could not run "claude"`. So a conversation whose directory had gone (a worktree removed by
+  hand, a project moved, a volume unmounted) failed with a sentence about `claude`, while every
+  other conversation in the same workspace went on working, because they are the same binary in a
+  directory that still exists. The one thing on screen said the one thing that was not the problem,
+  and the only way through it is to already know this about `posix_spawn`. `drivers::spawn_failed`
+  is the fix and it is shared by every driver: on the failure path only, ask the two questions the
+  kernel answered with one bit — is the directory there, is the program on `PATH` — and name
+  whichever is actually missing. The directory is checked first, because a conversation far more
+  often outlives its checkout than its agent.
 - **Take the transport that can do the most.** `claude` in stream-json mode with the control
   protocol; `codex app-server`, not `codex exec`; `agy -p= --input-format stream-json`, not the
   540 MB ACP runtime Google also ships — a vendor CLI the user already signed into beats a
@@ -550,6 +602,18 @@ is `docs/releasing.md`.
   answer, with no subprocess. A verb with no `cwd` resolves the conversation's first, because
   everything said about a row is keyed by directory and `git.pull` from the palette is about a
   directory too. Corner progress is kept for what has no row; it is not a substitute for the row.
+  **And it spins from the press, not from the network.** `p` used to do all of its deciding first —
+  a `git status` over the whole tree, then perhaps a fetch — and only mark the row busy once it had
+  settled on a route, so on anything bigger than a toy checkout the key visibly did nothing for a
+  second, which is indistinguishable from a key that is not bound. What somebody wants from `p` is
+  *that it heard them*; what it turns out to do is the second question. So `busy(cwd)` is claimed
+  up front and answers with the one call that releases it — a releaser rather than a second
+  counter, so a `finally` can call it over a path that already released — and it is released around
+  the *question*, because nothing on this machine is working while a person reads two options and a
+  spinner over that means nothing anywhere else either. The other half is that the redraw a
+  *starting* operation asks for must cost nothing: `decorate` keeps the last `RepoStatus` per
+  directory and draws from it while the checkout is busy rather than running a `git status` first,
+  since the numbers a spinner is beside are exactly the ones the operation is about to change.
 - **`/update` is the whole job on every kind of install.** It used to stop at `Update with: brew
   update && brew upgrade neosh` for anything a package manager owned, on the theory that driving
   somebody's package manager behind a keypress is how a machine ends up in a state its owner
@@ -742,6 +806,16 @@ is `docs/releasing.md`.
   terminal never notifies. A turn shorter than `notify.min_turn` finished while you were still
   looking at the key that started it. And `unread` stays the *record*: this points at it once and
   gets out of the way.
+- **And it goes in the corner you are not looking at, which is the top one.** A notice *overlays* —
+  reflowing would move the field you are typing into, which is the one thing it must never do — so
+  the only question it has left is what it covers, and the bottom-right corner answered it with the
+  composer and the last rows of the transcript. Those are the line being typed and the newest thing
+  the agent said: the two places somebody is certainly looking, and a notification is by definition
+  about something they are not. The top of a transcript is scrolled-past text during a turn and
+  empty space the rest of it. It stops short of whatever is docked across the top of the screen,
+  which is the tab strip — always drawn, the only place panes and tabs announce themselves, and
+  therefore never coverable — and the block grows *downwards* from there with the newest last, so a
+  row already on screen does not move when another arrives.
 - **A turn that finished while you were elsewhere is news until you go and look.** The panel says
   what is *happening* and stops the moment it stops, so an answer that arrived while you were in
   another conversation looks exactly like an answer you read yesterday. `SessionInfo::unread` is set
@@ -879,6 +953,15 @@ is `docs/releasing.md`.
   message and nothing else, so N queued messages meant N-1 questions drawn as asked and never put to
   anybody — which reads exactly like being ignored. `take_steering_into` joins them, in the order
   they were typed.
+- **A repaint ticker is one ticker, and a flag alone cannot say so.** Motion on screen arms a 20 fps
+  ticker and the first still frame takes it down, which is right — but `follow_motion(false)` then
+  `follow_motion(true)` inside one 50 ms sleep leaves the sleeping ticker waking to a flag that is
+  `true` again, so it carries on *and* a second one has been spawned beside it. Motion stopping and
+  restarting is not an edge case in a workspace watching an agent work: it is what every tool call
+  does, once when its spinner appears and once when it lands, so a turn with thirty of them is
+  thirty chances to add another 20 fps of repaints that never go away. The ticker carries a
+  generation, claimed on every call whichever way it went, and stops the moment it is not the live
+  one.
 - **A flash is one thing happening; a burst is a redraw.** `Animation::Flash` is the only motion
   here that fires once, so it needs a moment to count from — and a highlight group, shared by every
   row using it, cannot hold one. The *mark* does: an extmark is created once, so the frontend keys
@@ -1050,7 +1133,7 @@ only way to do anything.
 | `^T` | Projects and conversations. Switching is never refused — turns keep running where they are |
 | `^J` | The computers in this workspace. Add one by its address, allow one that is asking, rename one (`^E`), or open what it is running. A machine this one has reached that has not allowed it back says so, and says which key to press over there |
 | `^F` | What you have archived — see below. Filter it, put some back, or finally empty it |
-| `^N` | New conversation. In a repository it asks where: here, a worktree you need not name, one kept inside the project, one you do name, an existing one, another machine, elsewhere. A worktree you did not name is named by your first message — `fix/composer-paste-truncation`, not `wily-nimbus-7hq2` |
+| `^N` | New conversation. With another computer paired it asks **which** first — this one, or any of them, each with a cloud saying whether it can be reached; with none paired that question is not asked at all. Then, in a repository, where: here, a worktree you need not name, one kept inside the project, one you do name, an existing one, elsewhere. A worktree you did not name is named by your first message — `fix/composer-paste-truncation`, not `wily-nimbus-7hq2` |
 | `^O` | Add a project. The filter line **is** the path field: `/`, `~` and `./` complete directories from the first keystroke, `⇥` walks into the highlighted one, `↵` takes what you typed. `linux-box:` completes on that computer instead. Paste a repository address — `https://…`, `git@…`, `file://…`, or just `owner/repo` — and it offers to **clone** it: it asks where, remembers the folders you pick, draws git's own progress while it fetches, and leaves you in the new project |
 | `^B` | Toggle the sidebar |
 | `^K` | Command palette |
@@ -1262,7 +1345,7 @@ says how many are asking, `^T` is where you go, and it opens when you get there.
 | `J` `K` | Reorder within a group |
 | `r` | Rename a conversation |
 | `y` | Copy the row's directory — a worktree's path, ready to paste into a shell |
-| `p` | Bring that repository up to date — fast-forwards silently, asks *rebase or merge* when the branch has gone both ways, and goes and looks when nothing is waiting (a git-plugin contribution) |
+| `p` | Bring that repository up to date — fast-forwards silently, asks *rebase or merge* when the branch has gone both ways, and goes and looks when nothing is waiting. The row spins from the press, not from the network call three steps down (a git-plugin contribution) |
 | `d` | Remove a worktree from disk — its branch stays, and it asks first (a git-plugin contribution) |
 | `x` `X` | Archive, delete. Deleting the last conversation in a worktree takes the checkout with it, and the dialog says so — the branch stays. On a repository's heading, `X` takes the project off the list and leaves the directory; on a worktree's, it removes the checkout too |
 | `a` | The archive — the popup below. Nothing archived is ever a row in *this* panel, and by default not even a count. An `archive.action` contribution, not a key this panel owns |

--- a/crates/neosh-core/src/palette.rs
+++ b/crates/neosh-core/src/palette.rs
@@ -569,6 +569,39 @@ pub fn groups(variant: Variant) -> Vec<(&'static str, HighlightDef)> {
         // colour would make the panel read as two lists rather than one workspace that happens to
         // span machines. What says where it is running is the host name on the end of the row.
         ("Sidebar.Remote", link("Comment")),
+        // ---- another computer -----------------------------------------------
+        // The cloud on a row that is not on this machine, in the colour of what the link to that
+        // machine is doing. Four states and four answers, because "not here" is not one fact: a
+        // conversation on a machine that is up is one you can open and steer, and the same row on
+        // a machine that is not is a thing you can read about and not touch.
+        //
+        // The glyph is one column and it never moves position, so the colour is the whole of the
+        // message and it has to be readable at a glance beside twenty other rows.
+        //
+        // Connected. The same green everything settled and working wears, and deliberately *still*:
+        // a link that is up is not something happening, it is a condition, and this glyph is on
+        // every remote row in the panel at once. Motion on all of them would be the panel
+        // vibrating.
+        ("Swarm.Up", spec(fg(r.success))),
+        // Being dialled, or dialled again after a drop. The one swarm state that earns motion, by
+        // the rule `Git.Fetching` earns it: something is happening you cannot see, over a network,
+        // and a still glyph cannot be told from a wedged one. A pulse rather than frames — a frame
+        // set says "working through something", and a dial is one thing being waited on — and in
+        // the attention hue, because it is on its way to being fine and is not fine yet.
+        ("Swarm.Linking", spec(pulse(fg(r.attention), 1200))),
+        // Reached, proved who we are, and that machine has not allowed this one yet.
+        //
+        // The colour the workspace already uses for *act now*, because that is what this is — and
+        // the one thing it must not be is a spinner: nothing on this computer is working on it, and
+        // what it is waiting for is a person at the other keyboard. The pulse says "you", the way
+        // it does on a conversation that is asking you something; the shape does not say "us".
+        ("Swarm.Waiting", spec(pulse(fg(r.attention), 1600))),
+        // Nothing is dialling it. Dim, and still, for the reason `Git.Stale` is: it is not an
+        // emergency, it is not going to change on its own, and a panel that draws every machine
+        // you have ever paired in a warning colour is one you stop reading. The rows under it are
+        // still drawn — they were real a moment ago and probably still are — and this is what says
+        // you cannot reach them.
+        ("Swarm.Down", spec(dim(fg(r.faint)))),
         ("Status.Line", link("Comment")),
         // ---- the tab strip --------------------------------------------------
         // One row across the top of the main region, and the only chrome that is *always* there
@@ -822,6 +855,10 @@ mod tests {
             "Git.Diverged",
             "Git.Synced",
             "Diff.Add",
+            "Swarm.Up",
+            "Swarm.Linking",
+            "Swarm.Waiting",
+            "Swarm.Down",
         ] {
             assert!(names.contains(required), "{required} is missing from the palette");
         }
@@ -850,12 +887,26 @@ mod tests {
             matches!(animation("Forge.ChecksRunning"), Some(neosh_proto::Animation::Frames { .. })),
             "checks running is work happening on somebody else's machine"
         );
+        assert!(
+            matches!(animation("Swarm.Linking"), Some(neosh_proto::Animation::Pulse { .. })),
+            "a dial is seconds of nothing on screen against another computer, and a still glyph \
+             cannot be told from a wedged one"
+        );
+        assert!(
+            matches!(animation("Swarm.Waiting"), Some(neosh_proto::Animation::Pulse { .. })),
+            "half a pairing is waiting on a person, which pulses rather than spins: a spinner \
+             would be this machine claiming to be working on something it is not"
+        );
         for still in [
             "Git.Diverged", "Git.Synced", "Git.Behind", "Git.Ahead", "Git.Branch", "Git.Stale",
             // A pull request's *state* is news and never motion: open is true until somebody
             // reviews it, merged is true for ever, and a row that blinks about either charges
             // attention every time it changes with nothing new to say.
             "Forge.Open", "Forge.Draft", "Forge.Merged", "Forge.Closed", "Forge.ChecksFailed",
+            // A link that is up is a condition rather than an event, and this glyph is on every
+            // remote row at once — twenty of them pulsing in step is the panel vibrating. A link
+            // nothing is dialling is not going to change on its own either.
+            "Swarm.Up", "Swarm.Down",
         ] {
             assert!(
                 animation(still).is_none(),

--- a/crates/neosh-provider/src/drivers/acp.rs
+++ b/crates/neosh-provider/src/drivers/acp.rs
@@ -771,7 +771,9 @@ impl Provider for AcpProvider {
                 .stderr(Stdio::piped());
             let mut child = match cmd.spawn() {
                 Ok(c) => c,
-                Err(e) => return fail(tx, format!("could not run {program:?}: {e}")).await,
+                Err(e) => {
+                    return fail(tx, super::spawn_failed(&program, Some(&workdir), &e)).await;
+                }
             };
 
             let stdin = child.stdin.take().expect("stdin was piped");

--- a/crates/neosh-provider/src/drivers/antigravity.rs
+++ b/crates/neosh-provider/src/drivers/antigravity.rs
@@ -615,7 +615,7 @@ impl Live {
             .stderr(Stdio::null())
             .kill_on_drop(true)
             .spawn()
-            .map_err(|e| format!("could not run {program:?}: {e}"))?;
+            .map_err(|e| super::spawn_failed(program, Some(&workdir), &e))?;
         let stdin = child.stdin.take().ok_or("agy: stdin was not piped")?;
         let stdout = child.stdout.take().ok_or("agy: stdout was not piped")?;
         Ok(Self {

--- a/crates/neosh-provider/src/drivers/claude_cli.rs
+++ b/crates/neosh-provider/src/drivers/claude_cli.rs
@@ -1499,7 +1499,7 @@ impl Live {
         cmd.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped());
 
         let mut child =
-            cmd.spawn().map_err(|e| format!("could not run {program:?}: {e}"))?;
+            cmd.spawn().map_err(|e| super::spawn_failed(program, Some(&launch.cwd), &e))?;
         let stdout = child.stdout.take().expect("stdout was piped");
         let stderr = child.stderr.take().expect("stderr was piped");
         let stdin = child.stdin.take().expect("stdin was piped");

--- a/crates/neosh-provider/src/drivers/codex_cli.rs
+++ b/crates/neosh-provider/src/drivers/codex_cli.rs
@@ -644,7 +644,7 @@ async fn discover(program: &str) -> Result<Vec<ModelInfo>, ProviderError> {
         .stderr(Stdio::null())
         .kill_on_drop(true)
         .spawn()
-        .map_err(|e| ProviderError::Transport(format!("could not run {program} app-server: {e}")))?;
+        .map_err(|e| ProviderError::Transport(super::spawn_failed(program, None, &e)))?;
 
     let mut stdin = child.stdin.take().expect("stdin was piped");
     let stdout = child.stdout.take().expect("stdout was piped");
@@ -1106,7 +1106,7 @@ impl Live {
             .stderr(Stdio::piped())
             .kill_on_drop(true);
         let mut child =
-            cmd.spawn().map_err(|e| format!("could not run {program} app-server: {e}"))?;
+            cmd.spawn().map_err(|e| super::spawn_failed(program, Some(cwd), &e))?;
         let stdout = child.stdout.take().expect("stdout was piped");
         let stderr = child.stderr.take().expect("stderr was piped");
         let stdin = child.stdin.take().expect("stdin was piped");

--- a/crates/neosh-provider/src/drivers/mod.rs
+++ b/crates/neosh-provider/src/drivers/mod.rs
@@ -142,3 +142,74 @@ pub trait Unasked: Send + Sync + std::fmt::Debug {
         tasks: Vec<neosh_proto::BackgroundTask>,
     );
 }
+
+/// Why spawning a vendor CLI failed, said about the thing that is actually missing.
+///
+/// `Command::spawn` reports a working directory it cannot `chdir` into exactly as it reports a
+/// program it cannot find: `ENOENT`, "no such file or directory". So a conversation whose
+/// directory has been deleted — a worktree removed by hand, a project moved, a checkout on a
+/// volume that is no longer mounted — failed with `could not run "claude": no such file or
+/// directory`, which is a sentence about `claude`. Every other conversation in the same workspace
+/// went on working, because they are the same binary in a directory that still exists, and the
+/// one thing on screen said the one thing that was not the problem.
+///
+/// So the two are told apart before the error is written, by asking the questions the kernel
+/// answered with one bit: is the directory there, and is the program. Both are cheap, both happen
+/// only on the failure path, and either way the sentence names something the reader can go and
+/// look at.
+pub(crate) fn spawn_failed(
+    program: &str,
+    cwd: Option<&std::path::Path>,
+    e: &std::io::Error,
+) -> String {
+    if e.kind() == std::io::ErrorKind::NotFound {
+        // The directory first: it is the half that is invisible from the message, and a
+        // conversation is far more likely to outlive its checkout than its agent.
+        if let Some(dir) = cwd.filter(|d| !d.as_os_str().is_empty() && !d.is_dir()) {
+            return format!(
+                "{program} could not start here: {} no longer exists. \
+                 A conversation runs in its own directory, so put that one back \
+                 or start this work in one that is there.",
+                dir.display()
+            );
+        }
+        if claude_cli::which(program).is_none() {
+            return format!("could not run {program:?}: it is not on PATH");
+        }
+    }
+    format!("could not run {program:?}: {e}")
+}
+
+#[cfg(test)]
+mod spawn_failure_tests {
+    use super::spawn_failed;
+
+    fn enoent() -> std::io::Error {
+        std::io::Error::from_raw_os_error(2)
+    }
+
+    #[test]
+    fn a_conversation_whose_directory_is_gone_says_so_rather_than_blaming_the_agent() {
+        // The bug this exists for: one conversation in a workspace fails with `could not run
+        // "claude": no such file or directory` while every other one works, because the kernel
+        // reports a `chdir` it cannot do and a program it cannot find with the same errno.
+        let missing = std::path::Path::new("/definitely/not/a/directory/anywhere");
+        let said = spawn_failed("claude", Some(missing), &enoent());
+        assert!(said.contains("/definitely/not/a/directory/anywhere"), "got: {said}");
+        assert!(!said.contains("could not run"), "still blaming the program: {said}");
+    }
+
+    #[test]
+    fn a_program_that_is_not_installed_says_which_one_and_where_it_looked() {
+        let here = std::env::temp_dir();
+        let said = spawn_failed("neosh-definitely-not-installed", Some(&here), &enoent());
+        assert!(said.contains("not on PATH"), "got: {said}");
+    }
+
+    #[test]
+    fn anything_else_keeps_the_error_the_os_gave() {
+        let denied = std::io::Error::from(std::io::ErrorKind::PermissionDenied);
+        let said = spawn_failed("claude", None, &denied);
+        assert!(said.contains("could not run"), "got: {said}");
+    }
+}

--- a/crates/neosh-provider/src/quota.rs
+++ b/crates/neosh-provider/src/quota.rs
@@ -560,7 +560,7 @@ pub async fn codex_usage(program: &str) -> Result<Option<Quota>, ProviderError> 
         .stderr(Stdio::null())
         .kill_on_drop(true)
         .spawn()
-        .map_err(|e| ProviderError::Transport(format!("could not run {program} app-server: {e}")))?;
+        .map_err(|e| ProviderError::Transport(crate::drivers::spawn_failed(program, None, &e)))?;
 
     let mut stdin = child.stdin.take().expect("stdin was piped");
     let stdout = child.stdout.take().expect("stdout was piped");

--- a/crates/neosh-tui/src/render.rs
+++ b/crates/neosh-tui/src/render.rs
@@ -1142,7 +1142,31 @@ pub fn draw_with(frame: &mut Frame, mirror: &Mirror, theme: &Theme, gfx: &mut Gr
         }
     }
 
-    draw_notifications(frame, area, mirror, theme);
+    // Under whatever is docked across the top of the screen — which is the tab strip, and is the
+    // one row that must never be covered: it is always drawn, it is how you find out panes and
+    // tabs exist, and a notice over it hides the names of what is open.
+    let below_top = rects
+        .iter()
+        .filter(|(w, _)| {
+            matches!(
+                mirror.windows.get(w).map(|w| &w.layout),
+                Some(WindowLayout::Docked { pane: None, dock: Dock::Top, .. })
+            )
+        })
+        .map(|(_, r)| r.y.saturating_add(r.height))
+        .max()
+        .unwrap_or(area.y)
+        .max(area.y);
+    draw_notifications(
+        frame,
+        Rect {
+            y: below_top,
+            height: area.height.saturating_sub(below_top.saturating_sub(area.y)),
+            ..area
+        },
+        mirror,
+        theme,
+    );
 
     // The block cursor, last of all and over whatever the row under it ended up being.
     //
@@ -1503,11 +1527,21 @@ const ALERT_TTL: std::time::Duration = std::time::Duration::from_secs(20);
 /// crashed between the two — without it, one failed pull leaves `pulling…` on screen until restart.
 const PROGRESS_ABANDONED: std::time::Duration = std::time::Duration::from_secs(60);
 
-/// What is happening and what just happened, above the bottom-most content.
+/// What is happening and what just happened, in the top-right corner.
 ///
 /// Two lists in one corner, because they are two different claims and only one of them is about to
 /// stop being true. Progress sits above — it is what the program is *doing*, and it will change on
-/// its own — and messages below it, nearest the composer, because they are answers to a key.
+/// its own — and messages under it, newest last, so a row that is already there does not move when
+/// another arrives.
+///
+/// **The corner is the top one, and that is the whole point.** A notice is drawn over whatever is
+/// under it rather than reflowing the screen — reflowing would move the thing you are typing into —
+/// so the only question is *what* it is allowed to cover. In the bottom corner the answer was the
+/// composer and the last rows of the transcript: the line being typed, and the newest thing the
+/// agent had said. Both are the two places on screen somebody is certainly looking, and a
+/// notification is by definition about something they are not. The top of the transcript is
+/// scrolled-past text during a turn and empty space the rest of the time, which is the correct
+/// thing for a message to be laid over. It stops short of the tab strip, which is never covered.
 fn draw_notifications(frame: &mut Frame, area: Rect, mirror: &Mirror, theme: &Theme) {
     /// At most one reply and two alerts. The stack used to be three of anything, which meant a
     /// burst of replies could push the one piece of news off the top of it.
@@ -1531,8 +1565,10 @@ fn draw_notifications(frame: &mut Frame, area: Rect, mirror: &Mirror, theme: &Th
         return;
     }
 
-    // Newest at the bottom, older above it and dimmed — the same ordering as the toast stack it
-    // replaces, without the choreography. A repeat is a count on the end rather than a second row.
+    // Newest last, older above it and dimmed. Anchored at the top the block grows *downwards*, so
+    // this is also the order in which nothing already on screen moves when another arrives — the
+    // same "no choreography" the bottom corner had, read the other way up. A repeat is a count on
+    // the end rather than a second row.
     let mut lines: Vec<Line> = Vec::with_capacity(running.len() + live.len());
     for text in &running {
         lines.push(Line::from(Span::styled(
@@ -1558,7 +1594,7 @@ fn draw_notifications(frame: &mut Frame, area: Rect, mirror: &Mirror, theme: &Th
         lines.push(Line::from(Span::styled(text, style)));
     }
 
-    // Right-aligned, hugging the bottom, so it overlays chrome rather than reflowing it: a message
+    // Right-aligned, hugging the top, so it overlays chrome rather than reflowing it: a message
     // that pushed the composer down would move the thing the user is typing into.
     let rows = (lines.len() as u16).min(area.height);
     let widest = lines
@@ -1585,7 +1621,7 @@ fn draw_notifications(frame: &mut Frame, area: Rect, mirror: &Mirror, theme: &Th
     }
     let rect = Rect {
         x: area.x + area.width.saturating_sub(widest),
-        y: area.y + area.height.saturating_sub(rows + 1),
+        y: area.y,
         width: widest,
         height: rows,
     };

--- a/crates/neosh-tui/tests/rendering.rs
+++ b/crates/neosh-tui/tests/rendering.rs
@@ -808,8 +808,53 @@ fn a_notification_does_not_reflow_the_content_underneath() {
     let mut with = main_window_with(vec!["line one", "line two"]);
     with.apply(notice("hi", neosh_proto::NoticeKind::Reply));
     let after = rows_of(&with, 40, 6);
-    assert_eq!(before[0], after[0], "the first line did not move");
-    assert_eq!(before[1], after[1]);
+    assert!(after[0].starts_with("line one"), "the first line did not move: {after:?}");
+    assert_eq!(before[1], after[1], "and nothing below it moved either");
+    assert_eq!(before.len(), after.len());
+}
+
+#[test]
+fn a_notification_goes_to_the_top_corner_and_not_over_what_is_being_typed() {
+    // The bottom corner covered the composer and the newest rows of the transcript — the two
+    // places somebody is certainly looking, and a notification is by definition about somewhere
+    // else. Six rows of content in an eight-row window: the last of them must survive a message.
+    let mut m = main_window_with(vec!["one", "two", "three", "four", "five", "six"]);
+    m.apply(notice("a message about something else", neosh_proto::NoticeKind::Reply));
+    let rows = rows_of(&m, 46, 6);
+    assert!(rows[0].contains("a message about something else"), "top corner: {rows:?}");
+    assert!(
+        !rows.last().unwrap().contains("a message"),
+        "the last row is the newest thing said, and it is not covered: {rows:?}"
+    );
+}
+
+#[test]
+fn a_notification_never_covers_the_tab_strip() {
+    // The one row that is always drawn, and the only place panes and tabs announce themselves.
+    let mut m = main_window_with(vec!["one", "two", "three", "four"]);
+    m.apply(UiEvent::BufferOpened { buf: BufferId(9), name: "[tabs]".into() });
+    m.apply(UiEvent::BufferLines {
+        buf: BufferId(9),
+        start: 0,
+        old_end: 0,
+        lines: vec![line("1 neosh", vec![])],
+    });
+    m.apply(UiEvent::WindowOpened {
+        win: WindowId(9),
+        buf: BufferId(9),
+        layout: WindowLayout::Docked {
+            pane: None,
+            dock: Dock::Top,
+            size: Some(1),
+            gravity: Gravity::Start,
+            wrap: None,
+        },
+    });
+    m.apply(notice("a message", neosh_proto::NoticeKind::Reply));
+    let rows = rows_of(&m, 40, 6);
+    assert!(rows[0].contains("1 neosh"), "the strip is still there: {rows:?}");
+    assert!(!rows[0].contains("a message"), "and nothing is over it: {rows:?}");
+    assert!(rows[1].contains("a message"), "the notice sits under it: {rows:?}");
 }
 
 #[test]

--- a/crates/neosh/src/frontend.rs
+++ b/crates/neosh/src/frontend.rs
@@ -140,6 +140,16 @@ pub struct TerminalUi {
     input: mpsc::UnboundedSender<InputEvent>,
     /// Whether a repaint ticker is running, and the switch that stops it.
     animating: Arc<AtomicBool>,
+    /// Which ticker is the live one.
+    ///
+    /// A generation and not just the flag above, because the flag alone cannot tell a ticker that
+    /// it has been replaced. `follow_motion(false)` then `follow_motion(true)` inside one 50 ms
+    /// sleep leaves the sleeping ticker waking to a flag that is `true` again — so it carries on,
+    /// *and* a second one has been spawned beside it. Motion stopping and restarting is not an
+    /// edge case in a workspace watching an agent work: it is what every tool call does, once
+    /// when its spinner appears and once when it lands. Thirty calls in a turn is thirty chances
+    /// to add another 20 fps of repaints to a terminal that only ever needed one ticker.
+    generation: Arc<AtomicU64>,
     /// The last geometry we told the core about, per window.
     ///
     /// Only *changes* are sent. Emitting one per window per draw is a feedback loop: the event arms
@@ -205,6 +215,7 @@ impl TerminalUi {
                 input: tx_geometry,
                 reported: Default::default(),
                 animating: Arc::new(AtomicBool::new(false)),
+                generation: Arc::new(AtomicU64::new(0)),
             },
             rx,
         ))
@@ -279,15 +290,20 @@ impl TerminalUi {
             return;
         }
         self.animating.store(moving, Ordering::Relaxed);
+        // Claimed whichever way this went, so a ticker that was asleep across a stop finds itself
+        // superseded rather than finding the flag back on and deciding it is still the one.
+        let mine = self.generation.fetch_add(1, Ordering::Relaxed) + 1;
         if !moving {
             return;
         }
         let flag = self.animating.clone();
+        let generation = self.generation.clone();
         let tx = self.input.clone();
         tokio::spawn(async move {
-            // Re-checked each tick rather than held for the lifetime of the task, so the ticker
-            // stops itself the moment a frame comes back still.
-            while flag.load(Ordering::Relaxed) {
+            // Both re-checked each tick rather than held for the lifetime of the task, so the
+            // ticker stops itself the moment a frame comes back still — and there is never more
+            // than one of them, whatever order the starts and stops arrive in.
+            while flag.load(Ordering::Relaxed) && generation.load(Ordering::Relaxed) == mine {
                 tokio::time::sleep(MOTION_FRAME).await;
                 if tx.send(InputEvent::Repaint).is_err() {
                     return;

--- a/plugins/api/src/index.ts
+++ b/plugins/api/src/index.ts
@@ -125,6 +125,7 @@ import type { TurnRequest } from "./generated/TurnRequest";
 import type { Usage } from "./generated/Usage";
 import type { NodeCapabilities } from "./generated/NodeCapabilities";
 import type { NodeId } from "./generated/NodeId";
+import type { LinkState } from "./generated/LinkState";
 import type { NodeInfo } from "./generated/NodeInfo";
 import type { ProjectKey } from "./generated/ProjectKey";
 import type { RemoteProject } from "./generated/RemoteProject";
@@ -162,7 +163,7 @@ export type {
   Rect, RepoInfo, RepoStatus, ScrollAmount, SelectShape, SessionId, SessionInfo, StatusAlign, StatusSegment, StopReason,
   SurfaceCell, SurfaceId, TextEdit, ToolCall, ToolDef, ToolResult, TurnRequest, Usage, ImageFile,
   NodeCapabilities, NodeId, NodeInfo, ProjectKey, RemoteProject, StreamEvent,
-  SwarmAgent, SwarmNode, SwarmStranger,
+  LinkState, SwarmAgent, SwarmNode, SwarmStranger,
   VarScope, ViewId, ViewInfo, Viewport,
   WindowId, WindowInfo, WindowLayout,
   ChecksState,

--- a/plugins/builtin/git/main.ts
+++ b/plugins/builtin/git/main.ts
@@ -308,6 +308,15 @@ two-word scratch name it was created with.",
   // project is the expensive way to learn that one of them changed, and the row that just pulled
   // is wrong until this runs. `known` is a status the caller already has — a fetch answers with
   // one — so that row is drawn from it with no subprocess at all.
+  //
+  // The last answer per directory, so that the redraw a *starting* operation asks for costs
+  // nothing. A pull marks its row busy and calls this immediately — which is the whole point, the
+  // spinner has to be on screen before the network is — and going and running `git status` first
+  // put a subprocess between the key and the only feedback it produces. On a repository with a
+  // large tree that is most of a second of a key looking like it did nothing, which is exactly the
+  // complaint. While a checkout is busy the numbers cannot be trusted anyway: they are what the
+  // operation is about to change, and saying them a moment stale beside a spinner is honest.
+  const lastKnown = new Map<string, RepoStatus | null>();
   const decorate = async (only?: string, known: RepoStatus | null = null) => {
     const projects = await neosh.vars
       .get<unknown>({ scope: "global" }, "sidebar.projects")
@@ -330,7 +339,10 @@ two-word scratch name it was created with.",
       }
       const status = cwd === only && known
         ? known
-        : await neosh.git.status({ cwd }).catch(() => null);
+        : repoBusy(cwd) && lastKnown.has(cwd)
+          ? lastKnown.get(cwd) ?? null
+          : await neosh.git.status({ cwd }).catch(() => null);
+      lastKnown.set(cwd, status);
       const parts = status ? statParts(status, ascii) : [];
       // The one thing the block said that a count cannot: that these numbers are as of a fetch
       // that did not reach the remote. Appended rather than led with, because it qualifies the

--- a/plugins/builtin/git/sidebar.ts
+++ b/plugins/builtin/git/sidebar.ts
@@ -143,18 +143,36 @@ export function repoBusy(cwd: string): boolean {
  */
 let moved: (cwd: string | undefined, status: RepoStatus | null) => void = () => {};
 
-/** Mark a checkout busy, say so, run `body`, and say so again when it is over. */
-async function whileBusy<T>(cwd: string | undefined, body: () => Promise<T>): Promise<T> {
+/**
+ * Mark a checkout busy and say so, answering with the one call that stops it.
+ *
+ * Split out from {@link whileBusy} because a verb is not always one awaited body. `p` reads the
+ * status, may then ask a question, and only then talks to the remote — and the row has to be
+ * spinning across all of that except the question, which is the one part where nothing here is
+ * working. A releaser rather than a second counter: it is idempotent, so a `finally` can call it
+ * over a path that already released, which is what makes the question safe to bail out of.
+ */
+function busy(cwd: string | undefined): () => void {
   if (cwd) inFlight.set(cwd, (inFlight.get(cwd) ?? 0) + 1);
   moved(cwd, null);
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    if (!cwd) return;
+    const n = (inFlight.get(cwd) ?? 1) - 1;
+    if (n > 0) inFlight.set(cwd, n);
+    else inFlight.delete(cwd);
+  };
+}
+
+/** Mark a checkout busy, say so, run `body`, and say so again when it is over. */
+async function whileBusy<T>(cwd: string | undefined, body: () => Promise<T>): Promise<T> {
+  const idle = busy(cwd);
   try {
     return await body();
   } finally {
-    if (cwd) {
-      const n = (inFlight.get(cwd) ?? 1) - 1;
-      if (n > 0) inFlight.set(cwd, n);
-      else inFlight.delete(cwd);
-    }
+    idle();
   }
 }
 
@@ -197,98 +215,124 @@ export async function pullRepository(
   // from the palette is about a directory too even though nobody named it.
   cwd = await here(neosh, cwd);
   const where = cwd ? { cwd } : undefined;
-  const status = await neosh.git.status(where).catch(() => null);
-  if (!status) {
-    neosh.notify("not a git repository", "warn");
-    return;
+  // The row spins from the keypress, not from the network call three steps down.
+  //
+  // `p` used to do all of its deciding first — a `git status` over the whole tree, then perhaps a
+  // fetch — and only mark the row busy once it had settled on a route. On anything bigger than a
+  // toy checkout that is a second or more in which the key has visibly done nothing at all, which
+  // is indistinguishable from a key that is not bound. What somebody wants to know from `p` is
+  // *that it heard them*; what it is going to turn out to do is the second question.
+  //
+  // Released around the one part of this that is not work — see the question below.
+  let idle = busy(cwd);
+  try {
+    return await pull();
+  } finally {
+    idle();
+    // The row, now, from a fresh read: whatever these numbers are they are not the ones it was
+    // drawn with, and the spinner coming off has to take the stale count with it.
+    moved(cwd, null);
   }
-  if (!status.repo.upstream) {
-    // A statement rather than a verb: a branch tracking nothing is not behind anything, and there
-    // is no route from here to up-to-date that this key could take on its own.
-    neosh.notify("this branch is not tracking a remote branch", "warn");
-    return;
-  }
-  const { ahead, behind } = status.repo;
 
-  let rebase = false;
-  if (ahead > 0 && behind > 0) {
-    const chosen = await picker(
-      neosh,
-      [
-        {
-          label: "Rebase",
-          detail: `replay your ${count(ahead, "commit")} on top of the ${
-            count(behind, "commit")
-          } that arrived`,
-          value: "rebase",
-        },
-        {
-          label: "Merge",
-          detail: "bring them together in a merge commit, keeping both histories as they are",
-          value: "merge",
-        },
-      ],
-      {
-        title: `${status.repo.branch ?? "HEAD"} has gone both ways`,
-        width: 76,
-      },
-    );
-    if (!chosen) return;
-    rebase = chosen === "rebase";
-  } else if (behind === 0) {
-    // "Nothing waiting" is a claim about the remote-tracking ref **on this disk**, so cold — from
-    // the palette, from a script, from a row nobody has fetched for — it does not mean nothing is
-    // waiting. It means nobody has looked.
-    //
-    // The block never had this problem: it drew from a status it had just fetched, so `behind === 0`
-    // there really was "up to date, and the honest verb is go and look". Moved onto a command that
-    // anyone can call at any moment, that same branch turned `git.pull` into a fetch — the remote's
-    // commits stayed on the remote and the caller was told nothing was there.
-    //
-    // So look, and then do what was asked. Once: the second pass carries `fetched` and stops rather
-    // than fetching again, which is what keeps a repository that is genuinely level from bouncing
-    // between the two halves of this branch.
-    if (opts.fetched) {
-      neosh.notify("already up to date");
+  async function pull(): Promise<void> {
+    const status = await neosh.git.status(where).catch(() => null);
+    if (!status) {
+      neosh.notify("not a git repository", "warn");
       return;
     }
-    const fresh = await fetchRepository(neosh, cwd, { loud: true });
-    // Could not reach the remote. `fetchRepository` has already said so and filed it, and guessing
-    // at a pull on top of that would only produce git's version of the same complaint.
-    if (!fresh) return;
-    return await pullRepository(neosh, cwd, { fetched: true });
-  }
+    if (!status.repo.upstream) {
+      // A statement rather than a verb: a branch tracking nothing is not behind anything, and there
+      // is no route from here to up-to-date that this key could take on its own.
+      neosh.notify("this branch is not tracking a remote branch", "warn");
+      return;
+    }
+    const { ahead, behind } = status.repo;
 
-  // A rebase replays commits over a tree that is being edited underneath it. git refuses on a dirty
-  // tree anyway, and saying so before spending the round trip is a better answer than git's, which
-  // arrives after the fetch and names a file rather than the decision.
-  if (rebase && status.changes.some((c) => c.staged || c.unstaged)) {
-    if (
-      !(await confirm(neosh, "This working tree has uncommitted changes. Try to rebase anyway?"))
-    ) return;
-  }
+    let rebase = false;
+    if (ahead > 0 && behind > 0) {
+      // Nothing on this machine is working while a person is reading two options, and a spinner that
+      // keeps turning over a question is a spinner that means nothing anywhere else either.
+      idle();
+      moved(cwd, null);
+      const chosen = await picker(
+        neosh,
+        [
+          {
+            label: "Rebase",
+            detail: `replay your ${count(ahead, "commit")} on top of the ${
+              count(behind, "commit")
+            } that arrived`,
+            value: "rebase",
+          },
+          {
+            label: "Merge",
+            detail: "bring them together in a merge commit, keeping both histories as they are",
+            value: "merge",
+          },
+        ],
+        {
+          title: `${status.repo.branch ?? "HEAD"} has gone both ways`,
+          width: 76,
+        },
+      );
+      if (!chosen) return;
+      rebase = chosen === "rebase";
+      idle = busy(cwd);
+    } else if (behind === 0) {
+      // "Nothing waiting" is a claim about the remote-tracking ref **on this disk**, so cold — from
+      // the palette, from a script, from a row nobody has fetched for — it does not mean nothing is
+      // waiting. It means nobody has looked.
+      //
+      // The block never had this problem: it drew from a status it had just fetched, so `behind === 0`
+      // there really was "up to date, and the honest verb is go and look". Moved onto a command that
+      // anyone can call at any moment, that same branch turned `git.pull` into a fetch — the remote's
+      // commits stayed on the remote and the caller was told nothing was there.
+      //
+      // So look, and then do what was asked. Once: the second pass carries `fetched` and stops rather
+      // than fetching again, which is what keeps a repository that is genuinely level from bouncing
+      // between the two halves of this branch.
+      if (opts.fetched) {
+        neosh.notify("already up to date");
+        return;
+      }
+      const fresh = await fetchRepository(neosh, cwd, { loud: true });
+      // Could not reach the remote. `fetchRepository` has already said so and filed it, and guessing
+      // at a pull on top of that would only produce git's version of the same complaint.
+      if (!fresh) return;
+      return await pullRepository(neosh, cwd, { fetched: true });
+    }
 
-  neosh.progress("git.pull", rebase ? "rebasing…" : "pulling…");
-  try {
-    await whileBusy(cwd, async () => {
-      const summary = await neosh.git.pull({ ...(where ?? {}), rebase });
-      // A pull *is* a fetch, so it settles the trouble mark too: whatever these numbers are, they
-      // came off the remote a moment ago.
-      if (cwd) fetchTrouble.delete(cwd);
-      neosh.notify(short(summary));
-    });
-  } catch (e) {
-    // git's own message names it — diverged, no remote, an unresolved rebase — and inventing a
-    // friendlier one here would mean guessing which of those it was. Loud: it is the answer to a
-    // key somebody just pressed.
-    neosh.notify(String(e), "error");
-  } finally {
-    neosh.done("git.pull");
-    // The row, now. `↓3` after a pull that brought three commits in is a row that is wrong until
-    // something unrelated happens to redraw it — moving the cursor, switching conversations — and
-    // what it was wrong about is the one number the key was pressed for. A pull answers with a
-    // summary rather than a status, so this one is a read; it is one local subprocess.
-    moved(cwd, null);
+    // A rebase replays commits over a tree that is being edited underneath it. git refuses on a dirty
+    // tree anyway, and saying so before spending the round trip is a better answer than git's, which
+    // arrives after the fetch and names a file rather than the decision.
+    if (rebase && status.changes.some((c) => c.staged || c.unstaged)) {
+      idle();
+      moved(cwd, null);
+      const anyway = await confirm(
+        neosh,
+        "This working tree has uncommitted changes. Try to rebase anyway?",
+      );
+      if (!anyway) return;
+      idle = busy(cwd);
+    }
+
+    neosh.progress("git.pull", rebase ? "rebasing…" : "pulling…");
+    try {
+      await whileBusy(cwd, async () => {
+        const summary = await neosh.git.pull({ ...(where ?? {}), rebase });
+        // A pull *is* a fetch, so it settles the trouble mark too: whatever these numbers are, they
+        // came off the remote a moment ago.
+        if (cwd) fetchTrouble.delete(cwd);
+        neosh.notify(short(summary));
+      });
+    } catch (e) {
+      // git's own message names it — diverged, no remote, an unresolved rebase — and inventing a
+      // friendlier one here would mean guessing which of those it was. Loud: it is the answer to a
+      // key somebody just pressed.
+      neosh.notify(String(e), "error");
+    } finally {
+      neosh.done("git.pull");
+    }
   }
 }
 

--- a/plugins/builtin/sidebar/main.ts
+++ b/plugins/builtin/sidebar/main.ts
@@ -50,6 +50,7 @@ import type {
   NodeInfo,
   SessionInfo,
   Message,
+  LinkState,
   SwarmAgent,
   SwarmNode,
   SwarmStranger,
@@ -96,7 +97,17 @@ import {
 
 /** What a row points at, so the cursor survives the list being rebuilt underneath it. */
 type Target =
-  | { kind: "project"; cwd: string }
+  | {
+    kind: "project";
+    cwd: string;
+    /**
+     * The other computers this project is also on, by name — display only, for the key card.
+     *
+     * Not part of what identifies the row: {@link same} compares projects by directory, so a peer
+     * connecting between two frames must not move the cursor.
+     */
+    hosts?: string[];
+  }
   | { kind: "session"; id: string; cwd: string }
   /** The row that opens another directory. A row rather than only a key, because a verb nobody
    * can see is a verb nobody uses. */
@@ -109,8 +120,31 @@ type Target =
    */
   | { kind: "custom"; command?: string; args?: string[]; section?: string }
   /** A conversation on another computer. Addressed as `(node, session)`; the session id alone is
-   * unique only on its own machine. */
-  | { kind: "remote"; node: string; session: string; cwd: string; host: string };
+   * unique only on its own machine. `link` is where that machine stands, in words, for the key
+   * card — which is where the machine's name went when it came off the row. */
+  | {
+    kind: "remote";
+    node: string;
+    session: string;
+    cwd: string;
+    host: string;
+    link?: string;
+  }
+  /**
+   * A project that exists only on other computers.
+   *
+   * A row of its own kind rather than a `project` with somebody else's path in it: every verb this
+   * panel binds against `project` — fold, rename, archive, delete, remove from the list — is about
+   * a directory on *this* disk, and pointing them at a path that is not here is how a key deletes
+   * the wrong thing. What it can do is fold, and start a conversation over there.
+   */
+  | {
+    kind: "elsewhere";
+    key: string;
+    name: string;
+    /** Which computers have it, and where on each — enough to start one without asking again. */
+    machines: Array<{ id: string; name: string; cwd: string }>;
+  };
 
 /**
  * What the sidebar reads to find out what is not its own.
@@ -435,6 +469,7 @@ export async function activate({ neosh, subscriptions }: PluginContext) {
             // Filled in by `collect`, which is what reads the swarm and the decorations.
             decorations: new Map(),
             remote: new Map(),
+            links: new Map(),
             hosts: new Map(),
           });
           running = built.running;
@@ -796,12 +831,16 @@ function same(a: Target, b: Target): boolean {
   }
   if (a.kind === "session") return b.kind === "session" && a.id === b.id;
   if (a.kind === "project") return b.kind === "project" && a.cwd === b.cwd;
+  // By its project key, which is the only identity it has: there is no directory here to name it
+  // by. Left to fall through to `a.kind === b.kind`, every remote-only project in the column was
+  // the same row, and the cursor snapped to the first of them on every redraw.
+  if (a.kind === "elsewhere") return b.kind === "elsewhere" && a.key === b.key;
   if (a.kind === "custom") {
     // The args too: a section whose rows all run one command with a different argument each — a
     // list of branches, a list of pull requests — is exactly the case the command alone cannot tell
     // apart, and it is a common enough shape to be worth the join.
     return b.kind === "custom" && a.section === b.section && a.command === b.command &&
-      (a.args ?? []).join(" ") === (b.args ?? []).join(" ");
+      (a.args ?? []).join("\0") === (b.args ?? []).join("\0");
   }
   return a.kind === b.kind;
 }
@@ -1359,13 +1398,20 @@ async function registerCommands(w: Wiring): Promise<void> {
         add: "add a project",
         custom: "run it",
         remote: "watch it",
+        elsewhere: "fold or unfold",
       },
     },
   );
   await verb(`${NS}.fold`, "<Space>", "Fold or unfold this project", async (p, target) => {
+    // A project that is only on other computers folds like any other. Its key is the project key,
+    // because there is no directory on this disk to name it by.
+    if (target?.kind === "elsewhere") {
+      await arrangement.toggleFold(target.key);
+      return;
+    }
     if (target?.kind !== "project") return;
     await arrangement.toggleFold(target.cwd);
-  }, { on: { project: "fold or unfold" } });
+  }, { on: { project: "fold or unfold", elsewhere: "fold or unfold" } });
   await verb(`${NS}.favorite`, "f", "Pin this project to the top", async (p, target) => {
     let cwd = owningProject(target);
     if (cwd === null) return;
@@ -1442,12 +1488,23 @@ async function registerCommands(w: Wiring): Promise<void> {
     // one letter and a modifier apart and did visibly different things, so the only way to know
     // which one you wanted was to have already learned that they differ. Here is still the first
     // row, so `n ⏎` is what `n` always did.
+    // A project that is only on other computers has no directory here to start in, so this asks
+    // *that* machine — which is the one thing the row could always tell you and never do.
+    if (target?.kind === "elsewhere") {
+      await p.leave();
+      await newRemoteConversation(neosh, target);
+      return;
+    }
     const cwd = owningProject(target) ?? undefined;
     await p.leave();
     await newConversation(neosh, arrangement, cwd);
   }, {
     redraw: false,
-    on: { project: "new conversation here", session: "new conversation in this project" },
+    on: {
+      project: "new conversation here",
+      session: "new conversation in this project",
+      elsewhere: "new conversation over there",
+    },
   });
 
   // ---- doors out of the panel ----
@@ -1869,11 +1926,131 @@ function argsFor(target: Target | undefined): string[] {
  * which is correct rather than a casualty: `Another directory…` lists every tree git knows and is
  * how a directory joins the list in the first place.
  */
+/**
+ * Which computer, before where on it.
+ *
+ * Asked only when there is something to ask: with no machine paired — which is most workspaces —
+ * this returns `here` without drawing anything, and `^N` is the single key it has always been. The
+ * moment a second computer exists the question stops being theatre and starts being the first
+ * thing you would have to decide anyway, and asking it *first* is what makes it one decision
+ * rather than a path field you have to know the scp spelling of.
+ *
+ * This computer is the first row and the cursor starts on it, so `^N ⏎` is still what `^N` always
+ * did. Every paired machine is a row, including the ones that cannot be used — the rule the path
+ * field already follows: skipping them is right about what can be done and wrong about what should
+ * be said, and somebody who has just paired a computer and finds it missing reads that as the
+ * feature not existing.
+ */
+async function chooseMachine(
+  neosh: Neosh,
+  title: string,
+): Promise<{ kind: "here" } | { kind: "node"; node: SwarmNode } | null> {
+  const me = await neosh.swarm.self().catch(() => null);
+  const peers = (await neosh.swarm.nodes().catch(() => [] as SwarmNode[]))
+    .filter((n) => n.info.id !== me?.id);
+  if (peers.length === 0) return { kind: "here" };
+  const ascii = (await neosh.opt.get<boolean>("ui.ascii_only").catch(() => false)) ?? false;
+
+  type Row = { kind: "here" } | { kind: "node"; node: SwarmNode };
+  const rows: PickerItem<Row>[] = [{
+    label: "This computer",
+    detail: me?.name ?? "here",
+    keywords: "here local this machine",
+    icon: ascii ? "*" : "\u25cf",
+    hl: "Diagnostic.Ok",
+    value: { kind: "here" },
+  }];
+  for (const n of peers) {
+    const mark = cloud(n.link, ascii);
+    const usable = n.up && n.capabilities.accepts_commands;
+    const why = !n.up
+      ? linkWords(n.link)
+      : !n.capabilities.accepts_commands
+        ? "read-only \u2014 it does not accept commands"
+        : `${n.agents.length} ${n.agents.length === 1 ? "conversation" : "conversations"}`;
+    rows.push({
+      label: n.info.name,
+      detail: [why, n.info.os].filter(Boolean).join("  \u00b7  "),
+      keywords: `${n.info.id} ${n.info.os} computer machine remote host`,
+      icon: mark.text,
+      // The row's own colour says whether it can be used; the cloud says what the link is doing.
+      // A greyed row that is still a row is the panel telling you the machine exists and why you
+      // cannot start anything on it, which is strictly more than leaving it out.
+      hl: usable ? mark.hl : "Sidebar.Dim",
+      value: { kind: "node", node: n },
+    });
+  }
+  const chosen = await picker<Row>(neosh, rows, { title, width: 72, height: 12 });
+  if (chosen === null) return null;
+  if (chosen.kind === "here") return { kind: "here" };
+  if (!chosen.node.up) {
+    neosh.notify(`${chosen.node.info.name}: ${linkWords(chosen.node.link)}`, "info");
+    return null;
+  }
+  if (!chosen.node.capabilities.accepts_commands) {
+    neosh.notify(`${chosen.node.info.name} does not accept commands from here`, "info");
+    return null;
+  }
+  return chosen;
+}
+
+/**
+ * Start a conversation on a project that is only on other computers.
+ *
+ * The row already knows which machines have it and where on each, so with one there is nothing to
+ * ask and with several the question is which computer — never a path, which is the thing nobody
+ * standing at this keyboard can answer about somebody else's disk.
+ */
+async function newRemoteConversation(
+  neosh: Neosh,
+  target: { name: string; machines: Array<{ id: string; name: string; cwd: string }> },
+): Promise<void> {
+  const machines = target.machines;
+  let pick = machines[0];
+  if (machines.length > 1) {
+    const chosen = await picker(
+      neosh,
+      machines.map((m) => ({
+        label: m.name,
+        detail: m.cwd,
+        keywords: m.id,
+        icon: "\u2601",
+        hl: "Swarm.Up",
+        value: m,
+      })),
+      { title: `${target.name} \u2014 which computer?`, width: 72 },
+    );
+    if (!chosen) return;
+    pick = chosen;
+  }
+  if (!pick) return;
+  await startThere(neosh, {
+    node: pick.id,
+    cwd: pick.cwd,
+    label: `${pick.cwd} on ${pick.name}`,
+  });
+}
+
 async function newConversation(
   neosh: Neosh,
   arrangement: Arrangement,
   base?: string,
 ): Promise<void> {
+  // Which computer, first — and only when there is more than one. See {@link chooseMachine}.
+  const machine = await chooseMachine(neosh, "New conversation \u2014 where?");
+  if (machine === null) return;
+  if (machine.kind === "node") {
+    // The path field, pointed at that machine: the same picker, seeded exactly as somebody typing
+    // `linux-box:` would have reached, so the two routes cannot diverge. No local rows under it —
+    // every one of them means "on this computer", which is the answer that was just not chosen.
+    const chosen = await whereTo(neosh, [], {
+      title: `New conversation on ${machine.node.info.name}`,
+      seed: `${hostPrefix(machine.node)}:`,
+    });
+    if (chosen === null) return;
+    if (chosen.kind === "host") await startThere(neosh, chosen);
+    return;
+  }
   const current = await neosh.session.current().catch(() => null);
   const here = base ?? current?.cwd;
   // Empty outside a repository, which is also how this knows there is nothing to ask about: a
@@ -2509,6 +2686,14 @@ async function activateTarget(
   if (target.kind === "add") {
     await p.leave();
     await neosh.cmd.exec("project.open").catch(() => {});
+    return;
+  }
+  // A project that is only on other computers. There is nothing here to switch to, so `↵` does
+  // what it does on any project row with something in it: folds. Starting work in it is `n`, which
+  // asks which computer — see {@link newConversation}.
+  if (target.kind === "elsewhere") {
+    await arrangement.toggleFold(target.key);
+    await p.draw();
     return;
   }
   if (target.kind === "project") {
@@ -3527,6 +3712,15 @@ interface DrawOptions {
   remote: Map<string, SwarmAgent[]>;
   /** Which other machines have each project, by key. */
   hosts: Map<string, string[]>;
+  /**
+   * Where the link to each machine stands, by node id.
+   *
+   * Read on every remote row, because that is what the cloud on it is coloured by. A row about a
+   * machine this one cannot currently reach is not the same row as one about a machine it can —
+   * you can open and steer the second and only read about the first — and until this existed the
+   * panel drew both identically, which meant `↵` on a row was a coin toss you could not see.
+   */
+  links: Map<string, LinkState>;
 }
 
 /**
@@ -3559,30 +3753,51 @@ async function collect(
   // One list, favourites first. A separate `FAVORITES` section splits a short list in half and
   // makes you check two places for the same kind of thing; the star says which is which without
   // costing a heading, a rule and a blank line.
-  // What the other computers are running. One call; empty and harmless on a single machine.
-  const swarm = await neosh.swarm.agents().catch(() => [] as SwarmAgent[]);
+  // What the other computers are running, and how each of them is reachable.
+  //
+  // Built from `nodes()` rather than `agents()`, which is the same list minus the machines that
+  // are *not* up. That filter is right for "what can I act on" and wrong for a panel: a machine
+  // going quiet does not take its conversations off your screen, it takes them out of reach, and
+  // those are different rows. Drawing only the reachable ones meant a link dropping silently
+  // shortened the panel, which is the one thing a list must never do — you cannot tell it from a
+  // list that never had them. Now every one of them is drawn and the cloud beside it says which.
+  //
+  // One call; empty and harmless on a single machine.
+  const me = (await neosh.swarm.self().catch(() => null))?.id ?? null;
+  const peers = (await neosh.swarm.nodes().catch(() => [] as SwarmNode[]))
+    .filter((n) => n.info.id !== me);
   const remote = new Map<string, SwarmAgent[]>();
   const hosts = new Map<string, string[]>();
-  for (const r of swarm) {
-    const list = remote.get(r.agent.project) ?? [];
-    list.push(r);
-    remote.set(r.agent.project, list);
-    const names = hosts.get(r.agent.project) ?? [];
-    if (!names.includes(r.node.name)) names.push(r.node.name);
-    hosts.set(r.agent.project, names.sort());
+  const links = new Map<string, LinkState>();
+  for (const n of peers) {
+    links.set(n.info.id, n.link);
+    for (const agent of n.agents) {
+      const r: SwarmAgent = { node: n.info, agent };
+      const list = remote.get(agent.project) ?? [];
+      list.push(r);
+      remote.set(agent.project, list);
+      const names = hosts.get(agent.project) ?? [];
+      if (!names.includes(n.info.name)) names.push(n.info.name);
+      hosts.set(agent.project, names.sort());
+    }
   }
+  // Newest first, as `agents()` handed them over: a machine's own order is per machine, and two
+  // of them interleaved by nothing would shuffle every time either one ticked.
+  for (const list of remote.values()) list.sort((a, b) => b.agent.updated_at - a.agent.updated_at);
   // A local conversation tells us its project key indirectly: the host stamps the same key on both
   // sides, so a cwd here and a cwd there meet on the key rather than on the path.
   const keys = new Map<string, string>();
-  for (const r of swarm) {
-    if (!keys.has(r.agent.cwd)) keys.set(r.agent.cwd, r.agent.project);
+  for (const list of remote.values()) {
+    for (const r of list) {
+      if (!keys.has(r.agent.cwd)) keys.set(r.agent.cwd, r.agent.project);
+    }
   }
   // Marks other plugins put on our rows. Read every frame for the reason sections are: a
   // decorator re-contributes in place when its data changes, and the read is one call.
   const decorations = mergeDecorations(
     await neosh.ext.list<DecorationItem>(POINT_DECORATION).catch(() => []),
   );
-  opts = { ...opts, remote, hosts, decorations };
+  opts = { ...opts, remote, hosts, links, decorations };
   const projects = group(sessions, arrangement, keys).flat();
 
   // A directory that turned up in the conversation list and we had not seen before. Noted rather
@@ -3647,16 +3862,20 @@ async function collect(
 
       // Projects that exist only on other machines. Without these, a repository you have not
       // cloned here is invisible — and "which computers is this on" cannot answer "not this one".
+      //
+      // An ordinary project row, drawn by the same function with the same arrow, the same name in
+      // the same column and the same count on the right — because it *is* a project, and one that
+      // reads as a different kind of thing is one you have to learn separately. It was an inert
+      // line with a `▹` on it and the machine names where the count goes, which said "this is not
+      // one of your projects" three ways at once, none of them the way the panel says anything
+      // else. What makes it different is one column of cloud after the name, and that it folds on
+      // its project key rather than on a directory it does not have here.
       for (const [key, list] of remote) {
         if (projects.some((p) => p.key === key)) continue;
         const first = list[0];
         if (!first) continue;
-        rows.push({
-          text: ` ${opts.ascii ? "~" : "▹"} ${clip(first.agent.project_name, opts.width - 10)}`,
-          hl: "Sidebar.Remote",
-          right: { text: `${clip((hosts.get(key) ?? []).join(" "), 12)} `, hl: "Sidebar.Remote" },
-          inert: true,
-        });
+        rows.push(remoteProjectRow(key, first.agent.project_name, list, arrangement, opts, now));
+        if (arrangement.isFolded(key)) continue;
         for (const r of list) rows.push(remoteRow(r, opts, now));
       }
     },
@@ -3760,7 +3979,21 @@ function projectRow(
 
   // Which other computers have this project. The whole reason a project key is a normalised git
   // remote rather than a path: on two machines the path is different and this is the same.
+  //
+  // One column of cloud after the name, not the machines' names in the right-hand column. The
+  // names used to take up to fourteen columns of the narrowest panel in the workspace, on a row
+  // that also has to fit a project name, a star, a git badge and a pull-request badge — and they
+  // displaced the count and the elapsed time, so a repository you also had on a second computer
+  // stopped saying how long its turn had been running *here*. What the mark has to carry is the
+  // fact, which is one bit: this is not only here. Which computers, and whether they can be
+  // reached, is a sentence, and a sentence goes on the key card.
   const elsewhere = opts.hosts.get(p.key) ?? [];
+  const rank = (l: LinkState | undefined) =>
+    l?.state === "up" ? 3 : l?.state === "waiting" ? 2 : l?.state === "down" || !l ? 0 : 1;
+  const bestLink = (opts.remote.get(p.key) ?? [])
+    .map((r) => opts.links.get(r.node.id))
+    .reduce((a, b) => (rank(b) > rank(a) ? b : a), undefined as LinkState | undefined);
+  const sky = elsewhere.length > 0 ? cloud(bestLink, opts.ascii) : null;
 
   // What is finished and unseen inside a project you have folded shut. Only when folded, because
   // folding is the thing that hid it: with the project open the conversation says so on its own
@@ -3809,11 +4042,16 @@ function projectRow(
   // The star's two columns come off the name that is about to carry it, so a favourite and the
   // project under it still end in the same place — clipping the name is what a panel this narrow
   // does, and letting the mark run two columns past everything else is not.
-  const target: Target = { kind: "project", cwd: p.cwd };
+  const target: Target = {
+    kind: "project",
+    cwd: p.cwd,
+    // For the key card, which is where the machines' names went when they came off the row.
+    ...(elsewhere.length > 0 ? { hosts: elsewhere } : {}),
+  };
   // Everything the name and the badge have to share. The badge gives up its least important parts
   // before a single character comes off the name — a project you cannot read the name of is not a
   // row you can use, and how far behind the remote it is keeps until you widen the panel with `>`.
-  const room = opts.width - 8 - byteLength(mark) - byteLength(star) - (elsewhere.length ? 8 : 0);
+  const room = opts.width - 8 - byteLength(mark) - byteLength(star) - (sky ? 2 : 0);
   const decoration = fitBadge(
     opts.decorations.get(targetKey(target) ?? ""),
     room,
@@ -3829,8 +4067,13 @@ function projectRow(
     const from = byteLength(` ${arrow} ${name}${star}`);
     spans.push({ from, to: from + byteLength(mark), hl: markHl });
   }
+  const sky_ = sky ? ` ${sky.text}` : "";
+  if (sky) {
+    const from = byteLength(` ${arrow} ${name}${star}${mark} `);
+    spans.push({ from, to: from + byteLength(sky.text), hl: sky.hl });
+  }
   return decorateRow({
-    text: ` ${arrow} ${name}${star}${mark}`,
+    text: ` ${arrow} ${name}${star}${mark}${sky_}`,
     // A project's name is a directory name, and directory names are long. Clipped it is the same
     // eight characters as the three others you have open beside it, which is the panel failing at
     // the one thing it is for. The star and the unread dot are left off deliberately: they
@@ -3840,11 +4083,7 @@ function projectRow(
     // `here` is this panel's opinion; everything else is a decorator's to colour.
     hl: here ? "Directory" : decoration?.hl ?? "Sidebar.Dim",
     spans: spans.length > 0 ? spans : undefined,
-    right: elsewhere.length > 0
-      // The machines take the column the count would have used. A project that is in two places is
-      // a more useful thing to know than how many conversations are in it here.
-      ? { text: `${clip(elsewhere.join(" "), 14)} `, hl: "Sidebar.Remote" }
-      : right,
+    right,
     value: target,
   }, decoration, Boolean(busy) || elsewhere.length > 0);
 }
@@ -3928,31 +4167,174 @@ function worktreeRow(
 }
 
 /**
+ * The one glyph that says a row is on another computer, and how that computer is reachable.
+ *
+ * A cloud, because that is what the whole world already draws for "not on this machine", and one
+ * column because a panel this narrow has one to spend. The *colour* carries the rest: green for a
+ * link that is up, a pulsing amber for one being dialled or waiting on somebody over there, dim
+ * for one nothing is dialling. Which matters because "not here" is not one fact — a conversation
+ * on a machine that is up is one you can open and steer, and the same row on a machine that is
+ * down is one you can read about and not touch, and those were drawn identically.
+ *
+ * `waiting` and the two dialling states share a hue and differ in what the row says about them
+ * elsewhere: they are both "on its way, not there yet", and inventing a fourth colour for a
+ * distinction the key card spells out in words would be spending the panel's scarcest resource on
+ * something it cannot say.
+ */
+function cloud(link: LinkState | undefined, ascii: boolean): { text: string; hl: string } {
+  const glyph = ascii ? "~" : "\u2601";
+  switch (link?.state) {
+    case "up":
+      return { text: glyph, hl: "Swarm.Up" };
+    case "connecting":
+    case "retrying":
+      return { text: glyph, hl: "Swarm.Linking" };
+    case "waiting":
+      return { text: glyph, hl: "Swarm.Waiting" };
+    default:
+      // No entry at all is a machine the panel has a conversation from and no link row for, which
+      // is a peer that went away between the two reads. Down is the honest reading of that, and it
+      // is also the quietest — a row that shouts about a race is worse than one that under-reports
+      // for a tick.
+      return { text: glyph, hl: "Swarm.Down" };
+  }
+}
+
+/** How a link reads in words, for the key card — where there is room to be exact. */
+function linkWords(link: LinkState | undefined): string {
+  switch (link?.state) {
+    case "up":
+      return "connected";
+    case "connecting":
+      return link.attempt > 0 ? `connecting, try ${link.attempt}` : "connecting";
+    case "retrying":
+      return link.attempt > 0 ? `reconnecting, try ${link.attempt}` : "reconnecting";
+    case "waiting":
+      return "has not allowed this computer yet";
+    default:
+      return "not connected";
+  }
+}
+
+/**
+ * A project that is only on other computers, drawn as an ordinary project row.
+ *
+ * Same arrow in the same column, same name beside it, same count on the right — because it is the
+ * same kind of thing and a row that reads differently is one you have to learn separately. What
+ * marks it out is the cloud after the name, in the colour of the best link any of the machines
+ * holding it currently has: a project you can reach on one of two computers is a project you can
+ * reach.
+ *
+ * It folds like every other project. The key is the project *key* rather than a directory, since
+ * there is no directory here — which is also why it is its own {@link Target} kind: every verb the
+ * panel binds against a project is about a path on this disk.
+ */
+function remoteProjectRow(
+  key: string,
+  name: string,
+  list: SwarmAgent[],
+  arrangement: Arrangement,
+  opts: DrawOptions,
+  now: number,
+): ListRow<Target> {
+  const folded = arrangement.isFolded(key);
+  const arrow = opts.ascii ? (folded ? ">" : "v") : folded ? "\u25b8" : "\u25be";
+  // The best link of any machine holding it. A project on two computers, one reachable and one
+  // not, is a project you can reach — and the row that says otherwise is one you would not press.
+  const rank = (l: LinkState | undefined) =>
+    l?.state === "up" ? 3 : l?.state === "waiting" ? 2 : l?.state === "down" || !l ? 0 : 1;
+  const best = list
+    .map((r) => opts.links.get(r.node.id))
+    .reduce((a, b) => (rank(b) > rank(a) ? b : a), undefined as LinkState | undefined);
+  const mark = cloud(best, opts.ascii);
+  const busy = list.find((r) => r.agent.state === "running");
+  const right = busy && busy.agent.turn_started_at
+    ? {
+      text: `${elapsed(Math.max(0, now - busy.agent.turn_started_at * 1000))} `,
+      hl: "Status.Working",
+    }
+    : { text: `${list.length} `, hl: "Sidebar.Dim" };
+  const clipped = clip(name, Math.max(6, opts.width - 10));
+  const lead = ` ${arrow} `;
+  const machines: Array<{ id: string; name: string; cwd: string }> = [];
+  for (const r of list) {
+    if (!machines.some((m) => m.id === r.node.id)) {
+      machines.push({ id: r.node.id, name: r.node.name, cwd: r.agent.cwd });
+    }
+  }
+  return {
+    text: `${lead}${clipped} ${mark.text}`,
+    full: `${lead}${name} ${mark.text}`,
+    indent: 3,
+    hl: "Sidebar.Remote",
+    spans: [{
+      from: byteLength(`${lead}${clipped} `),
+      to: byteLength(`${lead}${clipped} ${mark.text}`),
+      hl: mark.hl,
+    }],
+    right,
+    value: { kind: "elsewhere", key, name, machines },
+  };
+}
+
+/**
  * A conversation on another computer.
  *
  * Indented with its project's own, because that is the claim: it is the same project, being worked
- * on somewhere else. The host name is what makes it honest — it reads as one list and says, per
- * row, which machine the work is actually happening on.
+ * on somewhere else.
+ *
+ * **The machine's name is not on the row.** It used to take the right-hand column — up to twelve
+ * of them, permanently, on every remote row — which is the column a local row spends on how long
+ * its turn has been running and how many conversations are folded inside it. That is a lot of a
+ * narrow panel to spend saying `mac-studio` twenty times about twenty rows that are all on
+ * `mac-studio`, and it clipped the one thing the row is for, which is what the conversation is
+ * called. What replaces it is one column of cloud in the gutter — which says *not here*, the fact
+ * you actually need at a glance, and says in its colour whether the machine can be reached — and
+ * the name itself moves to the key card, which appears beside the row you pause on and has room
+ * for a sentence. The rule this follows is the panel's own: what is true of every row in a block
+ * does not earn a column on each of them.
  */
 function remoteRow(r: SwarmAgent, opts: DrawOptions, now: number): ListRow<Target> {
-    const working = r.agent.state === "running";
-    const glyph = working ? (opts.ascii ? "*" : "◍") : opts.ascii ? "." : "·";
-    const host = clip(r.node.name, 12);
-    const width = Math.max(8, opts.width - 8 - host.length);
-    return {
-      text: `   ${glyph} ${clip(r.agent.label, width)}`,
-      full: `   ${glyph} ${r.agent.label}`,
-      indent: 5,
-      hl: working ? "Status.Monitoring" : "Sidebar.Remote",
-      right: { text: `${host} `, hl: "Sidebar.Remote" },
-      value: {
-        kind: "remote",
-        node: r.node.id,
-        session: r.agent.session,
-        cwd: r.agent.cwd,
-        host: r.node.name,
-      },
-    };
+  const working = r.agent.state === "running";
+  const link = opts.links.get(r.node.id);
+  const mark = cloud(link, opts.ascii);
+  // The state glyph a local conversation carries, in the same column it carries it in, so a
+  // project's conversations read as one list whichever machine each of them is on.
+  const glyph = working ? (opts.ascii ? "*" : "\u25cd") : opts.ascii ? "." : "\u00b7";
+  const width = Math.max(8, opts.width - 9);
+  const label = clip(r.agent.label, width);
+  const lead = `   ${glyph} `;
+  const spans = [{
+    from: byteLength(`${lead}${label} `),
+    to: byteLength(`${lead}${label} ${mark.text}`),
+    hl: mark.hl,
+  }];
+  return {
+    text: `${lead}${label} ${mark.text}`,
+    full: `${lead}${r.agent.label} ${mark.text}`,
+    indent: 5,
+    hl: working ? "Status.Monitoring" : "Sidebar.Remote",
+    spans,
+    // The right-hand column keeps meaning what it means on every other conversation row: how long
+    // the turn that is running has been running, and nothing when none is.
+    right: working && r.agent.turn_started_at
+      // The same clock a local row uses, in the same column: how long the turn that is running has
+      // been running. `ago` is for "last touched" and rounds a whole minute away, which on a turn
+      // that has been going twenty seconds reads as `now` for ever.
+      ? {
+        text: `${elapsed(Math.max(0, now - r.agent.turn_started_at * 1000))} `,
+        hl: "Status.Working",
+      }
+      : { text: "" },
+    value: {
+      kind: "remote",
+      node: r.node.id,
+      session: r.agent.session,
+      cwd: r.agent.cwd,
+      host: r.node.name,
+      link: linkWords(link),
+    },
+  };
 }
 
 function sessionRow(
@@ -4132,6 +4514,8 @@ function hints(opts: DrawOptions): ListRow<Target>[] {
           ? "run"
           : kind === "remote"
           ? "watch"
+          : kind === "elsewhere"
+          ? "fold"
           : "open",
       ],
       ["?", "keys"],
@@ -4262,17 +4646,33 @@ function legendLines(
   return lines;
 }
 
-/** What the card is called, by the kind of row it is about. */
+/**
+ * What the card is called, by the kind of row it is about.
+ *
+ * This is also where the machine went. A remote row used to spend up to twelve of the panel's
+ * columns saying `mac-studio`, on every one of them, about a block of rows that are all on
+ * `mac-studio` — and it clipped the conversation's own name to make room. What the row needs at a
+ * glance is one bit and a colour: not here, and reachable or not. Which computer, and what the
+ * link is doing in words, is exactly the sort of thing the card exists for — it appears beside the
+ * row you pause on, and a border has room for a sentence where a 34-column panel does not.
+ */
 function legendTitle(target: Target | undefined): string {
   switch (target?.kind) {
     case "session":
       return "conversation";
     case "project":
-      return "project";
+      // A project you also have on other computers says so here rather than on the row.
+      return target.hosts && target.hosts.length > 0
+        ? `project \u00b7 also on ${clip(target.hosts.join(", "), 40)}`
+        : "project";
     case "add":
       return "add a project";
     case "remote":
-      return "on another machine";
+      // The name of the machine, and what the link to it is doing — because `↵` on this row does
+      // something quite different depending on the answer, and the row cannot say which.
+      return `on ${clip(target.host, 24)}${target.link ? ` \u00b7 ${target.link}` : ""}`;
+    case "elsewhere":
+      return `only on ${clip(target.machines.map((m) => m.name).join(", "), 36)}`;
     case "custom":
       return target.section ?? "this row";
     default:

--- a/website/src/pages/docs/keys.md
+++ b/website/src/pages/docs/keys.md
@@ -24,7 +24,7 @@ Every default is a key your terminal already sends: Ctrl with a letter, `⇧⇥`
 | `^T` | Projects and conversations |
 | `^J` | The computers in this workspace |
 | `^F` | The archive |
-| `^N` | New conversation. In a repository it asks where |
+| `^N` | New conversation. With another computer paired it asks which one first; in a repository it then asks where |
 | `^O` | Add a project — a path, another computer, or a repository address to clone |
 | `^B` | Toggle the sidebar |
 | `^K` | Command palette |

--- a/website/src/pages/docs/machines.md
+++ b/website/src/pages/docs/machines.md
@@ -73,9 +73,29 @@ Steering an agent is a message. Approving one is a write to this machine's disk,
 
 ## What you see
 
-Conversations on other machines appear in the sidebar under the same project as yours, dimmed, with the host at the end of the row. Projects are matched by normalised git remote, not by path, so `/Users/me/dev/neosh` here and `/home/me/src/neosh` there are one project.
+Conversations on other machines appear in the sidebar under the same project as yours, in the same place and with the same name, marked with a cloud. Projects are matched by normalised git remote, not by path, so `/Users/me/dev/neosh` here and `/home/me/src/neosh` there are one project. A project that is only on other computers gets an ordinary project row of its own — same arrow, same name, same count — with a cloud after the name, so a repository you have not cloned here is still somewhere you can see and start work.
 
-`↵` on a remote conversation opens it: its history, then everything as it happens. `i` says something to it and `^C` asks its turn to stop. `^N` offers the other machines' checkouts alongside your worktrees, so "start something over there" is one key.
+The cloud is one column and its **colour is the link**:
+
+| | |
+| --- | --- |
+| green | connected — you can open it, steer it, start things on it |
+| amber, pulsing | being dialled, or waiting for somebody to allow this computer over there |
+| dim | nothing is dialling it |
+
+Which computer, and what the link is doing in words, is on the **key card** — pause on the row and it appears beside the panel: `on mac-studio · connected`. The name is not on the row itself, because a block of twenty rows that are all on `mac-studio` does not need to say so twenty times, and the columns it used to take are the ones the conversation's own name needs.
+
+Rows for a machine that has gone quiet stay where they are. They were real a moment ago and probably still are; what changed is that you cannot reach them, and a list that silently shortens is one you cannot tell from a list that never had them.
+
+`↵` on a remote conversation opens it: its history, then everything as it happens. `i` says something to it and `^C` asks its turn to stop.
+
+## Starting something over there
+
+With a machine paired, `^N` asks **which computer** first — this one, or any of them, each with its cloud and the reason it cannot be used when it cannot. `This computer` is the first row and the cursor starts on it, so `^N ⏎` is what it always was. Pick another and you get the path field pointed at that machine, which is the same thing typing `linux-box:` into it would have got you.
+
+With no machine paired the question is not asked at all, and `^N` is the single key it has always been.
+
+`n` on a project that is only on other computers skips straight to it: the row already knows which machines have it and where on each, so with one there is nothing to ask.
 
 ## What moves, and what does not
 

--- a/website/src/pages/docs/sidebar.md
+++ b/website/src/pages/docs/sidebar.md
@@ -126,6 +126,8 @@ With a relative root, neosh writes the directory into the repository's `.gitigno
 
 On a worktree's sidebar row: `y` copies its path for the shell you are about to `cd` in, `p` pulls its repository from the remote, and `d` removes the checkout from disk. The branch stays, it asks first, and it tells you how many conversations go with it.
 
+`p` marks the row busy from the press rather than from the network call three steps down: the badge is led with a spinner while anything is out to a remote, so a key on a large checkout is never a second of nothing happening. It stops while the *rebase or merge* question is on screen — nothing on this machine is working while you are reading two options.
+
 It works the other way round too. A worktree exists for the conversations in it, so deleting the last one — `X` on the row, `X` or `^X` in the archive, `archive.sweep` — removes the checkout as well, and the dialog says so: which directory, that the branch stays, and how many uncommitted changes go with it. `X` on a worktree's own row does the same. The repository itself is never removed; `X` on its heading only takes the row off the list. Pictures pasted into a conversation go with it as well.
 
 ## Generated branch names and commit messages


### PR DESCRIPTION
Five things reported from the keyboard, each with its own commit.

### 1. `could not run "claude": no such file or directory` in one session while every other one worked

It was never about `claude`. `Command::spawn` reports **a working directory it cannot `chdir` into** with exactly the `ENOENT` it reports a missing program with — so a conversation whose checkout had gone (a worktree removed by hand, a project moved, an unmounted volume) named the binary, which was on `PATH` all along, and that is why the other conversations in the same workspace were fine.

`drivers::spawn_failed` asks, on the failure path only, the two questions the kernel collapsed into one bit. The directory first, because a conversation far more often outlives its checkout than its agent:

```
claude could not start here: /Users/you/dev/thing no longer exists.
A conversation runs in its own directory, so put that one back or
start this work in one that is there.
```

Shared by `claude`, `codex`, `acp`, `agy` and the codex quota probe.

### 2. Notices drawn over the line being typed

A notice overlays rather than reflowing, so the only question is what it covers — and the bottom-right corner answered it with the composer and the last rows of the transcript. Those are the two places somebody is certainly looking, and a notification is by definition about somewhere else. It goes in the top corner now, stopping short of the tab strip, growing downwards so a row already up does not move.

### 3. A repaint ticker that could multiply

`follow_motion(false)` then `follow_motion(true)` inside one 50 ms sleep left the old ticker alive **and** spawned a new one. That is what every tool call does twice — once when its spinner appears, once when it lands — so a turn with thirty of them had thirty chances to stack another 20 fps of repaints. The ticker carries a generation now.

### 4. Paired computers

- One column of **cloud** in the gutter instead of the machine's name in the right-hand column, which was eating up to fourteen columns on every remote row to repeat the same name and clipping the conversation's own.
- The colour is the link: green up, pulsing amber dialling or waiting on somebody over there, dim when nothing is dialling. Up and down hold **still** — the glyph is on every remote row at once.
- The machine and what the link is doing, in words, on the **key card**.
- Built from `swarm.nodes()`, not `swarm.agents()`: a machine going quiet no longer silently shortens the panel.
- A project only on other machines is an **ordinary project row** now — same arrow, name, count, and it folds.
- **`^N` asks which computer first**, when there is one to ask about. Nothing paired, nothing asked. `This computer` is the first row, so `^N ⏎` is unchanged.
- `LinkState` re-exported from `@neosh/api`, since the panel could not name the type it draws.

### 5. `p` with no feedback

It did all its deciding first and only marked the row busy once it had settled on a route — a second of a key looking unbound on any real checkout. `busy(cwd)` is claimed from the press and released around the *question*, and `decorate` draws the busy row from the last known status instead of running a `git status` first.

---

Also: two literal NUL bytes committed in `plugins/builtin/sidebar/main.ts` (`join("<NUL>")` in `same()`), escaped to `\0`. Identical at runtime; the difference is that a source file with a raw NUL is a binary file to every text tool, so searching the sidebar plugin silently returned nothing.

### Verification

`neosh-tui` 147/147 (three new notification-placement tests), `neosh-core` 196/196 (palette contract extended with the four `Swarm.*` groups and their motion rules), `plugin_manager` 5/5, `builtin_plugins` 214 passed / 2 failed — the two `/private/var` path tests that fail on macOS regardless. TS bindings clean, `check.sh web` green, both `tsc` passes clean. The notification corner and the `p` spinner were both driven on a real pty; the pull was verified end to end against a local bare remote.

**One caveat, stated plainly:** the reported "rows jump for a millisecond" in the chat is *not* proven fixed. The ticker leak in #3 is a real defect found while chasing it, and #2 may well have been it — a notice flashing over the bottom rows is exactly that shape — but I could not reproduce the jump, so neither is claimed as the cause. I did rule out one theory by measuring: drawing a 12,000-line transcript is ~3 ms, so it is not draw cost.