### PR TITLE
release: v0.4.6, and the test sandbox that made three suites lie

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "neosh"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2433,7 +2433,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-agent"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "futures",
@@ -2452,7 +2452,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-core"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "insta",
  "neosh-proto",
@@ -2467,14 +2467,14 @@ dependencies = [
 
 [[package]]
 name = "neosh-plugins"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "include_dir",
 ]
 
 [[package]]
 name = "neosh-proto"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-provider"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "base64",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-script"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "deno_ast",
@@ -2530,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-swarm"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-syntax"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "syntect",
  "two-face",
@@ -2553,7 +2553,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-tui"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "base64",
  "crossterm",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "neosh-vcs"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "neosh-proto",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.5"
+version = "0.4.6"
 edition = "2024"
 rust-version = "1.90"
 license = "MIT"
@@ -27,16 +27,16 @@ homepage = "https://github.com/neoswarm/neosh"
 # Every one of these carries a `version` as well as a `path`: cargo refuses to package a crate whose
 # dependency has only a path, and the published crate is built against the registry version while
 # a checkout is built against the directory next door.
-neosh-proto = { path = "crates/neosh-proto", version = "0.4.5" }
-neosh-core = { path = "crates/neosh-core", version = "0.4.5" }
-neosh-provider = { path = "crates/neosh-provider", version = "0.4.5" }
-neosh-vcs = { path = "crates/neosh-vcs", version = "0.4.5" }
-neosh-swarm = { path = "crates/neosh-swarm", version = "0.4.5" }
-neosh-agent = { path = "crates/neosh-agent", version = "0.4.5" }
-neosh-script = { path = "crates/neosh-script", version = "0.4.5" }
-neosh-tui = { path = "crates/neosh-tui", version = "0.4.5" }
-neosh-syntax = { path = "crates/neosh-syntax", version = "0.4.5" }
-neosh-plugins = { path = "plugins", version = "0.4.5" }
+neosh-proto = { path = "crates/neosh-proto", version = "0.4.6" }
+neosh-core = { path = "crates/neosh-core", version = "0.4.6" }
+neosh-provider = { path = "crates/neosh-provider", version = "0.4.6" }
+neosh-vcs = { path = "crates/neosh-vcs", version = "0.4.6" }
+neosh-swarm = { path = "crates/neosh-swarm", version = "0.4.6" }
+neosh-agent = { path = "crates/neosh-agent", version = "0.4.6" }
+neosh-script = { path = "crates/neosh-script", version = "0.4.6" }
+neosh-tui = { path = "crates/neosh-tui", version = "0.4.6" }
+neosh-syntax = { path = "crates/neosh-syntax", version = "0.4.6" }
+neosh-plugins = { path = "plugins", version = "0.4.6" }
 
 # async
 tokio = { version = "1.53", features = ["rt", "rt-multi-thread", "macros", "sync", "time", "process", "io-util", "fs", "signal", "net"] }

--- a/crates/neosh/src/host.rs
+++ b/crates/neosh/src/host.rs
@@ -6153,8 +6153,19 @@ impl Host {
             say(&mut rows, tag, vec![(2, 2 + "neosh".len(), "Accent"), (2 + "neosh".len(), len, "Comment")]);
         }
         rows.push(String::new());
-        say(&mut rows, format!("  model      {model}"), vec![(0, 13, "Comment")]);
-        say(&mut rows, format!("  directory  {}", tilde(&self.cwd)), vec![(0, 13, "Comment")]);
+        // Fitted, because neither of these is a sentence this file gets to keep short. A model id
+        // is a catalogue's and an account's, and a directory is the user's — `tilde` takes `$HOME`
+        // off the front and there is nothing else to give. Nothing wraps the welcome, so a row
+        // longer than the pane becomes a second line at column zero under an indented one, which
+        // is exactly what the note under the next row is about; the difference is that that one
+        // could be hand-shortened and these cannot.
+        //
+        // The path is cut from the *front*: the end of a directory is the part that says which one
+        // it is, and `…/neosh/work` is an answer where `/Users/you/very/deep/pr…` is not.
+        let room = width.saturating_sub(13);
+        say(&mut rows, format!("  model      {}", elide(&model, room)), vec![(0, 13, "Comment")]);
+        let cwd = tilde(&self.cwd);
+        say(&mut rows, format!("  directory  {}", elide_start(&cwd, room)), vec![(0, 13, "Comment")]);
         rows.push(String::new());
         // Said only when it is true: there is no conversation anywhere, so nothing else on screen
         // is going to tell you that typing is how one starts.
