### PR TITLE
The transcript keeps time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -962,6 +962,28 @@ is `docs/releasing.md`.
   thirty chances to add another 20 fps of repaints that never go away. The ticker carries a
   generation, claimed on every call whichever way it went, and stops the moment it is not the live
   one.
+- **A row is written once, so what it says has to stay true — which is what a clock is and a
+  relative time is not.** A conversation happens *in* time and the transcript said nothing about
+  it: an answer that took four minutes and one that took four seconds read identically, a question
+  asked yesterday read exactly like the one asked a minute ago, and a card rebuilt from a stored
+  conversation carried no duration at all, because the messages recorded what happened and never
+  when. `Message::at` is the missing fact — stamped by whoever pushes the message, never by
+  `Session`, which has no clock in it precisely so that it and the store stay deterministic, and
+  `None` is *unknown* rather than the epoch. What it buys is one margin per turn, on the blank row
+  above its question: when it was asked, and how long it took. Both fixed, and that is the whole
+  design constraint — the transcript is written once and nothing comes back to it, so *how long
+  ago* is a lie waiting to happen and a clock time never is. The relative reading is therefore
+  offered on **exactly one row**, the newest turn's, which is the one a person walking back to
+  their terminal is actually asking about; it is kept true by a tick that runs at half a minute
+  rather than at a second, because nobody is watching it, and it **settles** — rewritten without
+  the *ago* — the moment another question is drawn below it. It is **virtual text** flush right,
+  not characters in the buffer: a transcript is an artefact you take pieces out of, so `y`, `ym`
+  and `ya` have to copy what was said and not what neosh wrote in the margin about it, and only
+  the frontend knows how wide a window is. And the date leads the margin only when the day changed
+  *since the turn above* — never when it changed since today, which is a fact about when the row
+  was drawn. One vocabulary for a duration everywhere the workspace prints one — `41s`, `4m 12s`,
+  `2h 30m` — because the working line said `123m 4s` about the same turn the sidebar three columns
+  to the left called `2h 03m`.
 - **A flash is one thing happening; a burst is a redraw.** `Animation::Flash` is the only motion
   here that fires once, so it needs a moment to count from — and a highlight group, shared by every
   row using it, cannot hold one. The *mark* does: an extmark is created once, so the frontend keys