@@ -15229,6 +15240,31 @@ fn elide(s: &str, room: usize) -> String {
         used += w;
     }
     out.push('\u{2026}');
+    out
+}
+
+/// `s`, or as much of its *end* as fits in `room` columns with an `…` where the front went.
+///
+/// [`elide`]'s mirror, and the right one for a path: what a directory is called is the last
+/// segment or two, so cutting the front of `/Users/you/src/neosh/work` leaves `…/neosh/work`
+/// while cutting the back leaves `/Users/you/src/n…`, which names nothing.
+fn elide_start(s: &str, room: usize) -> String {
+    if display_width(s) <= room {
+        return s.to_string();
+    }
+    let Some(budget) = room.checked_sub(1) else { return String::new() };
+    let mut tail: Vec<&str> = Vec::new();
+    let mut used = 0usize;
+    for g in s.graphemes(true).rev() {
+        let w = display_width(g);
+        if used + w > budget {
+            break;
+        }
+        tail.push(g);
+        used += w;
+    }
+    let mut out = String::from("\u{2026}");
+    out.extend(tail.into_iter().rev());
     out
 }
 

--- a/crates/neosh/tests/approvals.rs
+++ b/crates/neosh/tests/approvals.rs
@@ -12,6 +12,8 @@ use std::time::{Duration, Instant};
 
 use serde_json::Value;
 