--- a/crates/neosh-agent/src/agent.rs
+++ b/crates/neosh-agent/src/agent.rs
@@ -427,7 +427,7 @@ impl Agent {
         let mut selection = selection;
         let words = neosh_provider::prompt_injections(&instance.models, &mut selection);
         let mut messages =
-            vec![Message { role: Role::User, content: vec![ContentBlock::Text { text: prompt }] }];
+            vec![Message { role: Role::User, content: vec![ContentBlock::Text { text: prompt }], at: None }];
         neosh_provider::inject(&mut messages, &words);
 
         let request = TurnRequest {
@@ -612,7 +612,8 @@ impl Agent {
         // question the driver would go and ask.
         let asking = !text.is_empty() || !images.is_empty();
         if asking {
-            self.with(&session, |s| s.push_user(&Prompt { text: text.clone(), images }));
+            let asked = crate::now_secs();
+            self.with(&session, |s| s.push_user(&Prompt { text: text.clone(), images }, Some(asked)));
         }
 
         // --- turn.route: a plugin may say who answers ---------------------
@@ -862,10 +863,15 @@ impl Agent {
             let (produced, this_stop, usage) = assembler.finish();
             total.merge(&usage);
             let recorded = !produced.is_empty();
+            // Stamped as it enters the conversation, which is the only moment anything knows
+            // when it did: the messages themselves say what happened and, until this, never when.
+            // Good enough to be the turn's ending, because that is what a round boundary is for a
+            // model driver and what the close of the stream is for an agent driver.
+            let landed = crate::now_secs();
             self.with(&session, |s| {
                 s.add_usage(&usage);
                 for m in produced {
-                    s.push_message(m);
+                    s.push_message(m.at(landed));
                 }
             });
             if recorded {
@@ -901,7 +907,8 @@ impl Agent {
                 results.push((id, self.run_tool(bridge, &session, &cwd, call, &cancel).await));
             }
             let recorded = !results.is_empty();
-            self.with(&session, |s| s.push_tool_results(results));
+            let back = crate::now_secs();
+            self.with(&session, |s| s.push_tool_results(results, Some(back)));
             if recorded {
                 self.emit(AgentEvent::Committed {
                     session: session.clone(),
@@ -953,7 +960,8 @@ impl Agent {
             text: queued.iter().map(|p| p.text.as_str()).collect::<Vec<_>>().join("\n\n"),
             images: queued.into_iter().flat_map(|p| p.images).collect(),
         };
-        self.with(session, |s| s.push_user(&prompt));
+        let asked = crate::now_secs();
+        self.with(session, |s| s.push_user(&prompt, Some(asked)));
         // Drawn at the moment it enters the conversation, with whatever came with it — the picture
         // is part of the question, and a transcript showing the sentence without it is showing
         // half of what was asked.

--- a/crates/neosh-agent/src/lib.rs
+++ b/crates/neosh-agent/src/lib.rs
@@ -23,6 +23,20 @@ pub use turn::{TurnAssembler, TurnUpdate};
 
 use neosh_proto::{HookName, HookOutcome, HookPayload, PluginEvent, PluginId, ToolResult};
 
+/// Seconds since the epoch.
+///
+/// Here rather than in [`session`] on purpose: a [`Session`] and a [`SessionStore`] are pure data
+/// with no clock in them, so every timestamp they hold arrives from whoever put it there and both
+/// types stay deterministic under test. The [`Agent`] is the layer that has one — it runs turns,
+/// waits on deadlines and talks to the world — so when a message enters a conversation is a
+/// question it can answer and they cannot.
+pub fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
 /// How the agent reaches plugins.
 ///
 /// Implemented by the host. Every method is transport-agnostic on purpose: an implementation that

--- a/crates/neosh-agent/src/session.rs
+++ b/crates/neosh-agent/src/session.rs
@@ -224,17 +224,21 @@ impl Session {
     }
 
     pub fn push_user_text(&mut self, text: impl Into<String>) {
-        self.push_user(&Prompt::text(text));
+        self.push_user(&Prompt::text(text), None);
     }
 
-    /// What was said, with whatever came with it.
-    pub fn push_user(&mut self, prompt: &Prompt) {
+    /// What was said, with whatever came with it, and when.
+    ///
+    /// `at` is seconds since the epoch and comes from the caller for the reason every other
+    /// timestamp on this type does — see [`crate::now_secs`]. `None` is *unknown*, which is what a
+    /// test's message is and what a conversation written before messages were timed comes back as.
+    pub fn push_user(&mut self, prompt: &Prompt, at: Option<i64>) {
         // Saying something in a placeholder is what makes it a conversation. Here rather than at
         // any of the call sites because there is more than one way to speak into a session — the
         // composer, a steering message taken in mid-turn, a peer on another machine — and the one
         // that forgot would leave a conversation with messages in it that no list ever shows.
         self.ephemeral = false;
-        self.messages.push(Message { role: Role::User, content: prompt.blocks() });
+        self.messages.push(Message { role: Role::User, content: prompt.blocks(), at });
     }
 
     pub fn push_assistant(&mut self, msg: Message) {
@@ -256,7 +260,7 @@ impl Session {
 
     /// Tool results go back as a single user message, matching the wire model of every provider we
     /// target. Splitting them across messages teaches models to stop making parallel calls.
-    pub fn push_tool_results(&mut self, results: Vec<(ToolCallId, ToolResult)>) {
+    pub fn push_tool_results(&mut self, results: Vec<(ToolCallId, ToolResult)>, at: Option<i64>) {
         if results.is_empty() {
             return;
         }
@@ -271,6 +275,7 @@ impl Session {
                     images: r.images,
                 })
                 .collect(),
+            at,
         });
     }
 
@@ -357,7 +362,7 @@ mod tests {
         s.push_tool_results(vec![
             (ToolCallId("a".into()), ToolResult::ok("1")),
             (ToolCallId("b".into()), ToolResult::error("boom")),
-        ]);
+        ], None);
         assert_eq!(s.messages.len(), 1, "splitting these suppresses parallel tool use");
         assert_eq!(s.messages[0].role, Role::User);
         assert_eq!(s.messages[0].content.len(), 2);
@@ -370,7 +375,7 @@ mod tests {
     #[test]
     fn empty_assistant_messages_are_not_recorded() {
         let mut s = Session::new("/tmp");
-        s.push_assistant(Message { role: Role::Assistant, content: vec![] });
+        s.push_assistant(Message { role: Role::Assistant, content: vec![], at: None });
         assert!(s.messages.is_empty());
     }
 

--- a/crates/neosh-agent/src/turn.rs
+++ b/crates/neosh-agent/src/turn.rs
@@ -246,7 +246,7 @@ impl TurnAssembler {
             };
             match out.last_mut() {
                 Some(m) if m.role == role => m.content.push(block),
-                _ => out.push(Message { role, content: vec![block] }),
+                _ => out.push(Message { role, content: vec![block], at: None }),
             }
         }
         out
@@ -263,7 +263,7 @@ impl TurnAssembler {
             .filter(|m| m.role == Role::Assistant)
             .flat_map(|m| m.content)
             .collect();
-        Message { role: Role::Assistant, content }
+        Message { role: Role::Assistant, content, at: None }
     }
 
     /// Tool calls the model made, in the order it made them.

--- a/crates/neosh-core/src/palette.rs
+++ b/crates/neosh-core/src/palette.rs
@@ -331,6 +331,12 @@ pub fn groups(variant: Variant) -> Vec<(&'static str, HighlightDef)> {
         ("Agent.Tool", spec(fg(r.active))),
         ("Agent.ToolError", spec(bold(fg(r.danger)))),
         ("Agent.Usage", spec(dim(fg(r.muted)))),
+        // When a turn was asked, how long it took, and how long ago it finished — written in the
+        // right margin rather than into the transcript. Its own name and not `Agent.Usage`
+        // directly, because a theme that wants the clock a shade quieter than the token counts
+        // should not have to choose between them; still, they start the same, since both are the
+        // margin talking rather than the conversation.
+        ("Agent.Time", link("Agent.Usage")),
         // The mark beside a tool call, which appears only when the state is news: while the call
         // is out, and if it failed. There is deliberately no group for one that finished, since a
         // finished call is drawn with no mark at all.
@@ -771,6 +777,7 @@ mod tests {
             "Agent.ToolNet",
             "Agent.Tool",
             "Agent.Usage",
+            "Agent.Time",
             "Agent.PlanDone",
             "Agent.PlanActive",
             "Agent.PlanTodo",

--- a/crates/neosh-proto/src/agent.rs
+++ b/crates/neosh-proto/src/agent.rs
@@ -89,6 +89,39 @@ pub struct ImageFile {
 pub struct Message {
     pub role: Role,
     pub content: Vec<ContentBlock>,
+    /// When this entered the conversation, in seconds since the epoch.
+    ///
+    /// A transcript is a record of a conversation and a conversation happens *in time*: an answer
+    /// that took four minutes and one that took four seconds read identically once they are on
+    /// the screen, and a question asked yesterday reads exactly like the one asked a minute ago.
+    /// Nothing in the messages said when, so nothing that rebuilds a transcript from them could
+    /// say when either — which is why a card restored from a conversation has never carried a
+    /// duration while a card drawn live always has.
+    ///
+    /// Stamped by whoever pushes the message, never by the conversation itself, for the reason
+    /// every other timestamp here arrives from the caller: [`crate::SessionInfo::created_at`] and
+    /// the rest are set by the layer that has a clock, so the store stays deterministic.
+    ///
+    /// `None` for a message written before this existed, and for one a test made. Absent is
+    /// *unknown*, not the epoch — a transcript that stamped 1970 on every restored conversation
+    /// would be worse than one that says nothing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(type = "number | null")]
+    pub at: Option<i64>,
+}
+
+impl Message {
+    /// A message that nothing has timed — a test's, or one being built to send.
+    pub fn new(role: Role, content: Vec<ContentBlock>) -> Self {
+        Self { role, content, at: None }
+    }
+
+    /// The same, stamped with the moment it entered the conversation.
+    #[must_use]
+    pub fn at(mut self, at: i64) -> Self {
+        self.at = Some(at);
+        self
+    }
 }
 
 /// Why a turn stopped.

--- a/crates/neosh-provider/src/drivers/acp.rs
+++ b/crates/neosh-provider/src/drivers/acp.rs
@@ -1249,12 +1249,13 @@ mod tests {
     #[test]
     fn a_resumed_session_sends_only_the_new_question() {
         let msgs = vec![
-            Message { role: Role::User, content: vec![ContentBlock::Text { text: "old".into() }] },
+            Message { role: Role::User, content: vec![ContentBlock::Text { text: "old".into() }], at: None },
             Message {
                 role: Role::Assistant,
                 content: vec![ContentBlock::Text { text: "reply".into() }],
+                at: None,
             },
-            Message { role: Role::User, content: vec![ContentBlock::Text { text: "new".into() }] },
+            Message { role: Role::User, content: vec![ContentBlock::Text { text: "new".into() }], at: None },
         ];
         let latest = prompt_blocks(&msgs, true);
         assert_eq!(latest.len(), 1);
@@ -1306,6 +1307,7 @@ mod tests {
             messages: vec![Message {
                 role: Role::User,
                 content: vec![ContentBlock::Text { text: "hello".into() }],
+                at: None,
             }],
             tools: vec![],
             max_output_tokens: None,

--- a/crates/neosh-provider/src/drivers/anthropic.rs
+++ b/crates/neosh-provider/src/drivers/anthropic.rs
@@ -309,6 +309,7 @@ mod tests {
             messages: vec![Message {
                 role: Role::User,
                 content: vec![ContentBlock::Text { text: "hi".into() }],
+                at: None,
             }],
             tools: vec![],
             max_output_tokens: None,
@@ -367,6 +368,7 @@ mod tests {
                 ContentBlock::Thinking { text: "hm".into(), signature: None },
                 ContentBlock::Text { text: "answer".into() },
             ],
+            at: None,
         });
         let b = AnthropicProvider::body(&r, true);
         let blocks = b["messages"][1]["content"].as_array().unwrap();
@@ -390,6 +392,7 @@ mod tests {
                 name: "read_file".into(),
                 input: json!({"path": "a.txt"}),
             }],
+            at: None,
         });
         r.messages.push(Message {
             role: Role::User,
@@ -399,6 +402,7 @@ mod tests {
                 is_error: false,
                 images: Vec::new(),
             }],
+            at: None,
         });
         let b = AnthropicProvider::body(&r, true);
         assert_eq!(b["tools"][0]["input_schema"]["type"], "object");

--- a/crates/neosh-provider/src/drivers/antigravity.rs
+++ b/crates/neosh-provider/src/drivers/antigravity.rs
@@ -911,7 +911,7 @@ mod tests {
     fn the_message_sent_is_the_one_shape_agy_accepts() {
         // Every other event name is answered with "ignoring unsupported stream input message
         // event", on stdout, in plain text — so a wrong envelope here is a turn that hangs.
-        let msg = Message { role: Role::User, content: vec![ContentBlock::Text { text: "hi".into() }] };
+        let msg = Message { role: Role::User, content: vec![ContentBlock::Text { text: "hi".into() }], at: None };
         let v = user_frame(&[msg]);
         assert_eq!(v["event"], "user");
         assert_eq!(v["message"]["role"], "user");
@@ -922,9 +922,9 @@ mod tests {
     #[test]
     fn only_the_newest_question_is_sent_because_the_session_holds_the_rest() {
         let msgs = vec![
-            Message { role: Role::User, content: vec![ContentBlock::Text { text: "first".into() }] },
-            Message { role: Role::Assistant, content: vec![ContentBlock::Text { text: "ok".into() }] },
-            Message { role: Role::User, content: vec![ContentBlock::Text { text: "second".into() }] },
+            Message { role: Role::User, content: vec![ContentBlock::Text { text: "first".into() }], at: None },
+            Message { role: Role::Assistant, content: vec![ContentBlock::Text { text: "ok".into() }], at: None },
+            Message { role: Role::User, content: vec![ContentBlock::Text { text: "second".into() }], at: None },
         ];
         let v = user_frame(&msgs);
         let content = v["message"]["content"].as_array().expect("content is an array");

--- a/crates/neosh-provider/src/drivers/claude_cli.rs
+++ b/crates/neosh-provider/src/drivers/claude_cli.rs
@@ -1706,6 +1706,7 @@ mod tests {
             messages: vec![Message {
                 role: Role::User,
                 content: vec![ContentBlock::Text { text: "hello".into() }],
+                at: None,
             }],
             tools: vec![],
             max_output_tokens: None,
@@ -1715,12 +1716,13 @@ mod tests {
     #[test]
     fn prompt_uses_the_latest_user_message() {
         let msgs = vec![
-            Message { role: Role::User, content: vec![ContentBlock::Text { text: "old".into() }] },
+            Message { role: Role::User, content: vec![ContentBlock::Text { text: "old".into() }], at: None },
             Message {
                 role: Role::Assistant,
                 content: vec![ContentBlock::Text { text: "reply".into() }],
+                at: None,
             },
-            Message { role: Role::User, content: vec![ContentBlock::Text { text: "new".into() }] },
+            Message { role: Role::User, content: vec![ContentBlock::Text { text: "new".into() }], at: None },
         ];
         assert_eq!(ClaudeCliProvider::prompt_from(&msgs), "new");
     }
@@ -1730,7 +1732,7 @@ mod tests {
     #[test]
     fn a_message_with_no_picture_in_it_goes_as_it_always_did() {
         let msgs =
-            vec![Message { role: Role::User, content: vec![ContentBlock::Text { text: "hi".into() }] }];
+            vec![Message { role: Role::User, content: vec![ContentBlock::Text { text: "hi".into() }], at: None }];
         assert!(ClaudeCliProvider::prompt_from(&msgs).is_string());
     }
 
@@ -1750,6 +1752,7 @@ mod tests {
                 },
                 ContentBlock::Text { text: "what is this".into() },
             ],
+            at: None,
         }];
         let v = ClaudeCliProvider::prompt_from(&msgs);
         let blocks = v.as_array().expect("an array once there is more than text in it");
@@ -1776,6 +1779,7 @@ mod tests {
                 },
                 ContentBlock::Text { text: "still a question".into() },
             ],
+            at: None,
         }];
         assert_eq!(
             ClaudeCliProvider::prompt_from(&msgs),

--- a/crates/neosh-provider/src/drivers/codex_cli.rs
+++ b/crates/neosh-provider/src/drivers/codex_cli.rs
@@ -1498,6 +1498,7 @@ mod tests {
             messages: vec![Message {
                 role: Role::User,
                 content: vec![ContentBlock::Text { text: "hello".into() }],
+                at: None,
             }],
             tools: vec![],
             max_output_tokens: None,

--- a/crates/neosh-provider/src/drivers/google.rs
+++ b/crates/neosh-provider/src/drivers/google.rs
@@ -415,10 +415,11 @@ mod tests {
     #[test]
     fn assistant_role_is_named_model() {
         let b = GoogleProvider::body(&req(vec![
-            Message { role: Role::User, content: vec![ContentBlock::Text { text: "hi".into() }] },
+            Message { role: Role::User, content: vec![ContentBlock::Text { text: "hi".into() }], at: None },
             Message {
                 role: Role::Assistant,
                 content: vec![ContentBlock::Text { text: "yo".into() }],
+                at: None,
             },
         ]));
         assert_eq!(b["contents"][0]["role"], "user");
@@ -448,6 +449,7 @@ mod tests {
                     name: "read_file".into(),
                     input: json!({"path": "a"}),
                 }],
+                at: None,
             },
             Message {
                 role: Role::User,
@@ -457,6 +459,7 @@ mod tests {
                     is_error: false,
                     images: Vec::new(),
                 }],
+                at: None,
             },
         ]));
         assert_eq!(b["contents"][0]["parts"][0]["functionCall"]["name"], "read_file");
@@ -582,6 +585,7 @@ mod tests {
                     name: "read_file".into(),
                     input: json!({"path": "a"}),
                 }],
+                at: None,
             },
             Message {
                 role: Role::User,
@@ -591,6 +595,7 @@ mod tests {
                     is_error: false,
                     images: Vec::new(),
                 }],
+                at: None,
             },
         ]));
         assert_eq!(b["contents"][1]["parts"][0]["functionResponse"]["name"], "read_file");
@@ -608,6 +613,7 @@ mod tests {
                 is_error: true,
                 images: Vec::new(),
             }],
+            at: None,
         }]));
         let r = &b["contents"][0]["parts"][0]["functionResponse"]["response"];
         assert_eq!(r["error"], "no such file");
@@ -619,6 +625,7 @@ mod tests {
         let b = GoogleProvider::body(&req(vec![Message {
             role: Role::Assistant,
             content: vec![ContentBlock::Thinking { text: "x".into(), signature: None }],
+            at: None,
         }]));
         assert_eq!(b["contents"].as_array().unwrap().len(), 0);
     }

--- a/crates/neosh-provider/src/drivers/openai.rs
+++ b/crates/neosh-provider/src/drivers/openai.rs
@@ -369,7 +369,7 @@ mod tests {
     use neosh_proto::{InstanceId, ModelSelection, OptionSelection, ProviderOptionValue, ToolCallId};
 
     fn msg(role: Role, content: Vec<ContentBlock>) -> Message {
-        Message { role, content }
+        Message { role, content, at: None }
     }
 
     #[test]

--- a/crates/neosh-provider/src/injection.rs
+++ b/crates/neosh-provider/src/injection.rs
@@ -210,9 +210,9 @@ mod tests {
     #[test]
     fn the_word_goes_on_the_question_being_answered() {
         let mut messages = vec![
-            Message { role: Role::User, content: vec![ContentBlock::Text { text: "first".into() }] },
-            Message { role: Role::Assistant, content: vec![ContentBlock::Text { text: "answer".into() }] },
-            Message { role: Role::User, content: vec![ContentBlock::Text { text: "second".into() }] },
+            Message { role: Role::User, content: vec![ContentBlock::Text { text: "first".into() }], at: None },
+            Message { role: Role::Assistant, content: vec![ContentBlock::Text { text: "answer".into() }], at: None },
+            Message { role: Role::User, content: vec![ContentBlock::Text { text: "second".into() }], at: None },
         ];
         inject(&mut messages, &["ultrathink".into()]);
         let ContentBlock::Text { text: first } = &messages[0].content[0] else { panic!() };
@@ -224,7 +224,7 @@ mod tests {
     #[test]
     fn nothing_chosen_rewrites_nothing() {
         let mut messages =
-            vec![Message { role: Role::User, content: vec![ContentBlock::Text { text: "hi".into() }] }];
+            vec![Message { role: Role::User, content: vec![ContentBlock::Text { text: "hi".into() }], at: None }];
         inject(&mut messages, &[]);
         let ContentBlock::Text { text } = &messages[0].content[0] else { panic!() };
         assert_eq!(text, "hi");

--- a/crates/neosh-provider/tests/antigravity_stream_json.rs
+++ b/crates/neosh-provider/tests/antigravity_stream_json.rs
@@ -51,6 +51,7 @@ fn request(text: &str, dir: &std::path::Path) -> TurnRequest {
         messages: vec![Message {
             role: Role::User,
             content: vec![ContentBlock::Text { text: text.into() }],
+            at: None,
         }],
         tools: Vec::new(),
         max_output_tokens: None,

--- a/crates/neosh-provider/tests/claude_stream_json.rs
+++ b/crates/neosh-provider/tests/claude_stream_json.rs
@@ -121,6 +121,7 @@ fn req(dir: &std::path::Path, text: &str) -> TurnRequest {
         messages: vec![Message {
             role: Role::User,
             content: vec![ContentBlock::Text { text: text.into() }],
+            at: None,
         }],
         tools: vec![],
         max_output_tokens: None,

--- a/crates/neosh-provider/tests/codex_app_server.rs
+++ b/crates/neosh-provider/tests/codex_app_server.rs
@@ -130,6 +130,7 @@ fn req(dir: &std::path::Path) -> TurnRequest {
         messages: vec![Message {
             role: Role::User,
             content: vec![ContentBlock::Text { text: "run the tests".into() }],
+            at: None,
         }],
         tools: vec![],
         max_output_tokens: None,

--- a/crates/neosh/src/cards.rs
+++ b/crates/neosh/src/cards.rs
@@ -566,7 +566,14 @@ pub fn took(d: std::time::Duration) -> String {
     if secs < 60 {
         return format!("{:.1}s", d.as_secs_f64());
     }
-    format!("{}m {:02}s", secs / 60, secs % 60)
+    if secs < 3_600 {
+        return format!("{}m {:02}s", secs / 60, secs % 60);
+    }
+    // A call that has been out for two hours reads `120m 03s` without this, which is a number you
+    // have to divide before it means anything — and the seconds on it are three digits of noise
+    // beside the hours. The same shape [`crate::clock::lasted`] and `elapsed` in `@neosh/api`
+    // give, so a duration reads the same wherever the workspace prints one.
+    format!("{}h {:02}m", secs / 3_600, (secs % 3_600) / 60)
 }
 
 /// The status a shell tool reported, when what it handed back opens by saying so.
@@ -1926,7 +1933,9 @@ mod tests {
         assert_eq!(took(Duration::from_millis(1040)), "1.0s");
         assert_eq!(took(Duration::from_millis(59_900)), "59.9s");
         assert_eq!(took(Duration::from_secs(61)), "1m 01s");
-        assert_eq!(took(Duration::from_secs(3661)), "61m 01s");
+        assert_eq!(took(Duration::from_secs(3599)), "59m 59s");
+        assert_eq!(took(Duration::from_secs(3661)), "1h 01m");
+        assert_eq!(took(Duration::from_secs(9000)), "2h 30m");
     }
 
     #[test]

--- a/crates/neosh/src/clock.rs
+++ b/crates/neosh/src/clock.rs
@@ -1,0 +1,261 @@
+//! What time it was, said the way a transcript can afford to say it.
+//!
+//! A conversation happens in time and the transcript never said so. An answer that took four
+//! minutes and one that took four seconds read identically once they were on the screen; a
+//! question asked yesterday read exactly like the one asked a minute ago; and a card rebuilt from
+//! a stored conversation carried no duration at all, because the messages recorded what happened
+//! and never when. [`neosh_proto::Message::at`] is the missing fact and this is how it is written.
+//!
+//! **Everything here is fixed.** A clock time, a duration and the interval between two stamps are
+//! all true forever; *how long ago* is not, and a row is written once. So the relative reading is
+//! offered separately ([`ago`]) for the one row that is redrawn — the newest turn's — and
+//! everything that settles into the transcript is absolute.
+
+/// Seconds this machine is ahead of UTC, asked of the OS at most every few minutes.
+///
+/// [`crate::services::utc_offset`] spawns `date +%z`, which is the right answer for a chart drawn
+/// once and the wrong one for a transcript that stamps every turn: rebuilding a long conversation
+/// would fork a process per row. Cached, and re-asked on a timer rather than once for all time —
+/// a workspace left running across a daylight-saving change would otherwise draw every turn after
+/// it an hour out, which is exactly the sort of quietly wrong number this exists to remove.
+pub fn local_offset() -> i64 {
+    use std::sync::Mutex;
+    use std::time::{Duration, Instant};
+    static CACHE: Mutex<Option<(Instant, i64)>> = Mutex::new(None);
+    const FRESH: Duration = Duration::from_secs(300);
+    let Ok(mut cache) = CACHE.lock() else { return crate::services::utc_offset(None) };
+    if let Some((when, offset)) = *cache {
+        if when.elapsed() < FRESH {
+            return offset;
+        }
+    }
+    let offset = crate::services::utc_offset(None);
+    *cache = Some((Instant::now(), offset));
+    offset
+}
+
+/// Which local day an instant falls on, counted from the epoch.
+///
+/// The offset is applied before the division and not after, which is what makes a day start at
+/// midnight where the person is rather than at midnight in London.
+pub fn day(at: i64, offset: i64) -> i64 {
+    (at + offset).div_euclid(86_400)
+}
+
+/// The wall clock, `14:32` or `2:32pm`.
+pub fn clock(at: i64, offset: i64, twelve: bool) -> String {
+    let secs = (at + offset).rem_euclid(86_400);
+    let (h, m) = (secs / 3_600, (secs % 3_600) / 60);
+    if !twelve {
+        return format!("{h:02}:{m:02}");
+    }
+    let suffix = if h < 12 { "am" } else { "pm" };
+    let h = match h % 12 {
+        0 => 12,
+        n => n,
+    };
+    format!("{h}:{m:02}{suffix}")
+}
+
+/// The date, `8 Sep`, with the year when it is asked for.
+///
+/// No weekday and no full month name: this goes in the right margin of a transcript, beside the
+/// clock, and every column it takes is a column the conversation's own text does not have.
+pub fn date(at: i64, offset: i64, with_year: bool) -> String {
+    const MONTHS: [&str; 12] = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ];
+    let (y, m, d) = civil(day(at, offset));
+    let name = MONTHS.get((m as usize).saturating_sub(1)).copied().unwrap_or("?");
+    if with_year {
+        format!("{d} {name} {y}")
+    } else {
+        format!("{d} {name}")
+    }
+}
+
+/// Which year a local day falls in, for deciding whether [`date`] has to say.
+pub fn year(at: i64, offset: i64) -> i64 {
+    civil(day(at, offset)).0
+}
+
+/// Days since the epoch back into a date, by Howard Hinnant's `civil_from_days`.
+///
+/// The inverse of the `days_from_civil` in [`crate::usage`], and the same algorithm read the other
+/// way: an era of 400 years is exactly 146,097 days, which is what lets the whole thing be
+/// integer arithmetic with no table and no leap-year special cases.
+fn civil(days: i64) -> (i64, i64, i64) {
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+/// How long a turn took, at the least precision that is still an answer.
+///
+/// Coarser than [`crate::cards::took`], which is about a tool call: a call that came back in
+/// 40 ms is a fact about the call, and a *turn* that took 40 ms did not happen. Whole seconds up
+/// to a minute, minutes and seconds up to an hour, hours and minutes past that — because by then
+/// the seconds are noise beside the hours.
+pub fn lasted(secs: i64) -> String {
+    let secs = secs.max(0);
+    if secs < 60 {
+        return format!("{secs}s");
+    }
+    if secs < 3_600 {
+        return format!("{}m {:02}s", secs / 60, secs % 60);
+    }
+    format!("{}h {:02}m", secs / 3_600, (secs % 3_600) / 60)
+}
+
+/// How long ago something was, for the one row that is redrawn often enough to keep it true.
+///
+/// Deliberately vaguer the further back it goes: the difference between 3 and 4 minutes is
+/// something you might act on, and the difference between 3 and 4 days is not.
+pub fn ago(secs: i64) -> String {
+    let secs = secs.max(0);
+    if secs < 45 {
+        return "just now".to_string();
+    }
+    if secs < 3_600 {
+        return format!("{}m ago", (secs + 30) / 60);
+    }
+    if secs < 86_400 {
+        return format!("{}h ago", secs / 3_600);
+    }
+    format!("{}d ago", secs / 86_400)
+}
+
+/// What a turn's margin says, before it is a string.
+///
+/// The two instants it is between, and the two decisions about how much of the date to spell out
+/// — both of which are comparisons against the turn *above*, never against today, because these
+/// rows are written once and today is a fact about when they were drawn.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Stamp {
+    /// When the question was asked, and when the last thing the turn produced landed. `None`
+    /// while the turn is still running: a duration that stopped where the drawing happened to be
+    /// would be a measurement of the redraw.
+    pub asked: i64,
+    pub ended: Option<i64>,
+    /// Whether the label leads with the date, and whether that date carries a year.
+    pub dated: bool,
+    pub year: bool,
+}
+
+impl Stamp {
+    /// `[<date> ]<clock>[  ·  <how long it took>][  ·  <how long ago>]`.
+    ///
+    /// `now` is `Some` only for the newest turn in a transcript, which is the one row kept up to
+    /// date; everywhere else it is `None` and what comes out is true forever.
+    pub fn label(&self, offset: i64, twelve: bool, now: Option<i64>) -> String {
+        let mut out = String::new();
+        if self.dated {
+            out.push_str(&date(self.asked, offset, self.year));
+            out.push(' ');
+        }
+        out.push_str(&clock(self.asked, offset, twelve));
+        if let Some(ended) = self.ended {
+            out.push_str("  \u{b7}  ");
+            out.push_str(&lasted(ended - self.asked));
+            if let Some(now) = now {
+                out.push_str("  \u{b7}  ");
+                out.push_str(&ago(now - ended));
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_clock_is_read_where_the_person_is() {
+        // 2026-09-08T12:00:00Z, in a zone two hours ahead.
+        let at = 1_788_868_800;
+        assert_eq!(clock(at, 0, false), "12:00");
+        assert_eq!(clock(at, 2 * 3_600, false), "14:00");
+        assert_eq!(clock(at, -5 * 3_600, false), "07:00");
+    }
+
+    #[test]
+    fn a_twelve_hour_clock_says_which_half_of_the_day_it_is() {
+        let midnight = 1_788_868_800 - 12 * 3_600;
+        assert_eq!(clock(midnight, 0, true), "12:00am");
+        assert_eq!(clock(midnight + 13 * 3_600 + 5 * 60, 0, true), "1:05pm");
+        assert_eq!(clock(midnight + 12 * 3_600, 0, true), "12:00pm");
+    }
+
+    #[test]
+    fn a_day_starts_at_midnight_where_the_person_is_and_not_in_london() {
+        // 23:00 UTC is already tomorrow two hours east, and still today five hours west.
+        let late = 1_788_868_800 + 11 * 3_600;
+        assert_eq!(day(late, 2 * 3_600), day(late, 0) + 1);
+        assert_eq!(day(late, -5 * 3_600), day(late, 0));
+    }
+
+    #[test]
+    fn a_date_reads_back_as_the_date_it_was() {
+        assert_eq!(date(1_788_868_800, 0, false), "8 Sep");
+        assert_eq!(date(1_788_868_800, 0, true), "8 Sep 2026");
+        // The epoch itself, and a leap day, which is where a hand-rolled calendar goes wrong.
+        assert_eq!(date(0, 0, true), "1 Jan 1970");
+        assert_eq!(date(1_709_208_000, 0, true), "29 Feb 2024");
+    }
+
+    #[test]
+    fn a_turn_is_measured_in_what_you_would_say_out_loud() {
+        assert_eq!(lasted(0), "0s");
+        assert_eq!(lasted(41), "41s");
+        assert_eq!(lasted(61), "1m 01s");
+        assert_eq!(lasted(3_599), "59m 59s");
+        assert_eq!(lasted(3_600), "1h 00m");
+        assert_eq!(lasted(9_000), "2h 30m");
+        // A clock that went backwards is not a negative duration.
+        assert_eq!(lasted(-5), "0s");
+    }
+
+    fn stamp(asked: i64, ended: Option<i64>) -> Stamp {
+        Stamp { asked, ended, dated: false, year: false }
+    }
+
+    #[test]
+    fn a_turn_still_running_says_when_it_was_asked_and_nothing_it_cannot_know() {
+        // A duration stopping wherever the redraw happened would be a measurement of the redraw.
+        assert_eq!(stamp(1_788_868_800, None).label(0, false, Some(1_788_900_000)), "12:00");
+    }
+
+    #[test]
+    fn a_settled_turn_says_when_and_how_long_and_never_how_long_ago() {
+        // The whole reason the relative reading is separate: this row is written once and nothing
+        // ever comes back to it, so everything on it has to still be true tomorrow.
+        let s = stamp(1_788_868_800, Some(1_788_868_800 + 252));
+        assert_eq!(s.label(0, false, None), "12:00  \u{b7}  4m 12s");
+        assert_eq!(s.label(0, false, Some(1_788_868_800 + 900)), "12:00  \u{b7}  4m 12s  \u{b7}  11m ago");
+    }
+
+    #[test]
+    fn a_turn_on_a_new_day_leads_with_the_date_and_one_on_a_new_year_with_the_year() {
+        let at = 1_788_868_800;
+        assert_eq!(Stamp { asked: at, ended: None, dated: true, year: false }.label(0, false, None), "8 Sep 12:00");
+        assert_eq!(Stamp { asked: at, ended: None, dated: true, year: true }.label(0, false, None), "8 Sep 2026 12:00");
+    }
+
+    #[test]
+    fn how_long_ago_gets_vaguer_the_further_back_it_is() {
+        assert_eq!(ago(3), "just now");
+        assert_eq!(ago(44), "just now");
+        assert_eq!(ago(90), "2m ago");
+        assert_eq!(ago(3_599), "60m ago");
+        assert_eq!(ago(7_200), "2h ago");
+        assert_eq!(ago(200_000), "2d ago");
+    }
+}

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -449,6 +449,23 @@ struct PaneState {
     /// to *say*, because a question with nothing under it is indistinguishable from one still
     /// being thought about. See [`Host::close_unanswered`].
     unanswered: Option<u32>,
+    /// The turn whose time is in the right margin and is still moving, when times are on.
+    ///
+    /// Only ever the newest one. Every turn above it says a clock time and a duration, both of
+    /// which are true forever, so they are written once and never looked at again; the newest also
+    /// says *how long ago* it finished, which is the one thing a person walking back to their
+    /// terminal actually wants and the one thing that stops being true a minute later. So exactly
+    /// one row in the transcript is kept up to date, and it settles into the same fixed form as
+    /// the rest the moment another question is asked below it.
+    clocked: Option<Clocked>,
+    /// When the turn before the one being drawn was asked.
+    ///
+    /// What decides whether a turn's margin leads with a date: a clock time on its own is a lie by
+    /// omission the moment two turns are on different days, and repeating the date on every turn
+    /// of an afternoon's work is a column spent saying what the row above it already said.
+    /// Compared against the previous turn rather than against *today*, because "today" is a fact
+    /// about when the row was drawn and these rows outlive their drawing.
+    last_turn_at: Option<i64>,
     /// Set while output is streaming, so chunks append rather than starting a new line.
     streaming: Option<Stream>,
     /// The answer currently being written, and where it sits in the transcript.
@@ -568,6 +585,8 @@ impl PaneState {
             working: false,
             plan_rows: 0,
             unanswered: None,
+            clocked: None,
+            last_turn_at: None,
             streaming: None,
             answer: None,
             draft: String::new(),
@@ -622,6 +641,8 @@ impl PaneState {
             working: false,
             plan_rows: 0,
             unanswered: None,
+            clocked: None,
+            last_turn_at: None,
             streaming: None,
             answer: None,
             draft: String::new(),
@@ -1147,6 +1168,18 @@ struct Round {
     /// Kept after they finish rather than removed, so a late report about one that already ended
     /// lands somewhere instead of resurrecting it.
     tasks: Vec<Task>,
+}
+
+/// A turn's time in the right margin: the mark carrying it, and the instants it is made of.
+///
+/// The row is deliberately not in here. Text is inserted above this all the time — a card, a
+/// diff summary, a plan — and an extmark moves with what it is attached to, so the buffer is
+/// asked where it is rather than a number being kept in step with the buffer. That is the same
+/// mistake [`PaneState::unanswered`] has to work around by hand, and here it does not have to.
+#[derive(Clone, Copy, Debug)]
+struct Clocked {
+    mark: neosh_proto::ExtmarkId,
+    stamp: crate::clock::Stamp,
 }
 
 /// One sub-agent, from the turn's point of view.
@@ -8104,11 +8137,13 @@ impl Host {
         let show_tools = self.option_bool("chat.show_tools");
         let here = self.active_session();
         let running = self.turns.contains_key(&here);
-        let (lines, marks) = {
+        let offset = self.chat_clock().map(|(offset, _)| offset);
+        let (lines, marks, times) = {
             let store = self.agent.sessions();
             let Some(s) = store.get(&here) else { return };
-            let (lines, marks, _) = transcript(s, ascii, limits, width, show_tools, running);
-            (lines, marks)
+            let (lines, marks, _, times) =
+                transcript(s, ascii, limits, width, show_tools, running, offset);
+            (lines, marks, times)
         };
         let plugin = PluginId::from(BUILTIN);
         // Marks first, and all of them: a mark clamps rather than dies when the line under it is
@@ -8127,6 +8162,7 @@ impl Host {
             lines,
         });
         self.draw_marks(&marks, 0);
+        self.draw_turn_times(&times);
     }
 
     fn enter_session(&mut self) {
@@ -8172,12 +8208,13 @@ impl Host {
         let show_tools = self.option_bool("chat.show_tools");
         let here = self.active_session();
         let running = self.turns.contains_key(&here);
-        let Some((lines, marks, cards, label)) = ({
+        let offset = self.chat_clock().map(|(offset, _)| offset);
+        let Some((lines, marks, cards, times, label)) = ({
             let store = self.agent.sessions();
             store.get(&here).map(|s| {
-                let (lines, marks, cards) =
-                    transcript(s, ascii, limits, width, show_tools, running);
-                (lines, marks, cards, s.label())
+                let (lines, marks, cards, times) =
+                    transcript(s, ascii, limits, width, show_tools, running, offset);
+                (lines, marks, cards, times, s.label())
             })
         }) else {
             return;
@@ -8196,6 +8233,7 @@ impl Host {
             lines,
         });
         self.draw_marks(&marks, 0);
+        self.draw_turn_times(&times);
         // Where the window *is*, and not only what this end believes about it. `chat_top = None`
         // says "following the tail"; the window has to be told, because it is still sitting at
         // whatever row the last conversation was scrolled to — and a scroll offset is kept rather
@@ -8921,6 +8959,168 @@ impl Host {
         });
     }
 
+    // ---- the time in the margin -------------------------------------------
+
+    /// Whether the transcript writes the time in its margin, and on which clock.
+    ///
+    /// The offset is asked for here rather than per row: rebuilding a long conversation stamps a
+    /// margin per turn, and a process spawned for each of them would be a switch you could feel.
+    fn chat_clock(&self) -> Option<(i64, bool)> {
+        if !self.option_bool("chat.times") {
+            return None;
+        }
+        let twelve = self.editor.options().str("chat.clock") == Some("12h");
+        Some((crate::clock::local_offset(), twelve))
+    }
+
+    /// Where a mark has ended up, or `None` if it is gone.
+    fn mark_row(&mut self, id: neosh_proto::ExtmarkId) -> Option<u32> {
+        let call = ApiCall::MarkGet { ns: self.chat_ns, buf: self.v().chat, id };
+        let info = self.editor.apply(&PluginId::from(BUILTIN), call);
+        match info {
+            Ok(ApiOk::MarkInfo { info: Some(info) }) if !info.invalid => Some(info.row),
+            _ => None,
+        }
+    }
+
+    /// Put a time in the right margin of `row`, answering with the mark that carries it.
+    ///
+    /// Virtual text rather than characters in the buffer, and that is the whole design: a
+    /// transcript is an artefact you take pieces out of, so `y`, `ym` and `ya` have to copy what
+    /// was said and not what neosh wrote in the margin about it. It is also why the position is
+    /// [`VirtTextPos::Right`] — flush against the window's edge, which is a width only the
+    /// frontend knows, and which therefore survives a resize that a padded string would not.
+    fn set_turn_time(&mut self, row: u32, text: &str) -> Option<neosh_proto::ExtmarkId> {
+        let call = ApiCall::MarkSet {
+            ns: self.chat_ns,
+            buf: self.v().chat,
+            row,
+            col: 0,
+            opts: neosh_proto::ExtmarkOpts {
+                end_col: None,
+                hl_group: None,
+                line_hl_group: None,
+                virt_text: vec![chunk(text, "Agent.Time")],
+                virt_text_pos: neosh_proto::VirtTextPos::Right,
+                on_delete: neosh_proto::OnDelete::Clamp,
+                priority: 0,
+                image: None,
+            },
+        };
+        match self.editor.apply(&PluginId::from(BUILTIN), call) {
+            Ok(ApiOk::Mark { id }) => Some(id),
+            _ => None,
+        }
+    }
+
+    /// Draw the margin for the turn a question at `row` opens, and keep it as the moving one.
+    ///
+    /// `asked` is when the question entered the conversation, which the caller knows and this does
+    /// not: a steered message is drawn when the model is told rather than when it was typed.
+    fn start_turn_time(&mut self, row: u32, asked: i64) {
+        self.settle_turn_time(asked);
+        let Some((offset, twelve)) = self.chat_clock() else { return };
+        let before = self.v().last_turn_at;
+        let dated = before.is_none_or(|b| {
+            crate::clock::day(b, offset) != crate::clock::day(asked, offset)
+        });
+        let year = crate::clock::year(before.unwrap_or_else(now_secs), offset)
+            != crate::clock::year(asked, offset);
+        let stamp = crate::clock::Stamp { asked, ended: None, dated, year };
+        let text = stamp.label(offset, twelve, None);
+        let Some(mark) = self.set_turn_time(row, &text) else { return };
+        self.vm().clocked = Some(Clocked { mark, stamp });
+        self.vm().last_turn_at = Some(asked);
+    }
+
+    /// The turn in the margin has ended, and its margin says how long it took from now on.
+    fn end_turn_time(&mut self, ended: i64) {
+        if self.v().clocked.is_some_and(|c| c.stamp.ended.is_none()) {
+            if let Some(c) = self.vm().clocked.as_mut() {
+                c.stamp.ended = Some(ended);
+            }
+            self.redraw_turn_time();
+        }
+    }
+
+    /// Fix the moving margin at what it will say forever, because something is being drawn below.
+    ///
+    /// `by` is when that something happened, and it stands in for an ending the turn never got:
+    /// a question steered into a running turn closes off the stretch above it as surely as a
+    /// `TurnEnded` would, and a margin left saying only a clock time there would be the one turn
+    /// in the transcript that never says how long it took.
+    fn settle_turn_time(&mut self, by: i64) {
+        let Some(c) = self.v().clocked else { return };
+        if c.stamp.ended.is_none() {
+            if let Some(c) = self.vm().clocked.as_mut() {
+                c.stamp.ended = Some(by.max(c.stamp.asked));
+            }
+        }
+        // Without the *ago*: this row is about to stop being the newest thing in the transcript,
+        // and what it says from here on has to stay true with nothing ever redrawing it.
+        self.write_turn_time(false);
+        self.vm().clocked = None;
+    }
+
+    /// Write the moving margin again: with *how long ago* while it is the newest thing in the
+    /// transcript, and without it once it is not.
+    fn redraw_turn_time(&mut self) {
+        self.write_turn_time(true);
+    }
+
+    /// The half of the above that says whether *how long ago* is part of it.
+    fn write_turn_time(&mut self, with_ago: bool) {
+        let Some(c) = self.v().clocked else { return };
+        let Some((offset, twelve)) = self.chat_clock() else { return };
+        let Some(row) = self.mark_row(c.mark) else {
+            self.vm().clocked = None;
+            return;
+        };
+        let text = c.stamp.label(offset, twelve, with_ago.then(now_secs));
+        let plugin = PluginId::from(BUILTIN);
+        let _ = self.editor.apply(&plugin, ApiCall::MarkDel {
+            ns: self.chat_ns,
+            buf: self.v().chat,
+            id: c.mark,
+        });
+        match self.set_turn_time(row, &text) {
+            Some(mark) => {
+                if let Some(now) = self.vm().clocked.as_mut() {
+                    now.mark = mark;
+                }
+            }
+            None => self.vm().clocked = None,
+        }
+    }
+
+    /// Whether this view has a margin whose *ago* is going stale.
+    ///
+    /// What arms the slow tick. A turn that is still running has a working line counting up
+    /// already, and a margin with no ending on it says nothing that changes.
+    fn ageing(&self) -> bool {
+        self.v().clocked.is_some_and(|c| c.stamp.ended.is_some()) && self.chat_clock().is_some()
+    }
+
+    /// Draw every turn's margin for a transcript that has just been rebuilt.
+    ///
+    /// All of them are fixed except the last, which becomes the moving one — so a conversation
+    /// switched into says how long ago its newest answer arrived, which is very often the question
+    /// somebody switched into it to answer.
+    fn draw_turn_times(&mut self, times: &[TurnTime]) {
+        self.vm().clocked = None;
+        self.vm().last_turn_at = times.last().map(|t| t.stamp.asked);
+        let Some((offset, twelve)) = self.chat_clock() else { return };
+        let Some((last, earlier)) = times.split_last() else { return };
+        for t in earlier {
+            let text = t.stamp.label(offset, twelve, None);
+            self.set_turn_time(t.row, &text);
+        }
+        let text = last.stamp.label(offset, twelve, Some(now_secs()));
+        if let Some(mark) = self.set_turn_time(last.row, &text) {
+            self.vm().clocked = Some(Clocked { mark, stamp: last.stamp });
+        }
+    }
+
     /// Draw a rebuilt transcript's marks, `by` rows down from where they were computed.
     fn draw_marks(&mut self, marks: &[Mark], by: u32) {
         for m in marks.iter().map(|m| m.clone().shifted(by)) {
@@ -9182,6 +9382,13 @@ impl Host {
         // Whatever is drawn next clears this; if the turn ends and it is still set, the question
         // got no reply. See [`Self::unanswered`].
         self.vm().unanswered = Some(at);
+        // And the margin for the turn this question opens. On the blank row above it wherever
+        // there is one: an empty line is the one row a right-aligned annotation can never collide
+        // with what was said, and the question's own first row is where it goes when this question
+        // opens the transcript. Stamped now rather than from the message, because a steered
+        // question is drawn when the model is told about it and not when it was typed.
+        let row = if gap || at == 0 { at } else { at - 1 };
+        self.start_turn_time(row, now_secs());
         at
     }
 
@@ -9414,8 +9621,10 @@ impl Host {
 
         let ascii = self.option_bool("ui.ascii_only");
         let glyph = Glyphs::new(ascii).work;
-        let elapsed =
-            if secs >= 60 { format!("{}m {}s", secs / 60, secs % 60) } else { format!("{secs}s") };
+        // The same shape every other duration in the workspace is written in — the sidebar's
+        // running row, a tool card's tail — because a turn that has been going for two hours read
+        // `123m 4s` here and `2h 03m` three columns to the left, about the same turn.
+        let elapsed = crate::clock::lasted(secs as i64);
 
         let label = note.as_deref().unwrap_or(verb);
         let mut text = format!("{glyph} {label}\u{2026}  {elapsed}");
@@ -9766,6 +9975,11 @@ impl Host {
                     let n = me.draw_summary(&changes, at);
                     at = at.map(|row| row + n);
                     me.close_unanswered(at, &stop_reason);
+                    // The margin above this turn's question stops being a clock time and becomes
+                    // a clock time and a duration. However the turn ended: an interrupt and an
+                    // error both took as long as they took, and a turn that says nothing about
+                    // how long it ran is the one you cannot tell from one that never started.
+                    me.end_turn_time(now_secs());
                 });
                 // Queued after the last gap this turn had. It is a question that was asked and not
                 // yet answered, so it becomes the next turn rather than being quietly dropped.
@@ -11143,6 +11357,10 @@ impl Host {
                             me.draw_working();
                             me.tick_cards();
                             me.tick_footer();
+                            // The one row in the transcript that is not settled: how long ago the
+                            // newest turn finished. Every other margin says a clock time and a
+                            // duration, both of which are true forever and are written once.
+                            me.redraw_turn_time();
                         });
                     }
                     self.report_live();
@@ -11294,9 +11512,28 @@ impl Host {
                     hint.as_mut().reset(Instant::now() + Duration::from_millis(ms));
                 }
             }
-            if self.v().working && !ticking {
-                clock.as_mut().reset(Instant::now() + Duration::from_secs(1));
-                ticking = true;
+            if !ticking {
+                // Two speeds, because they answer two questions. A turn in flight has a clock on
+                // its working line that somebody is watching, so it moves every second. A turn
+                // that has finished has *how long ago* in its margin, which nobody is watching and
+                // which is wrong by a minute at worst — and a workspace nobody is using should not
+                // be waking up once a second to say so. With neither, there is no timer at all.
+                let (mut fast, mut slow) = (false, false);
+                for view in self.view_ids() {
+                    self.in_view(view, |me| {
+                        fast |= me.v().working;
+                        slow |= me.ageing();
+                    });
+                }
+                let every = match (fast, slow) {
+                    (true, _) => Some(Duration::from_secs(1)),
+                    (false, true) => Some(Duration::from_secs(30)),
+                    (false, false) => None,
+                };
+                if let Some(every) = every {
+                    clock.as_mut().reset(Instant::now() + every);
+                    ticking = true;
+                }
             }
             // A turn is the only thing that moves these numbers by an amount worth redrawing for,
             // so the poll that matters is the one just after one ends.
@@ -13246,6 +13483,25 @@ impl Host {
                 description: Some("Show a line in chat when a tool runs. Errors always show.".into()),
             },
             OptionSpec {
+                name: "chat.times".into(),
+                ty: OptionType::Bool,
+                default: OptionValue::Bool(true),
+                description: Some(
+                    "Write the time in the transcript's right margin: when each turn was asked, \
+                     how long it took, and how long ago the newest one finished. Virtual text, so \
+                     it is never part of what `y` copies."
+                        .into(),
+                ),
+            },
+            OptionSpec {
+                name: "chat.clock".into(),
+                ty: OptionType::Enum { values: vec!["24h".into(), "12h".into()] },
+                default: OptionValue::Str("24h".into()),
+                description: Some(
+                    "Which clock the times in the transcript are written on.".into(),
+                ),
+            },
+            OptionSpec {
                 name: "chat.show_plan".into(),
                 ty: OptionType::Bool,
                 default: OptionValue::Bool(true),
@@ -14431,7 +14687,8 @@ fn transcript(
     width: usize,
     show_tools: bool,
     running: bool,
-) -> (Vec<String>, Vec<Mark>, Vec<Card>) {
+    offset: Option<i64>,
+) -> (Vec<String>, Vec<Mark>, Vec<Card>, Vec<TurnTime>) {
     use neosh_proto::{ContentBlock, Role};
 
     let g = Glyphs::new(ascii);
@@ -14458,6 +14715,37 @@ fn transcript(
             _ => None,
         })
         .collect();
+    // When each turn was asked and when the last thing in it landed.
+    //
+    // There is no turn record in a conversation's messages and there does not need to be: a
+    // question is what a turn is *for*, so a turn starts where somebody said something and ends
+    // with the last thing that arrived before the next question. Tool results are user-role
+    // messages and open nothing — what makes a message a question is a block somebody typed.
+    let opens = |m: &neosh_proto::Message| {
+        m.role == Role::User
+            && m.content
+                .iter()
+                .any(|b| matches!(b, ContentBlock::Text { .. } | ContentBlock::Image { .. }))
+    };
+    let mut spans: Vec<(Option<i64>, Option<i64>)> = Vec::new();
+    for m in &session.messages {
+        if opens(m) {
+            spans.push((m.at, None));
+        } else if let (Some(last), Some(at)) = (spans.last_mut(), m.at) {
+            last.1 = Some(at);
+        }
+    }
+    // A turn that is still going has not taken any length of time yet. Its working line is
+    // counting up a few rows below, which is the honest place for a number that is still moving.
+    if running {
+        if let Some(last) = spans.last_mut() {
+            last.1 = None;
+        }
+    }
+    let mut times: Vec<TurnTime> = Vec::new();
+    let mut turn = 0usize;
+    // The turn before the one being drawn, for deciding whether a margin has to lead with a date.
+    let mut before: Option<i64> = None;
     let mut lines: Vec<String> = Vec::new();
     let mut marks: Vec<Mark> = Vec::new();
     let mut cards: Vec<Card> = Vec::new();
@@ -14611,7 +14899,59 @@ fn transcript(
     // under it must *not* get a blank line of its own: the picture and the sentence are one
     // question, and a gap between them reads as two.
     let mut after_image = false;
-    for message in &session.messages {
+    // Which message the margin above has already been drawn for, so a question made of a picture
+    // and a sentence — two blocks, one question — is one turn rather than two.
+    let mut timed: Option<usize> = None;
+    // The margin for the turn a question opens, on the blank row above it wherever there is one:
+    // an empty line always has room for something flush right, and a question that opens the
+    // transcript has no row above to use.
+    let open_turn = |lines: &mut Vec<String>,
+                         times: &mut Vec<TurnTime>,
+                         timed: &mut Option<usize>,
+                         before: &mut Option<i64>,
+                         turn: &mut usize,
+                         mi: usize| {
+        if *timed == Some(mi) {
+            return;
+        }
+        *timed = Some(mi);
+        let here = *turn;
+        *turn += 1;
+        let Some(offset) = offset else { return };
+        let Some((Some(asked), ended)) = spans.get(here).copied() else { return };
+        // A margin goes on the blank line above its question, and the first turn of a rebuilt
+        // conversation has none — `gap` has nothing to separate it from. One is made rather than
+        // the margin falling onto the question's own row: a right-aligned annotation there is
+        // fine until the question is longer than the window, and a first turn that reads
+        // differently from every turn under it is one more thing to learn.
+        if lines.is_empty() {
+            lines.push(String::new());
+        }
+        let row = if lines.last().is_some_and(|l| l.trim().is_empty()) {
+            lines.len() as u32 - 1
+        } else {
+            lines.len() as u32
+        };
+        times.push(TurnTime {
+            row,
+            stamp: crate::clock::Stamp {
+                asked,
+                ended,
+                dated: before.is_none_or(|b| {
+                    crate::clock::day(b, offset) != crate::clock::day(asked, offset)
+                }),
+                // Against *now* when there is nothing above to differ from: a conversation from
+                // this year needs no year on it, and one from two years ago is exactly where
+                // saying so matters. The comparison is re-made every time the transcript is
+                // rebuilt, which is the only moment this row is written, so it cannot go stale
+                // where it is read.
+                year: crate::clock::year(before.unwrap_or_else(now_secs), offset)
+                    != crate::clock::year(asked, offset),
+            },
+        });
+        *before = Some(asked);
+    };
+    for (mi, message) in session.messages.iter().enumerate() {
         for block in &message.content {
             let was_image = std::mem::take(&mut after_image);
             match block {
@@ -14620,6 +14960,7 @@ fn transcript(
                     if !was_image {
                         summarise(&mut lines, &mut marks, &mut changes);
                         gap(&mut lines);
+                        open_turn(&mut lines, &mut times, &mut timed, &mut before, &mut turn, mi);
                     }
                     let row = lines.len() as u32;
                     marks.push(Mark::at(row, 0, g.bar.len(), "Agent.User"));
@@ -14633,6 +14974,7 @@ fn transcript(
                         summarise(&mut lines, &mut marks, &mut changes);
                         gap(&mut lines);
                     }
+                    open_turn(&mut lines, &mut times, &mut timed, &mut before, &mut turn, mi);
                     for line in text.lines() {
                         marks.push(Mark::at(lines.len() as u32, 0, g.bar.len(), "Agent.User"));
                         lines.push(format!("{} {line}", g.bar));
@@ -14792,7 +15134,7 @@ fn transcript(
         marks.extend(Mark::of(row, &r));
         lines.push(r.text);
     }
-    (lines, marks, cards)
+    (lines, marks, cards, times)
 }
 
 /// One highlight in a rebuilt transcript, before it becomes an extmark.
@@ -14838,6 +15180,17 @@ impl Mark {
     }
 }
 
+
+/// Where one turn's margin goes, and what it is made of.
+///
+/// Produced by [`transcript`] while it rebuilds a conversation, because the turn boundaries are
+/// something it already has to find and nothing else does. The row is where the margin is drawn:
+/// the blank line above the question when there is one, which is a line with nothing on it and
+/// therefore always has room, and the question's own first row when the turn opens the transcript.
+struct TurnTime {
+    row: u32,
+    stamp: crate::clock::Stamp,
+}
 
 /// A virtual-text chunk, which is three words of ceremony often enough to be worth a name.
 fn chunk(text: impl Into<String>, hl: &str) -> neosh_proto::VirtChunk {

--- a/crates/neosh/src/main.rs
+++ b/crates/neosh/src/main.rs
@@ -20,6 +20,7 @@ mod clients;
 mod control;
 mod daemon;
 mod cards;
+mod clock;
 mod diff;
 mod logo;
 mod config;

--- a/crates/neosh/src/sessions.rs
+++ b/crates/neosh/src/sessions.rs
@@ -434,6 +434,7 @@ mod tests {
                 path: p.display().to_string(),
                 media_type: "image/png".into(),
             }],
+            at: None,
         };
         let mut going = session("look at this");
         going.messages.push(picture(&mine));

--- a/crates/neosh/tests/sessions.rs
+++ b/crates/neosh/tests/sessions.rs
@@ -212,6 +212,33 @@ impl Session {
         lines
     }
 
+    /// Every piece of virtual text the transcript has ever carried.
+    ///
+    /// The time a turn was asked and how long it took are drawn *beside* the transcript rather
+    /// than into it — a transcript is an artefact you take pieces out of, and `y` must copy what
+    /// was said — so nothing about them is in `chat_now`. Not folded like the lines are: a margin
+    /// is rewritten in place while it is the newest one, and what this asks is whether a shape
+    /// ever appeared at all.
+    fn chat_virt(&self) -> Vec<String> {
+        let chat = self.events.iter().find_map(|e| {
+            (e["type"] == "buffer_opened"
+                && e["name"].as_str().is_some_and(|n| n.starts_with("[chat]")))
+            .then(|| e["buf"].as_u64())?
+        });
+        let Some(chat) = chat else { return Vec::new() };
+        self.events
+            .iter()
+            .filter(|e| e["type"] == "buffer_lines" && e["buf"].as_u64() == Some(chat))
+            .filter_map(|e| e["lines"].as_array())
+            .flatten()
+            .filter_map(|l| l["marks"].as_array())
+            .flatten()
+            .filter_map(|m| m["virt_text"].as_array())
+            .flatten()
+            .filter_map(|c| c["text"].as_str().map(str::to_string))
+            .collect()
+    }
+
     fn transcript(&self) -> String {
         let mut s = String::from("--- text seen ---\n");
         for l in self.texts() {
@@ -840,6 +867,80 @@ fn a_restored_conversation_still_has_its_tool_cards() {
         now.iter().filter(|l| l.contains("Read  src")).count(),
         1,
         "the tool it called came back with it\n{now:?}"
+    );
+}
+
+/// Whether a margin reads as `[<date> ]HH:MM` with, once the turn has ended, a duration after it.
+fn is_a_turn_margin(text: &str) -> bool {
+    let clock = text.split_whitespace().find(|w| {
+        w.len() == 5
+            && w.as_bytes()[2] == b':'
+            && w.bytes().enumerate().all(|(i, b)| if i == 2 { true } else { b.is_ascii_digit() })
+    });
+    clock.is_some()
+}
+
+#[test]
+fn a_turn_says_when_it_was_asked_and_how_long_it_took() {
+    let sb = Sandbox::new("times");
+    install_driver(&sb);
+    let mut s = sb.start();
+    s.wait_for("driver ready");
+    s.type_text("when was this");
+    s.enter();
+    s.wait_for("when was this");
+    assert!(
+        s.pump(|s| s.chat_virt().iter().any(|t| is_a_turn_margin(t))),
+        "the turn carries a clock time in its margin\n{:?}",
+        s.chat_virt()
+    );
+    // And once it has ended, how long it took — which is the fact the transcript could never give
+    // before, because the messages recorded what happened and never when.
+    assert!(
+        s.pump(|s| s.chat_virt().iter().any(|t| is_a_turn_margin(t) && t.contains('\u{b7}'))),
+        "and how long it took, once it has ended\n{:?}",
+        s.chat_virt()
+    );
+    // Never in the buffer: the transcript is what `y` copies.
+    let said = s.chat_now();
+    assert!(
+        !said.iter().any(|l| is_a_turn_margin(l)),
+        "the margin is drawn beside the transcript, not into it\n{said:?}"
+    );
+}
+
+#[test]
+fn a_restored_conversation_still_says_when_its_turns_happened() {
+    // The whole reason a message carries a timestamp. Rebuilt from the conversation's messages, a
+    // transcript used to have no clock on it at all — a record of what happened and never when.
+    let sb = Sandbox::new("times-restart");
+    install_driver(&sb);
+    {
+        let mut s = sb.start();
+        s.wait_for("driver ready");
+        s.type_text("remember when");
+        s.enter();
+        s.wait_for("remember when");
+        assert!(
+            s.pump(|s| s.chat_virt().iter().any(|t| is_a_turn_margin(t))),
+            "drawn live first\n{:?}",
+            s.chat_virt()
+        );
+        s.command("quit");
+        assert!(s.exits_within(Duration::from_secs(10)), "clean exit");
+    }
+
+    let mut s = sb.start();
+    s.wait_for("driver ready");
+    assert!(
+        s.pump(|s| s.chat_now().iter().any(|l| l.contains("remember when"))),
+        "the conversation came back\n{:?}",
+        s.chat_now()
+    );
+    assert!(
+        s.pump(|s| s.chat_virt().iter().any(|t| is_a_turn_margin(t))),
+        "and so did the time it happened at\n{:?}",
+        s.chat_virt()
     );
 }
 

--- a/plugins/api/src/generated/Message.ts
+++ b/plugins/api/src/generated/Message.ts
@@ -2,4 +2,26 @@
 import type { ContentBlock } from "./ContentBlock";
 import type { Role } from "./Role";
 
-export type Message = { role: Role; content: Array<ContentBlock> };
+export type Message = {
+  role: Role;
+  content: Array<ContentBlock>;
+  /**
+   * When this entered the conversation, in seconds since the epoch.
+   *
+   * A transcript is a record of a conversation and a conversation happens *in time*: an answer
+   * that took four minutes and one that took four seconds read identically once they are on
+   * the screen, and a question asked yesterday reads exactly like the one asked a minute ago.
+   * Nothing in the messages said when, so nothing that rebuilds a transcript from them could
+   * say when either — which is why a card restored from a conversation has never carried a
+   * duration while a card drawn live always has.
+   *
+   * Stamped by whoever pushes the message, never by the conversation itself, for the reason
+   * every other timestamp here arrives from the caller: [`crate::SessionInfo::created_at`] and
+   * the rest are set by the layer that has a clock, so the store stays deterministic.
+   *
+   * `None` for a message written before this existed, and for one a test made. Absent is
+   * *unknown*, not the epoch — a transcript that stamped 1970 on every restored conversation
+   * would be worse than one that says nothing.
+   */
+  at?: number | null;
+};

--- a/website/src/pages/docs/concepts.md
+++ b/website/src/pages/docs/concepts.md
@@ -19,6 +19,25 @@ A conversation belongs to a directory, and that directory is where its work happ
 - A turn that finishes while you are elsewhere marks its conversation unread. Arriving clears the mark; there is nothing to dismiss.
 - Switching conversations is never refused. Turns keep running where they are.
 
+### The transcript keeps time
+
+Every turn carries the time in the right margin of the blank row above its question:
+
+```
+                                                     8 Sep 14:32  ·  4m 12s
+▌ why is the composer eating pasted newlines
+
+  Looking at the paste path…
+```
+
+When it was asked, and — once it has ended — how long it took. The newest turn also says how long ago it finished (`·  12m ago`), which is what you want when you walk back to a terminal that has been sitting there; it is kept true while it is the newest, and settles the moment you ask something below it. Every turn above says only things that are true forever, because those rows are written once and nothing comes back to them.
+
+The date leads the margin only when the day changed since the turn above — a whole afternoon's work is one date and a column of clock times — and the year only when that changed too. `chat.clock = "12h"` writes `2:32pm` instead.
+
+It is drawn beside the transcript rather than into it, so `y`, `ym` and `ya` copy what was said and never what neosh wrote in the margin about it. `chat.times = false` turns it off.
+
+Durations read the same wherever the workspace prints one: seconds under a minute, `4m 12s` under an hour, `2h 30m` past that — on the working line while a turn runs, on a tool card, on a conversation's row in the sidebar, and here.
+
 ## Projects and worktrees
 
 The sidebar (`^T`) groups conversations by project. A worktree nests under the repository it belongs to, named by its branch, so four scratch trees of one repository are one project, not four.

--- a/website/src/pages/docs/options.md
+++ b/website/src/pages/docs/options.md
@@ -34,6 +34,8 @@ Plugins declare their own options through the same call the built-ins use, and a
 | `chat.tool_output_lines` | `3` | How much of a tool result to show under it. `0` gives the line count and nothing else |
 | `chat.markdown` | `true` | Render answers as they arrive. `false` shows exactly what the model sent |
 | `chat.preview_lines` | | How many rows a tool card opens to while the cursor is in it |
+| `chat.times` | `true` | The time in the transcript's right margin: when each turn was asked, how long it took, and how long ago the newest one finished |
+| `chat.clock` | `"24h"` | Or `"12h"`. Which clock those times are written on |
 
 ## UI
 


### PR DESCRIPTION
A conversation happens in time and the transcript said nothing about it. An answer that took four minutes and one that took four seconds read identically once they were on screen; a question asked yesterday read exactly like the one asked a minute ago; and a card rebuilt from a stored conversation carried no duration at all, because the messages recorded *what* happened and never *when*.

## What it looks like

```
                                                     8 Sep 14:32  ·  4m 12s
▌ why is the composer eating pasted newlines

  Looking at the paste path…
```

In the right margin of the blank row above each question: when it was asked, and — once it has ended — how long it took. The newest turn also says how long ago it finished (`·  12m ago`), which is what you want when you walk back to a terminal that has been sitting there.

## The rule behind it

**A row is written once, so what it says has to stay true.** A clock time and a duration are true forever; *how long ago* is a lie waiting to happen. So the relative reading is on **exactly one row** — the newest turn's — kept true by a tick that runs at half a minute rather than at a second, because nobody is watching it and it is wrong by a minute at worst. It **settles**, rewritten without the *ago*, the moment another question is drawn below it. A workspace with neither a running turn nor a finished one to age still has no timer at all.

The date leads the margin only when the day changed **since the turn above** — an afternoon's work is one date and a column of clock times — and the year only when that changed too. Never a comparison against today, which is a fact about when the row was drawn and these rows outlive their drawing.

## How

- **`Message::at`** (`neosh-proto`, `#[serde(default)]`) is the missing fact. Every conversation already on disk loads unchanged and comes back with `None`, which is *unknown* rather than the epoch — a transcript stamping 1970 on every restored conversation would be worse than one that says nothing. Stamped by whoever pushes the message and never by `Session`, which has no clock in it precisely so it and the store stay deterministic; `neosh_agent::now_secs` is where the clock is read.
- **Virtual text, flush right** (`VirtTextPos::Right`), not characters in the buffer. A transcript is an artefact you take pieces out of, so `y`, `ym` and `ya` copy what was said and not what neosh wrote in the margin about it — and only the frontend knows how wide a window is, which is what makes the margin survive a resize. The extmark is also how the row is found again: text is inserted above it all the time and a mark moves with what it is attached to, which is the bookkeeping `unanswered` has to do by hand.
- Drawn identically by the live path and by the rebuild, so switching away and back does not re-space the conversation.
- **`Agent.Time`** is its own highlight group, linked to `Agent.Usage` — both are the margin talking rather than the conversation, but a theme should be able to pull them apart.
- **`chat.times = false`** turns it off; **`chat.clock = "12h"`** writes `2:32pm`.

## One duration vocabulary

A turn running for two hours read `123m 4s` on the working line and `2h 03m` on its conversation's row three columns to the left, about the same turn — and a tool call out that long said `120m 03s`. `clock::lasted` is the shape the sidebar and `elapsed` in `@neosh/api` have always used (`41s`, `4m 12s`, `2h 30m`), and the working line and a card's tail now use it too. A tool card keeps its sub-second precision under a minute, because how fast a fast call was is the interesting fact about it.

## Checked

- `check.sh crates` and `check.sh web` — all checks passed, bindings in sync.
- `neosh-core` 139, `neosh-agent` 99, `neosh-provider` 250, `neosh-tui` 147, `neosh --test sessions` 35 (two new), `neosh --bin` 325 (nine new in `clock`).
- `builtin_plugins`: 214 passed, 2 failed — `a_turn_runs_in_the_project_the_conversation_belongs_to` and `switching_conversations_moves_the_working_directory_too`, the known macOS `/var` vs `/private/var` baseline, failing on `main` too.
- Driven under a pty: live, after a restart, in a 35-column pane with a wrapping question, and across the 30-second tick (`0s · just now` → `0s · 1m ago`).