+mod support;
+
 const BUDGET: Duration = Duration::from_secs(30);
 
 struct Sandbox {
@@ -26,8 +28,7 @@ impl Drop for Sandbox {
 
 impl Sandbox {
     fn new(name: &str) -> Self {
-        let root = std::env::temp_dir().join(format!("neosh-approve-{}-{name}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = support::sandbox_root("ap", name);
         for d in ["config", "state", "work"] {
             std::fs::create_dir_all(root.join(d)).expect("dirs");
         }

--- a/crates/neosh/tests/builtin_plugins.rs
+++ b/crates/neosh/tests/builtin_plugins.rs
@@ -22,6 +22,8 @@ use std::time::{Duration, Instant};
 
 use serde_json::Value;
 
+mod support;
+
 const BUDGET: Duration = Duration::from_secs(30);
 
 struct Sandbox {
@@ -44,8 +46,7 @@ impl Sandbox {
     /// failure in whichever of the pair happened to be slower, which moves from run to run, which
     /// is exactly what a flaky test looks like from the outside.
     fn new(name: &str) -> Self {
-        let root = std::env::temp_dir().join(format!("neosh-builtin-{}-{name}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = support::sandbox_root("bp", name);
         // `claude` and `codex` are the vendors' own homes, empty unless a test fills one. See
         // `Sandbox::write_usage_history`.
         for d in ["config", "state", "work", "claude/projects", "codex/sessions"] {

--- a/crates/neosh/tests/editing.rs
+++ b/crates/neosh/tests/editing.rs
@@ -468,13 +468,21 @@ fn select_all_while_reading_takes_the_whole_transcript() {
     let sb = Sandbox::new("readall");
     let mut s = sb.start();
     s.ready();
-    assert!(s.pump(|s| s.chat().iter().any(|l| l.contains("neosh"))));
+    assert!(s.pump(|s| s.chat().iter().any(|l| l.contains("terminal-first"))));
 
     s.press(json!({"kind": "char", "c": "s"}), &["ctrl"]);
     s.ch("y");
     s.ch("a");
+    // Two rows that are several apart, because one of them is what a *line* copy would also have
+    // got and the claim here is that `ya` took the block. This used to look for `neosh`, which is
+    // not in the welcome at all — the word is drawn as the logo — so what it was really matching
+    // was the sandbox's own directory in the `directory` row, and the test passed or failed on
+    // what the temporary folder had been called.
     assert!(
-        s.pump(|s| s.copied().iter().any(|t| t.contains("neosh"))),
+        s.pump(|s| s
+            .copied()
+            .iter()
+            .any(|t| t.contains("terminal-first") && t.contains("model"))),
         "everything, not just the line under the cursor: {:?}",
         s.copied()
     );

--- a/crates/neosh/tests/editing.rs
+++ b/crates/neosh/tests/editing.rs
@@ -15,6 +15,8 @@ use std::time::{Duration, Instant};
 
 use serde_json::{Value, json};
 
+mod support;
+
 const BUDGET: Duration = Duration::from_secs(20);
 
 struct Sandbox {
@@ -29,8 +31,7 @@ impl Drop for Sandbox {
 
 impl Sandbox {
     fn new(name: &str) -> Self {
-        let root = std::env::temp_dir().join(format!("neosh-edit-{}-{name}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = support::sandbox_root("ed", name);
         for d in ["config", "state", "work"] {
             std::fs::create_dir_all(root.join(d)).expect("dirs");
         }

--- a/crates/neosh/tests/plugin_manager.rs
+++ b/crates/neosh/tests/plugin_manager.rs
@@ -9,6 +9,8 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
+mod support;
+
 struct Sandbox {
     root: PathBuf,
 }
@@ -21,8 +23,7 @@ impl Drop for Sandbox {
 
 impl Sandbox {
     fn new(name: &str) -> Self {
-        let root = std::env::temp_dir().join(format!("neosh-pm-{}-{name}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = support::sandbox_root("pm", name);
         for d in ["config", "data", "state", "src", "work"] {
             std::fs::create_dir_all(root.join(d)).expect("sandbox dirs");
         }

--- a/crates/neosh/tests/questions.rs
+++ b/crates/neosh/tests/questions.rs
@@ -20,6 +20,8 @@ use std::time::{Duration, Instant};
 
 use serde_json::Value;
 
+mod support;
+
 const BUDGET: Duration = Duration::from_secs(30);
 
 struct Sandbox {
@@ -34,8 +36,7 @@ impl Drop for Sandbox {
 
 impl Sandbox {
     fn new(name: &str) -> Self {
-        let root = std::env::temp_dir().join(format!("neosh-ask-{}-{name}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = support::sandbox_root("qs", name);
         for d in ["config", "state", "work"] {
             std::fs::create_dir_all(root.join(d)).expect("dirs");
         }

--- a/crates/neosh/tests/reading.rs
+++ b/crates/neosh/tests/reading.rs
@@ -15,6 +15,8 @@ use std::time::{Duration, Instant};
 
 use serde_json::{Value, json};
 
+mod support;
+
 const BUDGET: Duration = Duration::from_secs(20);
 
 struct Sandbox {
@@ -29,8 +31,7 @@ impl Drop for Sandbox {
 
 impl Sandbox {
     fn new(name: &str) -> Self {
-        let root = std::env::temp_dir().join(format!("neosh-read-{}-{name}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = support::sandbox_root("rd", name);
         for d in ["config", "state", "work"] {
             std::fs::create_dir_all(root.join(d)).expect("dirs");
         }

--- a/crates/neosh/tests/sessions.rs
+++ b/crates/neosh/tests/sessions.rs
@@ -12,6 +12,8 @@ use std::time::{Duration, Instant};
 
 use serde_json::Value;
 
+mod support;
+
 const BUDGET: Duration = Duration::from_secs(30);
 
 struct Sandbox {
@@ -26,8 +28,7 @@ impl Drop for Sandbox {
 
 impl Sandbox {
     fn new(name: &str) -> Self {
-        let root = std::env::temp_dir().join(format!("neosh-sess-{}-{name}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = support::sandbox_root("ss", name);
         for d in ["config", "state", "work", "other"] {
             std::fs::create_dir_all(root.join(d)).expect("sandbox dirs");
         }

--- a/crates/neosh/tests/support/mod.rs
+++ b/crates/neosh/tests/support/mod.rs
@@ -1,0 +1,49 @@
+//! What every suite's sandbox needs, in one place because nine copies of it were nine chances to
+//! get it subtly wrong — and on macOS all nine did.
+//!
+//! Not a test target of its own: cargo compiles `tests/*.rs` as integration tests and leaves a
+//! subdirectory alone, which is also why `scripts/check.sh` globbing `tests/*.rs` for suite names
+//! does not pick it up.
+
+use std::path::{Path, PathBuf};
+
+/// Where a sandbox lives: short, and spelled the way the operating system will spell it back.
+///
+/// Both properties were learned from tests that failed only on macOS, and neither is about the
+/// test that noticed.
+///
+/// **Short**, because a workspace's socket lives under here and `sun_path` is 104 bytes. macOS
+/// hands `std::env::temp_dir()` a per-user directory — `/var/folders/np/4l_yfdj…/T/` — which
+/// spends about fifty of them before the sandbox has named anything, so
+/// `…/run/neosh/<hash>.sock` ran past the limit and `bind` failed. That took out every test in
+/// `workspace.rs` at once, with a message about a socket that never appeared rather than about a
+/// path that was too long.
+///
+/// **Canonical**, because `/tmp` and `/var` are symlinks to `/private/tmp` and `/private/var`. A
+/// test that builds a path from this and compares it against one the *host* reports is comparing
+/// two spellings of the same directory, and only one of them has been resolved: the host works in
+/// the directory and reports what it is actually in, while the test reports what it asked for.
+/// `assert_eq!(format!("cwd={}", dir.display()), …)` then fails with two paths that a person
+/// reads as identical, which is the worst shape a failure can have.
+///
+/// `NEOSH_TEST_TMPDIR` overrides the base, for a machine where `/tmp` is not the right answer.
+pub fn sandbox_root(suite: &str, name: &str) -> PathBuf {
+    let base = std::env::var_os("NEOSH_TEST_TMPDIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/tmp"));
+    // `nsh` rather than `neosh`, and a two-letter suite rather than its file name: every column
+    // here is a column the socket path and the welcome's directory row do not get, and the pid
+    // already tells two runs apart.
+    let root = base.join(format!("nsh-{suite}-{}-{name}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).expect("sandbox root");
+    canonical(&root)
+}
+
+/// A path as the operating system will report it, or unchanged when it cannot be resolved.
+///
+/// Separate from [`sandbox_root`] because a test that makes a directory of its own *inside* the
+/// sandbox — a second project, a worktree — has to spell that one the same way.
+pub fn canonical(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}

--- a/crates/neosh/tests/user_config.rs
+++ b/crates/neosh/tests/user_config.rs
@@ -13,6 +13,8 @@ use std::time::{Duration, Instant};
 
 use serde_json::Value;
 
+mod support;
+
 const BUDGET: Duration = Duration::from_secs(30);
 
 /// A scratch config directory plus workspace, torn down on drop.
@@ -28,8 +30,7 @@ impl Drop for Sandbox {
 
 impl Sandbox {
     fn new(name: &str) -> Self {
-        let root = std::env::temp_dir().join(format!("neosh-usercfg-{}-{name}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = support::sandbox_root("uc", name);
         for d in ["config", "state", "work"] {
             std::fs::create_dir_all(root.join(d)).expect("sandbox dirs");
         }

--- a/crates/neosh/tests/workspace.rs
+++ b/crates/neosh/tests/workspace.rs
@@ -15,6 +15,8 @@ use std::time::{Duration, Instant};
 
 use neosh_proto::{ClientMessage, DetachReason, InputEvent, ServerMessage, UiEvent};
 
+mod support;
+
 /// How long any "wait until" in here is allowed to take.
 ///
 /// Generous, because a cold workspace boots deno and discovers plugins before it binds, and CI is
@@ -45,9 +47,7 @@ impl Drop for Sandbox {
 
 impl Sandbox {
     fn new(name: &str) -> Self {
-        let root =
-            std::env::temp_dir().join(format!("neosh-workspace-{}-{name}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = support::sandbox_root("ws", name);
         for d in ["config", "state", "work", "run"] {
             std::fs::create_dir_all(root.join(d)).expect("sandbox dirs");
         }

--- a/npm/neosh/package.json
+++ b/npm/neosh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neosh",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Neovim for controlling AI agents. A terminal workspace where every feature is a plugin.",
   "license": "MIT",
   "bin": {
@@ -32,9 +32,9 @@
     "!._*"
   ],
   "optionalDependencies": {
-    "@neosh/cli-darwin-arm64": "0.4.5",
-    "@neosh/cli-darwin-x64": "0.4.5",
-    "@neosh/cli-linux-x64": "0.4.5",
-    "@neosh/cli-linux-arm64": "0.4.5"
+    "@neosh/cli-darwin-arm64": "0.4.6",
+    "@neosh/cli-darwin-x64": "0.4.6",
+    "@neosh/cli-linux-x64": "0.4.6",
+    "@neosh/cli-linux-arm64": "0.4.6"
   }
 }

--- a/plugins/api/package-lock.json
+++ b/plugins/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neosh/api",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neosh/api",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.0"

--- a/plugins/api/package.json
+++ b/plugins/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/api",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "The neosh plugin API. Types are generated from the Rust side and drift-checked in CI.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/approvals/package.json
+++ b/plugins/builtin/approvals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/approvals",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Asks before the agent does something the policy says to ask about.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/archive/package.json
+++ b/plugins/builtin/archive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/archive",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "What you have finished with: a panel to find it in, and the verbs that empty it.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/git/package.json
+++ b/plugins/builtin/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/git",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Branch, commit and status, with model-written names and messages you can re-prompt.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/model/package.json
+++ b/plugins/builtin/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/model",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Model and reasoning-effort switchers, in the status line and behind a picker.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/palette/package.json
+++ b/plugins/builtin/palette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/palette",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "One key to everything: commands, conversations, and what they are bound to.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/questions/package.json
+++ b/plugins/builtin/questions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/questions",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Draws the question an agent asks you, and sends back what you said.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/sidebar/package.json
+++ b/plugins/builtin/sidebar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/sidebar",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "A docked panel: where you are, what changed, and what is answering.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/slash/package.json
+++ b/plugins/builtin/slash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/slash",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Type / to reach a command \u2014 neosh's own, and whatever the driver says it accepts.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/titles/package.json
+++ b/plugins/builtin/titles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/titles",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Names a conversation after what it turned out to be about.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/update/package.json
+++ b/plugins/builtin/update/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/update",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Says when there is a newer neosh, and becomes it.",
   "license": "MIT",
   "type": "module",

--- a/plugins/builtin/usage/package.json
+++ b/plugins/builtin/usage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neosh/usage",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "How full the context window is, what the conversation has cost, and what the plan has left.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Three commits: the version bump, and two fixes for failures that have been red on macOS since August.

## `release: v0.4.6`

The sixteen files a release touches — both halves of the root manifest (the `[workspace.package]` version *and* the ten internal pins), `Cargo.lock`, the npm launcher and its four platform pins, `plugins/api` and all ten bundled plugins.

**One caveat, stated plainly.** `docs/releasing.md` says 0.x is breaking at the *minor*, and three public-API breaks have landed since v0.4.5 — `Message` gained a field, `UpdateOutcome::Delegated` went, `InstallMethod::upgrade_command` changed signature. By that rule this should be v0.5.0. I raised it; the call was to ship it as v0.4.6.

## `test: a sandbox is short and spelled the way the OS spells it back`

Nine suites each built their own root from `std::env::temp_dir()`, and on macOS all nine were wrong the same two ways.

**Short.** macOS hands `temp_dir()` a per-user directory — `/var/folders/np/4l_yfdj…/T/` — which spends about fifty of `sun_path`'s 104 bytes before the sandbox has named anything. A workspace's socket lives under the root, so `bind` failed and all twenty-three tests in `workspace.rs` reported that the workspace never came up: a message about a socket that never appeared, for a path that was too long.

**Canonical.** `/tmp` and `/var` are symlinks to `/private/tmp` and `/private/var`. A test that builds a path from its root and compares it against one the *host* reports is comparing two spellings of one directory — the host works in it and reports where it actually is, the test reports what it asked for. `a_turn_runs_in_the_project_the_conversation_belongs_to` and `switching_conversations_moves_the_working_directory_too` have failed on this since August, with two paths in the diff that a person reads as identical.

`tests/support/mod.rs` is both, once. Not a suite of its own: cargo compiles `tests/*.rs` and leaves a subdirectory alone, which is also why `check.sh` globbing that pattern for suite names does not pick it up. `NEOSH_TEST_TMPDIR` overrides the base.

## `fix(chat): the welcome's own rows fit the pane they are drawn in`

A real bug the width test was tripping over. Nothing wraps the welcome, so a row longer than the chat becomes a second line at column zero under an indented one — the note under the "Nothing open" line says exactly that, and answers it by keeping *that* sentence short. Which works for a sentence this file writes and not for the two it does not: a model id belongs to a catalogue and an account, a directory belongs to the user.

The path is cut from the **front**, because the end of a directory is the part that says which one it is: `…/neosh/work` is an answer where `/Users/you/very/deep/pr…` is not. `elide_start` is `elide`'s mirror — by grapheme cluster and display width, never by `char`.

## Verification

**Not verified locally, and that is why this is a PR rather than a tag.** The external volume this repo sits on unmounted itself four times while I was working, and every build died with `SIGBUS: access to undefined memory` reading `target/`. `git fsck` is clean and the commits verify, but the release gate never ran here.

CI is the verification. If it goes green, `main` gets these and the `v0.4.6` tag follows.